### PR TITLE
Get strategy from the right ReleaseLink

### DIFF
--- a/controllers/release_controller.go
+++ b/controllers/release_controller.go
@@ -75,15 +75,16 @@ func (r *ReleaseReconciler) triggerReleasePipeline(ctx context.Context, release 
 		return ctrl.Result{}, nil
 	}
 
-	_, err = r.getTargetReleaseLink(ctx, releaseLink)
+	targetReleaseLink, err := r.getTargetReleaseLink(ctx, releaseLink)
 	if err != nil {
-		log.Error(err, "Failed to find a matching ReleaseLink in target workspace", "ReleaseLink.Target", releaseLink.Spec.Target)
+		log.Error(err, "Failed to find a matching ReleaseLink in target workspace",
+			"ReleaseLink.Target", releaseLink.Spec.Target)
 		release.Status.SetErrorCondition(err)
 
 		return ctrl.Result{}, nil
 	}
 
-	releaseStrategy, err := r.getReleaseStrategy(ctx, releaseLink)
+	releaseStrategy, err := r.getReleaseStrategy(ctx, targetReleaseLink)
 	if err != nil {
 		log.Error(err, "Failed to get ReleaseStrategy")
 		release.Status.SetErrorCondition(err)
@@ -126,8 +127,8 @@ func (r *ReleaseReconciler) getReleaseLink(ctx context.Context, release *v1alpha
 func (r *ReleaseReconciler) getReleaseStrategy(ctx context.Context, releaseLink *v1alpha1.ReleaseLink) (*v1alpha1.ReleaseStrategy, error) {
 	releaseStrategy := &v1alpha1.ReleaseStrategy{}
 	err := r.Get(ctx, types.NamespacedName{
-		Namespace: releaseLink.Spec.Target,
 		Name:      releaseLink.Spec.ReleaseStrategy,
+		Namespace: releaseLink.Namespace,
 	}, releaseStrategy)
 
 	if err != nil {
@@ -156,7 +157,7 @@ func (r *ReleaseReconciler) getTargetReleaseLink(ctx context.Context, releaseLin
 		}
 	}
 
-	return nil, fmt.Errorf("no ReleaseLink found in target workspace %s with target %s and application %s",
+	return nil, fmt.Errorf("no ReleaseLink found in target workspace '%s' with target '%s' and application '%s'",
 		releaseLink.Spec.Target, releaseLink.Namespace, releaseLink.Spec.Application)
 }
 

--- a/demos/m4/base/release_links.yaml
+++ b/demos/m4/base/release_links.yaml
@@ -16,5 +16,5 @@ metadata:
 spec:
   displayName: Managed Workspace's ReleaseLink
   application: m4-app
-  target: managed
+  target: demo
   releaseStrategy: m4-strategy

--- a/demos/m4/base/release_strategy.yaml
+++ b/demos/m4/base/release_strategy.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: managed
 spec:
   pipeline: m4-release-pipeline
-  bundle: quay.io/hacbs-release/hello-world:0.3-alpine
+  bundle: quay.io/hacbs-release/m4:0.1-alpine

--- a/demos/m4/overlays/dev/pipeline_run.yaml
+++ b/demos/m4/overlays/dev/pipeline_run.yaml
@@ -9,4 +9,4 @@ metadata:
 spec:
   pipelineRef:
     name: m4-build-pipeline
-    bundle: quay.io/hacbs-release/hello-world:0.3-alpine
+    bundle: quay.io/hacbs-release/m4:0.1-alpine


### PR DESCRIPTION
We were fetching the strategy name from the ReleaseLink in the user's workspace, which doesn't have that value. This commit fix the issue, loading the remote ReleaseLink and getting the strategy from that resource.