### PR TITLE
feat(HACBS-782): register more labels

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -139,7 +139,8 @@ func (r *Release) MarkFailed(reason ReleaseReason, message string) {
 	r.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 	r.setStatusConditionWithMessage(metav1.ConditionFalse, reason, message)
 
-	go metrics.RegisterCompletedRelease(reason.String(), r.Status.StartTime, r.Status.CompletionTime, false)
+	go metrics.RegisterCompletedRelease(reason.String(), r.Status.ReleaseStrategy, r.Status.TargetWorkspace,
+		r.Status.StartTime, r.Status.CompletionTime, false)
 }
 
 // MarkInvalid changes the Succeeded condition to False with the provided reason and message.
@@ -162,7 +163,7 @@ func (r *Release) MarkRunning() {
 	r.Status.StartTime = &metav1.Time{Time: time.Now()}
 	r.setStatusCondition(metav1.ConditionUnknown, ReleaseReasonRunning)
 
-	go metrics.RegisterNewRelease(r.Status.TargetWorkspace, r.GetCreationTimestamp(), r.Status.StartTime)
+	go metrics.RegisterNewRelease(r.GetCreationTimestamp(), r.Status.StartTime)
 }
 
 // MarkSucceeded registers the completion time and changes the Succeeded condition to True.
@@ -174,7 +175,8 @@ func (r *Release) MarkSucceeded() {
 	r.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 	r.setStatusCondition(metav1.ConditionTrue, ReleaseReasonSucceeded)
 
-	go metrics.RegisterCompletedRelease(ReleaseReasonSucceeded.String(), r.Status.StartTime, r.Status.CompletionTime, false)
+	go metrics.RegisterCompletedRelease(ReleaseReasonSucceeded.String(), r.Status.ReleaseStrategy, r.Status.TargetWorkspace,
+		r.Status.StartTime, r.Status.CompletionTime, false)
 }
 
 // SetCondition creates a new condition with the given status and reason. Then, it sets this new condition,

--- a/metrics/release.go
+++ b/metrics/release.go
@@ -21,7 +21,7 @@ var (
 			Help:    "Release durations from the moment the release PipelineRun was created til the release is marked as finished",
 			Buckets: []float64{60, 150, 300, 450, 600, 750, 900, 1050, 1200, 1800, 3600},
 		},
-		[]string{"reason", "succeeded"},
+		[]string{"reason", "strategy", "succeeded", "target_workspace"},
 	)
 
 	ReleaseAttemptInvalidTotal = prometheus.NewCounterVec(
@@ -45,34 +45,43 @@ var (
 			Name: "release_attempt_total",
 			Help: "Total number of releases processed by the operator",
 		},
-		[]string{"target_workspace"},
+		[]string{"reason", "strategy", "succeeded", "target_workspace"},
 	)
 )
 
-// RegisterCompletedRelease decrements the 'release_attempt_concurrent_total' metric and registers a new observation for
-// 'release_attempt_duration_seconds' with the elapsed time from the moment the Release attempt started (Release marked
-// as 'Running').
-func RegisterCompletedRelease(reason string, startTime, completionTime *metav1.Time, succeeded bool) {
+// RegisterCompletedRelease decrements the 'release_attempt_concurrent_total' metric, increments `release_attempt_total`
+// and registers a new observation for 'release_attempt_duration_seconds' with the elapsed time from the moment the
+// Release attempt started (Release marked as 'Running').
+func RegisterCompletedRelease(reason, strategy, targetWorkspace string, startTime, completionTime *metav1.Time, succeeded bool) {
+	labels := prometheus.Labels{
+		"reason":           reason,
+		"strategy":         strategy,
+		"succeeded":        strconv.FormatBool(succeeded),
+		"target_workspace": targetWorkspace,
+	}
+
 	ReleaseAttemptConcurrentTotal.Dec()
-	ReleaseAttemptDurationSeconds.With(
-		prometheus.Labels{"reason": reason, "succeeded": strconv.FormatBool(succeeded)},
-	).Observe(completionTime.Sub(startTime.Time).Seconds())
+	ReleaseAttemptDurationSeconds.With(labels).Observe(completionTime.Sub(startTime.Time).Seconds())
+	ReleaseAttemptTotal.With(labels).Inc()
 }
 
-// RegisterInvalidRelease increments the 'release_attempt_invalid_total' metrics.
+// RegisterInvalidRelease increments the 'release_attempt_invalid_total' and `release_attempt_total` metrics.
 func RegisterInvalidRelease(reason string) {
 	ReleaseAttemptInvalidTotal.With(prometheus.Labels{"reason": reason}).Inc()
+	ReleaseAttemptTotal.With(prometheus.Labels{
+		"reason":           reason,
+		"strategy":         "",
+		"succeeded":        "false",
+		"target_workspace": "",
+	}).Inc()
 }
 
-// RegisterNewRelease increments the 'release_attempt_concurrent_total' and `release_attempt_total` metrics, and
-// registers a new observation for 'release_attempt_duration_seconds' with the elapsed time from the moment the Release
-// was created to when it started (Release marked as 'Running').
-func RegisterNewRelease(targetWorkspace string, creationTime metav1.Time, startTime *metav1.Time) {
+// RegisterNewRelease increments the 'release_attempt_concurrent_total' and registers a new observation for
+// 'release_attempt_duration_seconds' with the elapsed time from the moment the Release was created to when
+// it started (Release marked as 'Running').
+func RegisterNewRelease(creationTime metav1.Time, startTime *metav1.Time) {
 	ReleaseAttemptConcurrentTotal.Inc()
 	ReleaseAttemptRunningSeconds.Observe(startTime.Sub(creationTime.Time).Seconds())
-	ReleaseAttemptTotal.With(prometheus.Labels{
-		"target_workspace": targetWorkspace,
-	}).Inc()
 }
 
 func init() {


### PR DESCRIPTION
This commit changes the release_attempt_duration_seconds and release_attempt_total metrics to add labels registering the reason, strategy, target workspace and whether the release succeeded or not.

In addition, the release_attempt_total is now registered once the release is completed and not when it's first seen.

Signed-off-by: David Moreno García <damoreno@redhat.com>