### PR TITLE
feat(HACBS-606): pass release to the Release pipeline

### DIFF
--- a/controllers/release/release_adapter.go
+++ b/controllers/release/release_adapter.go
@@ -172,7 +172,7 @@ func (a *Adapter) EnsureReleasePipelineStatusIsTracked() (results.OperationResul
 func (a *Adapter) createReleasePipelineRun(releaseStrategy *v1alpha1.ReleaseStrategy, applicationSnapshot *v1alpha1.ApplicationSnapshot) (*v1beta1.PipelineRun, error) {
 	pipelineRun := tekton.NewReleasePipelineRun(releaseStrategy.Name, releaseStrategy.Namespace).
 		WithOwner(a.release).
-		WithReleaseLabels(a.release.Name, a.release.Namespace).
+		WithRelease(a.release).
 		WithReleaseStrategy(releaseStrategy).
 		WithApplicationSnapshot(applicationSnapshot).
 		AsPipelineRun()

--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"unicode"
 
+	"k8s.io/apimachinery/pkg/types"
+	"strings"
+
 	libhandler "github.com/operator-framework/operator-lib/handler"
 	"github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -94,13 +97,19 @@ func (r *ReleasePipelineRun) WithOwner(release *v1alpha1.Release) *ReleasePipeli
 	return r
 }
 
-// WithReleaseLabels adds Release name and namespace as labels to the release PipelineRun.
-func (r *ReleasePipelineRun) WithReleaseLabels(releaseName, releaseNamespace string) *ReleasePipelineRun {
+// WithRelease adds Release name and namespace as labels to the release PipelineRun. It also sets an extra 'release'
+// parameter with the namespaced name of the release.
+func (r *ReleasePipelineRun) WithRelease(release *v1alpha1.Release) *ReleasePipelineRun {
 	r.ObjectMeta.Labels = map[string]string{
 		PipelinesTypeLabel:    PipelineTypeRelease,
-		ReleaseNameLabel:      releaseName,
-		ReleaseWorkspaceLabel: releaseNamespace,
+		ReleaseNameLabel:      release.Name,
+		ReleaseWorkspaceLabel: release.Namespace,
 	}
+
+	r.WithExtraParam(strings.ToLower(release.Kind), tektonv1beta1.ArrayOrString{
+		Type:      tektonv1beta1.ParamTypeString,
+		StringVal: fmt.Sprintf("%s%c%s", release.Namespace, types.Separator, release.Name),
+	})
 
 	return r
 }


### PR DESCRIPTION
The Release pipeline will make use of a workspace. To make sure nothing gets overwritten while running multiple pipelines, we need to use a subpath. For this, we can make use of the release name in the format `<namespace>/<name>`.

Signed-off-by: David Moreno García <damoreno@redhat.com>