### PR TITLE
fix(HACBS-858): fix HasSucceeded to return a valid value

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -116,7 +116,7 @@ func (r *Release) HasStarted() bool {
 
 // HasSucceeded checks whether the Release has succeeded or not.
 func (r *Release) HasSucceeded() bool {
-	return !meta.IsStatusConditionTrue(r.Status.Conditions, releaseConditionType)
+	return meta.IsStatusConditionTrue(r.Status.Conditions, releaseConditionType)
 }
 
 // IsDone returns a boolean indicating whether the Release's status indicates that it is done or not.


### PR DESCRIPTION
HasSucceeded function was returned the opposite value of what it should return.

Thanks to @dirgim for noticing and reporting this bug.

Signed-off-by: David Moreno García <damoreno@redhat.com>