### PR TITLE
fix(HACBS-987): fix finalization when no PR is present

### DIFF
--- a/controllers/release/release_adapter.go
+++ b/controllers/release/release_adapter.go
@@ -186,7 +186,7 @@ func (a *Adapter) finalizeRelease() error {
 
 	if pipelineRun != nil {
 		err = a.client.Delete(a.context, pipelineRun)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/controllers/release/release_adapter_test.go
+++ b/controllers/release/release_adapter_test.go
@@ -236,6 +236,21 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		}, time.Second*10).Should(BeTrue())
 	})
 
+	It("can finalize a Release", func() {
+		// Release should be properly finalized if there is no ReleasePipelineRun
+		Expect(adapter.finalizeRelease()).To(Succeed())
+
+		// It should finalize properly as well when there's a ReleasePipelineRun
+		result, err := adapter.EnsureReleasePipelineRunExists()
+		Expect(result.CancelRequest).To(BeFalse())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(adapter.finalizeRelease()).To(Succeed())
+		Eventually(func() bool {
+			pipelineRun, _ := adapter.getReleasePipelineRun()
+			return pipelineRun == nil
+		}, time.Second*10).Should(BeTrue())
+	})
+
 	It("can create a ReleasePipelineRun", func() {
 		applicationSnapshot.TypeMeta.Kind = "applicationSnapshot"
 		Expect(k8sClient.Update(ctx, applicationSnapshot)).Should(Succeed())


### PR DESCRIPTION
There was an edge case in which the finalization could fail when the PipelineRun was not present.

Signed-off-by: David Moreno García <damoreno@redhat.com>