### PR TITLE
fix(HACBS-510): fail on description starting with uppercase

### DIFF
--- a/.github/gitlint/contrib_description_conventional_commits.py
+++ b/.github/gitlint/contrib_description_conventional_commits.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from gitlint.rules import CommitRule, RuleViolation
+
+
+class ConventionalCommitsDescription(CommitRule):
+    """This rule will enforce that each commit description starts with
+    a lowercase."""
+
+    id = "UC1"
+    name = "contrib-description-conventional-commits"
+
+    def validate(self, commit):
+        """Validate the given commit checking that the description starts with
+        a lowercase."""
+        if ":" not in commit.message.title:
+            self.log.debug("Title does not follow conventional commit specification")
+            return
+
+        description = commit.message.title.split(":")[1].strip()
+
+        if len(description) > 0 and description[0].isupper():
+            return [
+                RuleViolation(
+                    self.id, "Description should start with lowercase", line_nr=1
+                )
+            ]

--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,6 @@
 [general]
 contrib=contrib-title-conventional-commits,CC1
+extra-path=.github/gitlint
 ignore=T5
 
 [title-max-length]


### PR DESCRIPTION
We are following Conventional Commits and using Gitlint to enforce the specification. Although the description doesn't have a set-on-stone format, examples on Conventional Commits spec seem to use always a sentence starting with lowercase. This is not enforced by Gitlint, but I think it would be good to enforce it. First because all our commits will follow the same convention. Second because a new user following the spec will already think this is the proper way.

Signed-off-by: David Moreno García <damoreno@redhat.com>