### PR TITLE
fix(HACBS-571): use proper ReleaseLink name

### DIFF
--- a/demos/m5/overlays/dev/release.yaml
+++ b/demos/m5/overlays/dev/release.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: demo
 spec:
   applicationSnapshot: m5-snapshot
-  releaseLink: demo
+  releaseLink: m5-release-link-demo


### PR DESCRIPTION
The name of the ReleaseLink in the Release was incorrect.

Signed-off-by: David Moreno García <damoreno@redhat.com>