### PR TITLE
feat(HACBS-666): set a proper name for the release PipelineRun

### DIFF
--- a/controllers/release/release_adapter.go
+++ b/controllers/release/release_adapter.go
@@ -170,7 +170,7 @@ func (a *Adapter) EnsureReleasePipelineStatusIsTracked() (results.OperationResul
 // will be extracted from the given ReleaseStrategy. The Release's ApplicationSnapshot will also be passed to the
 // release PipelineRun.
 func (a *Adapter) createReleasePipelineRun(releaseStrategy *v1alpha1.ReleaseStrategy, applicationSnapshot *v1alpha1.ApplicationSnapshot) (*v1beta1.PipelineRun, error) {
-	pipelineRun := tekton.NewReleasePipelineRun(releaseStrategy.Name, releaseStrategy.Namespace).
+	pipelineRun := tekton.NewReleasePipelineRun("release-pipelinerun", releaseStrategy.Namespace).
 		WithOwner(a.release).
 		WithRelease(a.release).
 		WithReleaseStrategy(releaseStrategy).


### PR DESCRIPTION
We are currently using a name that references the ReleaseStrategy name. This doesn't seem to be a proper name any more so this commit updates the name to `release-pipelinerun-`.

Signed-off-by: David Moreno García <damoreno@redhat.com>