### PR TITLE
Add release webhook

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -24,6 +24,9 @@ resources:
   kind: Release
   path: github.com/redhat-appstudio/release-service/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - controller: true
   domain: redhat.com
   group: appstudio

--- a/api/v1alpha1/release_webhook.go
+++ b/api/v1alpha1/release_webhook.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var releaselog = logf.Log.WithName("release-resource")
+
+func (r *Release) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-release,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=releases,verbs=create;update,versions=v1alpha1,name=vrelease.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &Release{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *Release) ValidateCreate() error {
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *Release) ValidateUpdate(old runtime.Object) error {
+	releaselog.Info("validate update", "name", r.Name)
+
+	return fmt.Errorf("release resources cannot be updated")
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *Release) ValidateDelete() error {
+	return nil
+}

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -80,6 +80,9 @@ var _ = BeforeSuite(func() {
 	err = admissionv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = admissionv1beta1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
@@ -99,6 +102,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&ReleaseLink{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&Release{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:webhook

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -38,6 +38,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-appstudio-redhat-com-v1alpha1-release
+  failurePolicy: Fail
+  name: vrelease.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - releases
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-appstudio-redhat-com-v1alpha1-releaselink
   failurePolicy: Fail
   name: vreleaselink.kb.io

--- a/main.go
+++ b/main.go
@@ -106,8 +106,14 @@ func main() {
 
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		setupLog.Info("setting up webhooks")
+
 		if err = (&appstudiov1alpha1.ReleaseLink{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "ReleaseLink")
+			os.Exit(1)
+		}
+
+		if err = (&appstudiov1alpha1.Release{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "Release")
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
The new webhook will forbid updates to Releases as these resources should not be updated once created. At that point the controller is already processing them and adding data specific to the fields in the resource specification.