### PR TITLE
Add checks for make build and bundle

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -85,8 +85,11 @@ jobs:
             exit 1
           fi
       - name: Run Go Tests
-        run: |
-          make test
+        run: make test
+      - name: Ensure make build succeeds
+        run: make build
+      - name: Ensure make bundle succeeds
+        run: make bundle
   docker:
     name: Check docker build
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Add checks to our per PR CI that ensures both the
make build and make bundle targets run successfully

Signed-off-by: Johnny Bieren <jbieren@redhat.com>