### PR TITLE
feat(HACBS-555): add auto-release label to ReleaseLinks

### DIFF
--- a/api/v1alpha1/releaselink_webhook.go
+++ b/api/v1alpha1/releaselink_webhook.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -29,12 +30,19 @@ func (r *ReleaseLink) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// +kubebuilder:webhook:path=/mutate-appstudio-redhat-com-v1alpha1-releaselink,mutating=true,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=releaselinks,verbs=create;update,versions=v1alpha1,name=mreleaselink.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-appstudio-redhat-com-v1alpha1-releaselink,mutating=true,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=releaselinks,verbs=create,versions=v1alpha1,name=mreleaselink.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Defaulter = &ReleaseLink{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (r *ReleaseLink) Default() {
+	label := "release.appstudio.openshift.io/auto-release"
+	if _, found := r.GetLabels()[label]; !found {
+		if r.Labels == nil {
+			r.Labels = make(map[string]string)
+		}
+		r.Labels[label] = "true"
+	}
 }
 
 // +kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-releaselink,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=releaselinks,verbs=create;update,versions=v1alpha1,name=vreleaselink.kb.io,admissionReviewVersions=v1

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -21,7 +21,6 @@ webhooks:
     - v1alpha1
     operations:
     - CREATE
-    - UPDATE
     resources:
     - releaselinks
   sideEffects: None


### PR DESCRIPTION
This commit adds a mutating webhook for ReleaseLink CRs. The webhook
checks to see if the release.appstudio.openshift.io/auto-release label
exists. If it does not exist, it adds it with a value of true. If it
does exist (meaning the user added the label when creating the CR),
it will do nothing.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>