### PR TITLE
feat(HACBS-776): submit coverage reports to codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,21 @@
+name: Code Coverage Report
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Run tests
+        run: make test
+      - name: Codecov
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,6 +86,8 @@ jobs:
           fi
       - name: Run Go Tests
         run: make test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
       - name: Ensure make build succeeds
         run: make build
       - name: Ensure make bundle succeeds

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "api/v1alpha1/zz_generated.deepcopy.go" # generated file


### PR DESCRIPTION
This change configures the CI to push coverage reports to Codecov whenever a PR to main is created or there is a push to the main branch.

A codecov.yml file has been added to ignore those files that should not be part of the report.

Signed-off-by: David Moreno García <damoreno@redhat.com>