### PR TITLE
fix(HACBS-791): fix isDone function

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -119,9 +119,14 @@ func (r *Release) HasSucceeded() bool {
 	return !meta.IsStatusConditionTrue(r.Status.Conditions, releaseConditionType)
 }
 
-// IsDone returns true if the Release's status indicates that it is done.
+// IsDone returns a boolean indicating whether the Release's status indicates that it is done or not.
 func (r *Release) IsDone() bool {
-	return !meta.IsStatusConditionPresentAndEqual(r.Status.Conditions, releaseConditionType, metav1.ConditionUnknown)
+	condition := meta.FindStatusCondition(r.Status.Conditions, releaseConditionType)
+	if condition != nil {
+		return condition.Status != metav1.ConditionUnknown
+	}
+
+	return false
 }
 
 // MarkFailed registers the completion time and changes the Succeeded condition to False with


### PR DESCRIPTION
Whenever markInvalid is called, the output of isDone is checked to know if we have to send a metric or not. The isDone function was properly checking the value of the condition but was not taking into account the case in which the condition didn't exist.

Signed-off-by: David Moreno García <damoreno@redhat.com>