### PR TITLE
feat(HACBS-471): add demo files for M5

### DIFF
--- a/demos/m5/README.md
+++ b/demos/m5/README.md
@@ -1,0 +1,10 @@
+# Milestone 5 demo
+
+This directory contains the resources needed for running the release demo for Milestone 5.
+
+## Environments
+
+This demo can run in two different environments:
+
+* **dev**: Use this environment to run on an empty CRC cluster with Openshift Pipelines preinstalled.
+* **staging**: This environment is meant to be used in a cluster bootstrapped with infra-deployments.

--- a/demos/m5/base/application_snapshot.yaml
+++ b/demos/m5/base/application_snapshot.yaml
@@ -1,0 +1,13 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ApplicationSnapshot
+metadata:
+  name: m5-snapshot
+  namespace: demo
+spec:
+  images:
+    - component: component1
+      pullSpec: quay.io/redhat-appstudio/component1@sha256:d5e85e49c89df42b221d972f5b96c6507a8124717a6e42e83fd3caae1031d514
+    - component: component2
+      pullSpec: quay.io/redhat-appstudio/component2@sha256:a01dfd18cf8ca8b68770b09a9b6af0fd7c6d1f8644c7ab97f0e06c34dfc5860e
+    - component: component3
+      pullSpec:  quay.io/redhat-appstudio/component3@sha256:d90a0a33e4c5a1daf5877f8dd989a570bfae4f94211a8143599245e503775b1f

--- a/demos/m5/base/kustomization.yaml
+++ b/demos/m5/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespaces.yaml
+  - application_snapshot.yaml
+  - release_strategy.yaml
+  - release_links.yaml
+  - tekton_feature_flags_config_map.yaml

--- a/demos/m5/base/namespaces.yaml
+++ b/demos/m5/base/namespaces.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: managed

--- a/demos/m5/base/release_links.yaml
+++ b/demos/m5/base/release_links.yaml
@@ -1,0 +1,20 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseLink
+metadata:
+  name: m5-release-link-demo
+  namespace: demo
+spec:
+  displayName: Users's ReleaseLink
+  application: m5-app
+  target: managed
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseLink
+metadata:
+  name: m5-release-link-managed
+  namespace: managed
+spec:
+  displayName: Managed Workspace's ReleaseLink
+  application: m5-app
+  target: demo
+  releaseStrategy: m5-strategy

--- a/demos/m5/base/release_strategy.yaml
+++ b/demos/m5/base/release_strategy.yaml
@@ -1,0 +1,8 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseStrategy
+metadata:
+  name: m5-strategy
+  namespace: managed
+spec:
+  pipeline: release-pipeline
+  bundle: quay.io/hacbs-release/demo:m5-alpine

--- a/demos/m5/base/tekton_feature_flags_config_map.yaml
+++ b/demos/m5/base/tekton_feature_flags_config_map.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+  name: feature-flags
+  namespace: openshift-pipelines
+data:
+  disable-affinity-assistant: "true"
+  disable-creds-init: "false"
+  disable-home-env-overwrite: "true"
+  disable-working-directory-overwrite: "true"
+  enable-api-fields: stable
+  enable-custom-tasks: "false"
+  enable-tekton-oci-bundles: "true"
+  require-git-ssh-secret-known-hosts: "false"
+  running-in-environment-with-injected-sidecars: "true"
+  scope-when-expressions-to-task: "false"

--- a/demos/m5/overlays/dev/kustomization.yaml
+++ b/demos/m5/overlays/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - release.yaml

--- a/demos/m5/overlays/dev/release.yaml
+++ b/demos/m5/overlays/dev/release.yaml
@@ -1,0 +1,8 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: m5-release
+  namespace: demo
+spec:
+  applicationSnapshot: m5-snapshot
+  releaseLink: demo

--- a/demos/m5/overlays/staging/kustomization.yaml
+++ b/demos/m5/overlays/staging/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base


### PR DESCRIPTION
Adds new demo files to trigger the operator through the creations of a Release. Component and Application references have been removed.

Signed-off-by: David Moreno García <damoreno@redhat.com>