### PR TITLE
feat(HACBS-154): add release metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY metrics/ metrics/
 COPY tekton/ tekton/
 
 # Build

--- a/README.md
+++ b/README.md
@@ -51,3 +51,16 @@ using the following command:
 ```shell
 $ ENABLE_WEBHOOKS=false make run install
 ```
+
+## Metrics
+
+Apart from the [metrics provided by controller-runtime](https://book.kubebuilder.io/reference/metrics-reference.html)
+by default, this operator exports the following custom metrics:
+
+| Metric name                         | Type      | Description                                                                                                  |
+|-------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------|
+| release_attempt_concurrent_requests | Gauge     | Total number of concurrent release attempts.                                                                 |
+| release_attempt_duration_seconds    | Histogram | Release durations from the moment the release PipelineRun was created til the release is marked as finished. |
+| release_attempt_invalid_total       | Counter   | Number of invalid releases.                                                                                  |
+| release_attempt_running_seconds     | Histogram | Release durations from the moment the release resource was created til the release is marked as running.     |
+| release_attempt_total               | Counter   | Total number of releases processed by the operator.                                                          |

--- a/config/crd/bases/appstudio.redhat.com_releases.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releases.yaml
@@ -155,10 +155,20 @@ spec:
                   release PipelineRun executed as part of this release
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
+              releaseStrategy:
+                description: ReleaseStrategy contains the namespaced name of the ReleaseStrategy
+                  used for this release
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
               startTime:
                 description: StartTime is the time when the Release PipelineRun was
                   created and set to run
                 format: date-time
+                type: string
+              targetWorkspace:
+                description: TargetWorkspace is the workspace where this release will
+                  be released to
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
             type: object
         type: object

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -22,7 +22,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    openshift.io/cluster-monitoring: "true"
   name: system
 ---
 apiVersion: apps/v1

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -35,3 +35,6 @@ resources:
 # Application service
 - component_role.yaml
 - component_role_binding.yaml
+# Prometheus
+- prometheus_viewer_role.yaml
+- prometheus_role_binding.yaml

--- a/config/rbac/prometheus_role_binding.yaml
+++ b/config/rbac/prometheus_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-viewer-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/config/rbac/prometheus_viewer_role.yaml
+++ b/config/rbac/prometheus_viewer_role.yaml
@@ -1,0 +1,14 @@
+# permissions for prometheus to view custom metrics.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-viewer-role
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/metrics
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.12.1 // indirect
+	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/metrics/release.go
+++ b/metrics/release.go
@@ -1,0 +1,86 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"strconv"
+)
+
+var (
+	ReleaseAttemptConcurrentTotal = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "release_attempt_concurrent_requests",
+			Help: "Total number of concurrent release attempts",
+		},
+	)
+
+	ReleaseAttemptDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "release_attempt_duration_seconds",
+			Help:    "Release durations from the moment the release PipelineRun was created til the release is marked as finished",
+			Buckets: []float64{60, 150, 300, 450, 600, 750, 900, 1050, 1200, 1800, 3600},
+		},
+		[]string{"reason", "succeeded"},
+	)
+
+	ReleaseAttemptInvalidTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "release_attempt_invalid_total",
+			Help: "Number of invalid releases",
+		},
+		[]string{"reason"},
+	)
+
+	ReleaseAttemptRunningSeconds = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "release_attempt_running_seconds",
+			Help:    "Release durations from the moment the release resource was created til the release is marked as running",
+			Buckets: []float64{0.5, 1, 2, 3, 4, 5, 6, 7, 10, 15, 30},
+		},
+	)
+
+	ReleaseAttemptTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "release_attempt_total",
+			Help: "Total number of releases processed by the operator",
+		},
+		[]string{"target_workspace"},
+	)
+)
+
+// RegisterCompletedRelease decrements the 'release_attempt_concurrent_total' metric and registers a new observation for
+// 'release_attempt_duration_seconds' with the elapsed time from the moment the Release attempt started (Release marked
+// as 'Running').
+func RegisterCompletedRelease(reason string, startTime, completionTime *metav1.Time, succeeded bool) {
+	ReleaseAttemptConcurrentTotal.Dec()
+	ReleaseAttemptDurationSeconds.With(
+		prometheus.Labels{"reason": reason, "succeeded": strconv.FormatBool(succeeded)},
+	).Observe(completionTime.Sub(startTime.Time).Seconds())
+}
+
+// RegisterInvalidRelease increments the 'release_attempt_invalid_total' metrics.
+func RegisterInvalidRelease(reason string) {
+	ReleaseAttemptInvalidTotal.With(prometheus.Labels{"reason": reason}).Inc()
+}
+
+// RegisterNewRelease increments the 'release_attempt_concurrent_total' and `release_attempt_total` metrics, and
+// registers a new observation for 'release_attempt_duration_seconds' with the elapsed time from the moment the Release
+// was created to when it started (Release marked as 'Running').
+func RegisterNewRelease(targetWorkspace string, creationTime metav1.Time, startTime *metav1.Time) {
+	ReleaseAttemptConcurrentTotal.Inc()
+	ReleaseAttemptRunningSeconds.Observe(startTime.Sub(creationTime.Time).Seconds())
+	ReleaseAttemptTotal.With(prometheus.Labels{
+		"target_workspace": targetWorkspace,
+	}).Inc()
+}
+
+func init() {
+	metrics.Registry.MustRegister(
+		ReleaseAttemptConcurrentTotal,
+		ReleaseAttemptDurationSeconds,
+		ReleaseAttemptInvalidTotal,
+		ReleaseAttemptRunningSeconds,
+		ReleaseAttemptTotal,
+	)
+}


### PR DESCRIPTION
This commit adds metrics to the release resource so we can support the Release Service SLIs. In addition, adds changes to allow the Prometheus instance in openshift-monitoring to scrap our ServiceMonitor.