### PR TITLE
feat(HACBS-769): use gosec in release-service ci 

### DIFF
--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -1,0 +1,27 @@
+---
+name: Go Test on Pull Requests
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - '**.go'
+  workflow_dispatch:
+jobs:
+  gosec:
+    name: Check GO security
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: -exclude-generated ./...
+        env:
+          GOROOT: ""


### PR DESCRIPTION
Please see upstream docs here:
https://github.com/securego/gosec/

Jira: HACBS-769
Signed-off-by: Jon Disnard <jdisnard@redhat.com>