### PR TITLE
feat(HACBS-694): generate APIResourceSchema

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,6 +41,11 @@ jobs:
         run: |
           rm -f bin/kustomize bin/controller-gen
           make kustomize controller-gen
+      - name: Install kcp tooling
+        run: |
+          git clone https://github.com/kcp-dev/kcp ~/kcp
+          cd ~/kcp
+          WHAT=./cmd/kubectl-kcp make install
       - name: Cache go modules
         id: cache-mod
         uses: actions/cache@v2
@@ -75,12 +80,21 @@ jobs:
         with:
           version: "2021.1.2"
           install-go: false
-      - name: Check manifests
+      - name: Check kcp manifests
         run: |
-          make generate manifests
+          CONTROL_PLANE=kcp make generate manifests
           if [[ ! -z $(git status ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen' -s) ]]
           then
-            echo "generated sources are not up to date:"
+            echo "generated kcp sources are not up to date:"
+            git --no-pager diff ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen'
+            exit 1
+          fi
+      - name: Check kubernetes manifests
+        run: |
+          CONTROL_PLANE=kubernetes make generate manifests
+          if [[ ! -z $(git status ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen' -s) ]]
+          then
+            echo "generated k8s sources are not up to date:"
             git --no-pager diff ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen'
             exit 1
           fi

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ TAG_NAME ?= next
 CERT_MANAGER_VERSION ?= v1.8.0
 ENABLE_WEBHOOKS ?= true
 
+# CONTROL_PLANE defines the type of cluster that will be used. Possible values are kubernetes (default) and kcp.
+CONTROL_PLANE ?= kubernetes
+
 # DEFAULT_PERSISTENT_VOLUME_CLAIM defines the default PVC to be used in the Release pipeline workspace declaration.
 DEFAULT_RELEASE_PVC ?= release-pvc
 
@@ -98,6 +101,9 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+ifeq ($(CONTROL_PLANE), kcp)
+	hack/generate-kcp-api.sh ## Generate KCP APIResourceSchema from CRDs
+endif
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/config/kcp/apiexport_release.yaml
+++ b/config/kcp/apiexport_release.yaml
@@ -1,0 +1,12 @@
+# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
+# Please do not modify!
+
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIExport
+metadata:
+  name: release
+spec:
+  latestResourceSchemas:
+    - v202206271449.releaselinks.appstudio.redhat.com
+    - v202206271449.releases.appstudio.redhat.com
+    - v202206271449.releasestrategies.appstudio.redhat.com

--- a/config/kcp/apiresourceschema_release.yaml
+++ b/config/kcp/apiresourceschema_release.yaml
@@ -1,0 +1,351 @@
+# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
+# Please do not modify!
+
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v202206271449.releaselinks.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: ReleaseLink
+    listKind: ReleaseLinkList
+    plural: releaselinks
+    singular: releaselink
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display Name
+      priority: 1
+      type: string
+    - jsonPath: .spec.application
+      name: Application
+      type: string
+    - jsonPath: .spec.target
+      name: Target
+      type: string
+    - jsonPath: .spec.releaseStrategy
+      name: Release Strategy
+      type: string
+    name: v1alpha1
+    schema:
+      description: ReleaseLink is the Schema for the releaselinks API.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ReleaseLinkSpec defines the desired state of ReleaseLink.
+          properties:
+            application:
+              description: Application is a reference to the application to be released
+                in the managed workspace
+              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+              type: string
+            displayName:
+              description: DisplayName refers to the name of the ReleaseLink to link
+                a user and managed workspace together
+              type: string
+            releaseStrategy:
+              description: Release Strategy defines which strategy will be used to
+                release the application in the managed workspace. This field has no
+                effect for ReleaseLink resources in unmanaged workspaces
+              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+              type: string
+            target:
+              description: Target is a reference to the workspace to establish a link
+                with
+              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+              type: string
+          required:
+          - application
+          - displayName
+          - target
+          type: object
+        status:
+          description: ReleaseLinkStatus defines the observed state of ReleaseLink.
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v202206271449.releases.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: Release
+    listKind: ReleaseList
+    plural: releases
+    singular: release
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.applicationSnapshot
+      name: Snapshot
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Succeeded")].status
+      name: Succeeded
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Succeeded")].reason
+      name: Reason
+      type: string
+    - jsonPath: .status.releasePipelineRun
+      name: PipelineRun
+      priority: 1
+      type: string
+    - jsonPath: .status.startTime
+      name: Start Time
+      priority: 1
+      type: date
+    - jsonPath: .status.completionTime
+      name: Completion Time
+      priority: 1
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      description: Release is the Schema for the releases API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ReleaseSpec defines the desired state of Release
+          properties:
+            applicationSnapshot:
+              description: ApplicationSnapshot to be released
+              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+              type: string
+            releaseLink:
+              description: ReleaseLink referencing the workspace where the snapshot
+                will be released
+              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+              type: string
+          required:
+          - applicationSnapshot
+          - releaseLink
+          type: object
+        status:
+          description: ReleaseStatus defines the observed state of Release
+          properties:
+            completionTime:
+              description: CompletionTime is the time the Release PipelineRun completed
+              format: date-time
+              type: string
+            conditions:
+              description: Conditions represent the latest available observations
+                for the release
+              items:
+                description: "Condition contains details for one aspect of the current
+                  state of this API Resource. --- This struct is intended for direct
+                  use as an array at the field path .status.conditions.  For example,
+                  type FooStatus struct{ // Represents the observations of a foo's
+                  current state. // Known .status.conditions.type are: \"Available\",
+                  \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                  // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                  `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                  protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                properties:
+                  lastTransitionTime:
+                    description: lastTransitionTime is the last time the condition
+                      transitioned from one status to another. This should be when
+                      the underlying condition changed.  If that is not known, then
+                      using the time when the API field changed is acceptable.
+                    format: date-time
+                    type: string
+                  message:
+                    description: message is a human readable message indicating details
+                      about the transition. This may be an empty string.
+                    maxLength: 32768
+                    type: string
+                  observedGeneration:
+                    description: observedGeneration represents the .metadata.generation
+                      that the condition was set based upon. For instance, if .metadata.generation
+                      is currently 12, but the .status.conditions[x].observedGeneration
+                      is 9, the condition is out of date with respect to the current
+                      state of the instance.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  reason:
+                    description: reason contains a programmatic identifier indicating
+                      the reason for the condition's last transition. Producers of
+                      specific condition types may define expected values and meanings
+                      for this field, and whether the values are considered a guaranteed
+                      API. The value should be a CamelCase string. This field may
+                      not be empty.
+                    maxLength: 1024
+                    minLength: 1
+                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                    type: string
+                  status:
+                    description: status of the condition, one of True, False, Unknown.
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      --- Many .condition.type values are consistent across resources
+                      like Available, but because arbitrary conditions can be useful
+                      (see .node.status.conditions), the ability to deconflict is
+                      important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                    maxLength: 316
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    type: string
+                required:
+                - lastTransitionTime
+                - message
+                - reason
+                - status
+                - type
+                type: object
+              type: array
+            releasePipelineRun:
+              description: ReleasePipelineRun contains the namespaced name of the
+                release PipelineRun executed as part of this release
+              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+              type: string
+            releaseStrategy:
+              description: ReleaseStrategy contains the namespaced name of the ReleaseStrategy
+                used for this release
+              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+              type: string
+            startTime:
+              description: StartTime is the time when the Release PipelineRun was
+                created and set to run
+              format: date-time
+              type: string
+            targetWorkspace:
+              description: TargetWorkspace is the workspace where this release will
+                be released to
+              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+              type: string
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v202206271449.releasestrategies.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: ReleaseStrategy
+    listKind: ReleaseStrategyList
+    plural: releasestrategies
+    singular: releasestrategy
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      description: ReleaseStrategy is the Schema for the releasestrategies API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ReleaseStrategySpec defines the desired state of ReleaseStrategy
+          properties:
+            bundle:
+              description: Bundle is a reference to the Tekton bundle where to find
+                the pipeline
+              type: string
+            params:
+              description: Params to pass to the pipeline
+              items:
+                description: Params holds the definition of a parameter that should
+                  be passed to the release Pipeline
+                properties:
+                  name:
+                    description: Name is the name of the parameter
+                    type: string
+                  value:
+                    description: Value is the string value of the parameter
+                    type: string
+                  values:
+                    description: Values is a list of values for the parameter
+                    items:
+                      type: string
+                    type: array
+                required:
+                - name
+                type: object
+              type: array
+            persistentVolumeClaim:
+              description: PersistentVolumeClaim is the pvc to use in the Release
+                pipeline workspace
+              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+              type: string
+            pipeline:
+              description: Release Tekton Pipeline to execute
+              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+              type: string
+            policy:
+              description: Policy to validate before releasing an artifact
+              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+              type: string
+            serviceAccount:
+              description: ServiceAccount is the name of the service account to use
+                in the release PipelineRun to gain elevated privileges
+              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+              type: string
+          required:
+          - pipeline
+          - policy
+          type: object
+        status:
+          description: ReleaseStrategyStatus defines the observed state of ReleaseStrategy
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---

--- a/config/kcp/kustomization.yaml
+++ b/config/kcp/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - apiexport_release.yaml
+  - apiresourceschema_release.yaml

--- a/hack/generate-kcp-api.sh
+++ b/hack/generate-kcp-api.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+set -e
+
+if ! which kubectl-kcp; then
+  echo "kubectl-kcp required on path"
+  echo "you can install it with running:"
+  echo "    $ git clone https://github.com/kcp-dev/kcp && cd kcp && make install"
+  exit 1
+fi
+
+THIS_DIR="$(dirname "$(realpath "$0")")"
+CRD_DIR="$( realpath ${THIS_DIR}/../config/crd/bases)"
+KCP_API_DIR="$( realpath ${THIS_DIR}/../config/kcp)"
+
+KCP_API_SCHEMA_FILE_CURRENT="${KCP_API_DIR}/apiresourceschema_release.yaml"
+KCP_API_SCHEMA_FILE_NEW="${KCP_API_DIR}/apiresourceschema_release.yaml_new"
+cat << EOF > ${KCP_API_SCHEMA_FILE_NEW}
+# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
+# Please do not modify!
+
+EOF
+
+# APIResourceSchema is immutable so when we want to update something, we actually have to create new version.
+# Version is defined by this prefix, which is taken from date. This will allow us to do new version each minute, which
+# should be hopefully enough granularity :)
+PREFIX=$( TZ="Etc/UTC" date +%Y%m%d%H%M )
+
+I=0
+for CRD in $( ls ${CRD_DIR} ); do
+  kubectl-kcp crd snapshot -f "${CRD_DIR}/${CRD}" --prefix v${PREFIX} >> ${KCP_API_SCHEMA_FILE_NEW}
+done
+
+# If there are some changes in new generated file, we replace old one. Otherwise just remove new file.
+# The regex is there to ignore name change, because we're updating date there so it is expected to change.
+# Ignored line looks like this:
+# '  name: v202206151654.applications.appstudio.redhat.com'
+if ! diff -I '^  name: v[0-9]\{12\}\..*\.appstudio\.redhat\.com$' ${KCP_API_SCHEMA_FILE_CURRENT} ${KCP_API_SCHEMA_FILE_NEW} > /dev/null; then
+  mv ${KCP_API_SCHEMA_FILE_NEW} ${KCP_API_SCHEMA_FILE_CURRENT}
+  echo "updated KCP APIResourceSchema for release saved at '${KCP_API_SCHEMA_FILE_CURRENT}'"
+else
+  echo "no changes in KCP API"
+  rm ${KCP_API_SCHEMA_FILE_NEW}
+fi
+
+
+# now create APIExport and link all created APIResourceSchemas there
+KCP_API_EXPORT_FILE="${KCP_API_DIR}/apiexport_release.yaml"
+cat << EOF > ${KCP_API_EXPORT_FILE}
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIExport
+metadata:
+  name: release
+spec:
+  latestResourceSchemas:
+EOF
+
+# match APIResourceSchema name pattern with date prefix
+for SCHEMA in $( cat ${KCP_API_SCHEMA_FILE_CURRENT} | grep -o "v[0-9]\{12\}\..*\.appstudio\.redhat\.com" ); do
+  echo "    - ${SCHEMA}" >> ${KCP_API_EXPORT_FILE}
+done
+
+cat << EOF > ${KCP_API_EXPORT_FILE}
+# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
+# Please do not modify!
+
+$( cat ${KCP_API_EXPORT_FILE} )
+EOF


### PR DESCRIPTION
This commit adds the APIResourceSchema for the release service. This
is needed for KCP integration. The generate-kcp-api.sh script is copied
from the has and spi repos.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>