### PR TITLE
fix: remove redundant parenthesis

### DIFF
--- a/controllers/release/release_adapter_test.go
+++ b/controllers/release/release_adapter_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	It("ensures a PipelineRun object exists", func() {
 		Eventually(func() bool {
 			result, err := adapter.EnsureReleasePipelineRunExists()
-			return (!result.CancelRequest && err == nil)
+			return !result.CancelRequest && err == nil
 		}, time.Second*10).Should(BeTrue())
 
 		pipelineRun, err := adapter.getReleasePipelineRun()


### PR DESCRIPTION
Just a minor change to remove redundant parenthesis.

Signed-off-by: David Moreno García <damoreno@redhat.com>