### PR TITLE
fix: add timeout to every Eventually block

### DIFF
--- a/controllers/release/release_adapter_test.go
+++ b/controllers/release/release_adapter_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 				Namespace: testNamespace,
 			}, release)
 			return err
-		}).ShouldNot(HaveOccurred())
+		}, time.Second*10).ShouldNot(HaveOccurred())
 
 		adapter = NewAdapter(release, ctrl.Log, k8sClient, ctx)
 		Expect(reflect.TypeOf(adapter)).To(Equal(reflect.TypeOf(&Adapter{})))
@@ -350,7 +350,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 				Namespace: testNamespace,
 			}, release)
 			return err == nil && release.Status.ReleasePipelineRun == "foo/test"
-		}).Should(BeTrue())
+		}, time.Second*10).Should(BeTrue())
 	})
 
 	It("can get an existing ApplicationSnapshot", func() {


### PR DESCRIPTION
The default timeout (1s) is not enough and was causing problems.

Signed-off-by: David Moreno García <damoreno@redhat.com>