### PR TITLE
setup Pipelines-as-Code for release-service

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: release-service-pull-request
+  annotations:
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  params: 
+    - name: git-url
+      value: "{{ repo_url }}"
+    - name: revision
+      value: "{{ revision }}"
+    - name: output-image
+      value: 'quay.io/redhat-appstudio/pull-request-builds:release-service-{{ revision }}'
+  pipelineRef:
+    name: docker-build
+    bundle: quay.io/redhat-appstudio/build-templates-bundle:c135924c0ea4d8c7f5c4c721f866e040d66f14ba
+  serviceAccountName: pipeline
+  workspaces:
+    - name: workspace
+      persistentVolumeClaim:
+        claimName: app-studio-default-workspace
+      subPath: release-service-check-{{ revision }}

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -17,7 +17,7 @@ spec:
       value: 'quay.io/redhat-appstudio/pull-request-builds:release-service-{{ revision }}'
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/build-templates-bundle:c135924c0ea4d8c7f5c4c721f866e040d66f14ba
+    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
   serviceAccountName: pipeline
   workspaces:
     - name: workspace

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: release-service-on-push
+  annotations:
+    pipelinesascode.tekton.dev/on-event: "[push]" 
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  params:
+    - name: git-url
+      value: "{{ repo_url }}"
+    - name: revision
+      value: "{{ revision }}"
+    - name: output-image
+      value: 'quay.io/redhat-appstudio/release-service:{{ revision }}'
+    - name: path-context
+      value: .
+    - name: dockerfile
+      value: Dockerfile
+  pipelineRef:
+    name: docker-build
+    bundle: quay.io/redhat-appstudio/build-templates-bundle:c135924c0ea4d8c7f5c4c721f866e040d66f14ba
+  workspaces: 
+   - name: workspace 
+     persistentVolumeClaim: 
+        claimName: app-studio-default-workspace 
+     subPath: release-service-push-{{ revision }}

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -30,3 +30,6 @@ spec:
      persistentVolumeClaim: 
         claimName: app-studio-default-workspace 
      subPath: release-service-push-{{ revision }}
+   - name: deploy-key
+     secret:
+        secretName: infra-deployments-deploy-key

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -19,9 +19,12 @@ spec:
       value: .
     - name: dockerfile
       value: Dockerfile
+    - name: infra-deployment-update-script
+      value: |
+        sed -i -e 's|\(https://github.com/redhat-appstudio/release-service/config/default?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/release/kustomization.yaml
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/build-templates-bundle:c135924c0ea4d8c7f5c4c721f866e040d66f14ba
+    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
   workspaces: 
    - name: workspace 
      persistentVolumeClaim: 


### PR DESCRIPTION
This will enable release-service repo to easily configure Tekton as CI for PR checks.
The goal of Pipelines as Code is to let you define your Tekton templates inside your source code repository and have the pipeline run and report the status of the execution when triggered by a Pull Request or a Push.

related PR on infra-deployments: https://github.com/redhat-appstudio/infra-deployments/pull/283