### PR TITLE
Add instructions for M4 demo

### DIFF
--- a/demos/m4/README.md
+++ b/demos/m4/README.md
@@ -1,0 +1,35 @@
+# Milestone 4 demo
+
+This directory contains the resources needed for running the release demo for Milestone 4.
+
+## Environments
+
+This demo can run in two different environments:
+
+* dev: This environment uses an empty CRC cluster with Openshift Pipelines preinstalled.
+* staging: Meant to be used in a cluster bootstrapped with infra-deployments.
+
+## Running the demo
+
+To run the demo execute the following commands:
+
+```bash
+$ git clone https://github.com/redhat-appstudio/release-service.git
+$ cd release-service/demo/m4
+$ kubectl apply -k overlays/<environment>
+```
+
+## What to expect
+
+After running the commands above, you should expect to find:
+
+* a Build PipelineRun for the component `m4-component`;
+* a Release created in the `demo` namespace;
+* a Release PipelineRun created in the `managed` namespace.
+
+The following command can be used to inspect the result of the release:
+```bash
+oc get release -n demo -o wide
+NAME            COMPONENT      TRIGGER     SUCCEEDED   REASON      PIPELINERUN         START TIME   COMPLETION TIME   AGE
+release-crndf   m4-component   automated   True        Succeeded   m4-strategy-stk9q   41s          32s               50s
+```

--- a/demos/m4/base/kustomization.yaml
+++ b/demos/m4/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespaces.yaml
+  - release_strategy.yaml
+  - release_links.yaml

--- a/demos/m4/base/namespaces.yaml
+++ b/demos/m4/base/namespaces.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: managed

--- a/demos/m4/base/release_links.yaml
+++ b/demos/m4/base/release_links.yaml
@@ -1,0 +1,20 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseLink
+metadata:
+  name: demo
+  namespace: demo
+spec:
+  displayName: Users's ReleaseLink
+  application: m4-app
+  target: managed
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseLink
+metadata:
+  name: managed
+  namespace: managed
+spec:
+  displayName: Managed Workspace's ReleaseLink
+  application: m4-app
+  target: managed
+  releaseStrategy: m4-strategy

--- a/demos/m4/base/release_strategy.yaml
+++ b/demos/m4/base/release_strategy.yaml
@@ -1,0 +1,8 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseStrategy
+metadata:
+  name: m4-strategy
+  namespace: managed
+spec:
+  pipeline: m4-release-pipeline
+  bundle: quay.io/hacbs-release/hello-world:0.3-alpine

--- a/demos/m4/overlays/dev/component.yaml
+++ b/demos/m4/overlays/dev/component.yaml
@@ -1,0 +1,13 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  name: m4-component
+  namespace: demo
+spec:
+  componentName: m4-component
+  application: m4-app
+  source:
+    git:
+      url: https://github.com/sbose78/devfile-sample-code-with-quarkus
+  build:
+    containerImage: quay.io/damoreno/foobar:dev-code-with-quarkus

--- a/demos/m4/overlays/dev/kustomization.yaml
+++ b/demos/m4/overlays/dev/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - component.yaml
+  - tekton_feature_flags_config_map.yaml
+  - pipeline_run.yaml

--- a/demos/m4/overlays/dev/pipeline_run.yaml
+++ b/demos/m4/overlays/dev/pipeline_run.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: build-m4-component
+  labels:
+    pipelines.appstudio.openshift.io/type: build
+    build.appstudio.openshift.io/component: m4-component
+  namespace: demo
+spec:
+  pipelineRef:
+    name: m4-build-pipeline
+    bundle: quay.io/hacbs-release/hello-world:0.3-alpine

--- a/demos/m4/overlays/dev/tekton_feature_flags_config_map.yaml
+++ b/demos/m4/overlays/dev/tekton_feature_flags_config_map.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+  name: feature-flags
+  namespace: openshift-pipelines
+data:
+  disable-affinity-assistant: "true"
+  disable-creds-init: "false"
+  disable-home-env-overwrite: "true"
+  disable-working-directory-overwrite: "true"
+  enable-api-fields: stable
+  enable-custom-tasks: "false"
+  enable-tekton-oci-bundles: "true"
+  require-git-ssh-secret-known-hosts: "false"
+  running-in-environment-with-injected-sidecars: "true"
+  scope-when-expressions-to-task: "false"

--- a/demos/m4/overlays/staging/application.yaml
+++ b/demos/m4/overlays/staging/application.yaml
@@ -1,0 +1,7 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Application
+metadata:
+  name: m4-app
+  namespace: demo
+spec:
+  displayName: M4 sample app

--- a/demos/m4/overlays/staging/component.yaml
+++ b/demos/m4/overlays/staging/component.yaml
@@ -1,0 +1,13 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  name: m4-component
+  namespace: demo
+spec:
+  componentName: m4-component
+  application: m4-app
+  source:
+    git:
+      url: https://github.com/sbose78/devfile-sample-code-with-quarkus
+  build:
+    containerImage: quay.io/damoreno/foobar:dev-code-with-quarkus

--- a/demos/m4/overlays/staging/kustomization.yaml
+++ b/demos/m4/overlays/staging/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - application.yaml
+  - component.yaml


### PR DESCRIPTION
This PR adds resources and information for M4 demo. It uses kustomize to be able to run it in a dev environment (with CRC and Openshift Pipelines) and in staging (with a cluster bootstrapped with infra-deployments).