### PR TITLE
feat(HACBS-392): pass ApplicationSnapshot to Release pipeline

### DIFF
--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -17,7 +17,9 @@ limitations under the License.
 package tekton
 
 import (
+	"encoding/json"
 	"fmt"
+
 	libhandler "github.com/operator-framework/operator-lib/handler"
 	"github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -98,6 +100,22 @@ func (r *ReleasePipelineRun) WithReleaseLabels(releaseName, releaseNamespace str
 		ReleaseNameLabel:      releaseName,
 		ReleaseWorkspaceLabel: releaseNamespace,
 	}
+
+	return r
+}
+
+// WithApplicationSnapshot adds a param containing the ApplicationSnapshot as a json string
+// to the release PipelineRun.
+func (r *ReleasePipelineRun) WithApplicationSnapshot(snapshot *v1alpha1.ApplicationSnapshot) *ReleasePipelineRun {
+	// We ignore the error here because none should be raised when marshalling the spec of a CRD.
+	// If we end up deciding it is useful, we will need to pass the errors trough the chain and
+	// add something like a `Complete` function that returns the final object and error.
+	snapshotString, _ := json.Marshal(snapshot.Spec)
+
+	r.WithExtraParam(snapshot.Kind, tektonv1beta1.ArrayOrString{
+		Type:      tektonv1beta1.ParamTypeString,
+		StringVal: string(snapshotString),
+	})
 
 	return r
 }


### PR DESCRIPTION
Extract the ApplicationSnapshot from the Release CR that is being processed
and pass that as a parameter to the Release pipeline.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>