### PR TITLE
feat(HACBS-514): add application spec field to ApplicationSnapshot

### DIFF
--- a/api/v1alpha1/applicationsnapshot_types.go
+++ b/api/v1alpha1/applicationsnapshot_types.go
@@ -33,6 +33,11 @@ type Image struct {
 
 // ApplicationSnapshotSpec defines the desired state of ApplicationSnapshot
 type ApplicationSnapshotSpec struct {
+	// Application is a reference to the application that this ApplicationSnapshot belongs to
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	// +required
+	Application string `json:"application"`
+
 	// Images is the list of component images that makes up the snapshot
 	// +required
 	Images []Image `json:"images"`
@@ -43,6 +48,7 @@ type ApplicationSnapshotStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Application",type=string,JSONPath=`.spec.application`
 
 // ApplicationSnapshot is the Schema for the applicationsnapshots API
 type ApplicationSnapshot struct {

--- a/config/crd/bases/appstudio.redhat.com_applicationsnapshots.yaml
+++ b/config/crd/bases/appstudio.redhat.com_applicationsnapshots.yaml
@@ -15,7 +15,11 @@ spec:
     singular: applicationsnapshot
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.application
+      name: Application
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ApplicationSnapshot is the Schema for the applicationsnapshots
@@ -36,6 +40,11 @@ spec:
           spec:
             description: ApplicationSnapshotSpec defines the desired state of ApplicationSnapshot
             properties:
+              application:
+                description: Application is a reference to the application that this
+                  ApplicationSnapshot belongs to
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
               images:
                 description: Images is the list of component images that makes up
                   the snapshot
@@ -56,6 +65,7 @@ spec:
                   type: object
                 type: array
             required:
+            - application
             - images
             type: object
           status:


### PR DESCRIPTION
This commit adds the additional 'application' spec field to
the ApplicationSnapshot CRD.

Signed-off-by: Krunoslav Pavic <kpavic@redhat.com>