### PR TITLE
feat(HACBS-541): add serviceAccount field

### DIFF
--- a/api/v1alpha1/releasestrategy_types.go
+++ b/api/v1alpha1/releasestrategy_types.go
@@ -33,6 +33,11 @@ type ReleaseStrategySpec struct {
 
 	// Policy to validate before releasing an artifact
 	Policy string `json:"policy,omitempty"`
+
+	// Service account to use in the release PipelineRun to gain elevated privileges
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	// +optional
+	ServiceAccount string `json:"serviceAccount,omitempty"`
 }
 
 // Params holds the definition of a parameter that should be passed to the release Pipeline

--- a/config/crd/bases/appstudio.redhat.com_releasestrategies.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releasestrategies.yaml
@@ -66,6 +66,11 @@ spec:
               policy:
                 description: Policy to validate before releasing an artifact
                 type: string
+              serviceAccount:
+                description: Service account to use in the release PipelineRun to
+                  gain elevated privileges
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
             required:
             - pipeline
             type: object

--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -148,5 +148,15 @@ func (r *ReleasePipelineRun) WithReleaseStrategy(strategy *v1alpha1.ReleaseStrat
 		})
 	}
 
+	r.WithServiceAccount(strategy.Spec.ServiceAccount)
+
+	return r
+}
+
+// WithServiceAccount adds a reference to the service account to be used to gain elevated privileges during the
+// execution of the different Pipeline tasks.
+func (r *ReleasePipelineRun) WithServiceAccount(serviceAccount string) *ReleasePipelineRun {
+	r.Spec.ServiceAccountName = serviceAccount
+
 	return r
 }


### PR DESCRIPTION
This commit allows to specify a service account for the release PipelineRun. We are going to need to pass a service account to be able to clone private repositories (at least).

Signed-off-by: David Moreno García <damoreno@redhat.com>