### PR TITLE
feat(HACBS-572): add rbac for ApplicationSnapshots

### DIFF
--- a/config/rbac/applicationsnapshot_role_binding.yaml
+++ b/config/rbac/applicationsnapshot_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: applicationsnapshot-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: applicationsnapshot-viewer-role
+subjects:
+  - kind: ServiceAccount
+    name: controller-manager
+    namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -10,6 +10,9 @@ resources:
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 # Aggregating roles which are otherwise done by OLM
+- applicationsnapshot_editor_role.yaml
+- applicationsnapshot_role_binding.yaml
+- applicationsnapshot_viewer_role.yaml
 - release_editor_role.yaml
 - release_role_binding.yaml
 - release_viewer_role.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,12 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
+  - applicationsnapshots
+  verbs:
+  - get
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
   - releases
   verbs:
   - create

--- a/controllers/release/release_controller.go
+++ b/controllers/release/release_controller.go
@@ -53,6 +53,7 @@ func NewReleaseReconciler(client client.Client, logger *logr.Logger, scheme *run
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releases/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releases/finalizers,verbs=update
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applicationsnapshots,verbs=get
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
We are currently seeing failures when accessing ApplicationSnapshots. This is due to the fact that don't have set proper RBAC for that resource. This commit adds the proper permissions.

Signed-off-by: David Moreno García <damoreno@redhat.com>