### PR TITLE
fix(HACBS-509): prevent spec updates exclusively

### DIFF
--- a/api/v1alpha1/release_webhook.go
+++ b/api/v1alpha1/release_webhook.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
+	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -46,7 +47,11 @@ func (r *Release) ValidateCreate() error {
 func (r *Release) ValidateUpdate(old runtime.Object) error {
 	releaselog.Info("validate update", "name", r.Name)
 
-	return fmt.Errorf("release resources cannot be updated")
+	if !reflect.DeepEqual(r.Spec, old.(*Release).Spec) {
+		return fmt.Errorf("release resources spec cannot be updated")
+	}
+
+	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type

--- a/api/v1alpha1/release_webhook_test.go
+++ b/api/v1alpha1/release_webhook_test.go
@@ -17,78 +17,62 @@ package v1alpha1
 
 import (
 	"context"
-	"reflect"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	//+kubebuilder:scaffold:imports
 )
 
 var _ = Describe("Release validation webhook", func() {
-	// Define utility constants for object names
-	const (
-		Name                = "test-release-"
-		Namespace           = "default"
-		ApplicationSnapshot = "test-snapshot"
-		ReleaseLink         = "test-releaselink"
-	)
+	var release *Release
+
+	BeforeEach(func() {
+		release = &Release{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "appstudio.redhat.com/v1alpha1",
+				Kind:       "Release",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-release-",
+				Namespace:    "default",
+			},
+			Spec: ReleaseSpec{
+				ApplicationSnapshot: "test-snapshot",
+				ReleaseLink:         "test-releaselink",
+			},
+		}
+	})
+
+	AfterEach(func() {
+		_ = k8sClient.Delete(ctx, release)
+	})
 
 	Context("Update Release CR fields", func() {
 		It("Should error out when updating the resource", func() {
 			ctx := context.Background()
 
-			release := &Release{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "appstudio.redhat.com/v1alpha1",
-					Kind:       "Release",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: Name,
-					Namespace:    Namespace,
-				},
-				Spec: ReleaseSpec{
-					ApplicationSnapshot: ApplicationSnapshot,
-					ReleaseLink:         ReleaseLink,
-				},
-			}
 			Expect(k8sClient.Create(ctx, release)).Should(Succeed())
 
-			// Look up the Release resource that was created
-			releaseLookupKey := types.NamespacedName{Name: release.Name, Namespace: Namespace}
-			createdRelease := &Release{}
-			Eventually(func() bool {
-				k8sClient.Get(ctx, releaseLookupKey, createdRelease)
-				return !reflect.DeepEqual(createdRelease, &Release{})
-			}, timeout, interval).Should(BeTrue())
-
 			// Try to update the Release application snapshot
-			createdRelease.Spec.ApplicationSnapshot = "another-snapshot"
-			err := k8sClient.Update(ctx, createdRelease)
+			release.Spec.ApplicationSnapshot = "another-snapshot"
+
+			err := k8sClient.Update(ctx, release)
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("release resources spec cannot be updated"))
+		})
 
-			// Delete the specified Release resource
-			deleteReleaseCR(releaseLookupKey)
+		It("Should not error out when updating the resource metadata", func() {
+			ctx := context.Background()
+
+			Expect(k8sClient.Create(ctx, release)).Should(Succeed())
+
+			// Try to update the Release annotations
+			release.ObjectMeta.Annotations = map[string]string{
+				"foo": "bar",
+			}
+
+			Expect(k8sClient.Update(ctx, release)).ShouldNot(HaveOccurred())
 		})
 	})
-
 })
-
-// deleteReleaseCR deletes the specified Release resource and verifies it was properly deleted.
-func deleteReleaseCR(releaseLookupKey types.NamespacedName) {
-	// Delete
-	Eventually(func() error {
-		f := &Release{}
-		k8sClient.Get(context.Background(), releaseLookupKey, f)
-		return k8sClient.Delete(context.Background(), f)
-	}, timeout, interval).Should(Succeed())
-
-	// Wait for delete to finish
-	Eventually(func() error {
-		f := &Release{}
-		return k8sClient.Get(context.Background(), releaseLookupKey, f)
-	}, timeout, interval).ShouldNot(Succeed())
-}

--- a/api/v1alpha1/release_webhook_test.go
+++ b/api/v1alpha1/release_webhook_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Release validation webhook", func() {
 			createdRelease.Spec.ApplicationSnapshot = "another-snapshot"
 			err := k8sClient.Update(ctx, createdRelease)
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("release resources cannot be updated"))
+			Expect(err.Error()).Should(ContainSubstring("release resources spec cannot be updated"))
 
 			// Delete the specified Release resource
 			deleteReleaseCR(releaseLookupKey)

--- a/api/v1alpha1/release_webhook_unit_test.go
+++ b/api/v1alpha1/release_webhook_unit_test.go
@@ -61,7 +61,7 @@ func TestReleaseUpdateValidatingWebhook(t *testing.T) {
 	}{
 		{
 			name:         "trying to update a release fails",
-			errorMessage: "release resources cannot be updated",
+			errorMessage: "release resources spec cannot be updated",
 			release: Release{
 				Spec: ReleaseSpec{
 					ApplicationSnapshot: "snapshot2",


### PR DESCRIPTION
The Release admission webhook was preventing the objects to be updated to add a finalizer. The admission webhook for updates should exclusively prevent spec updates.

Signed-off-by: David Moreno García <damoreno@redhat.com>