### PR TITLE
fix: checkout kcp branch in ci

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           git clone https://github.com/kcp-dev/kcp ~/kcp
           cd ~/kcp
+          git checkout v0.7.1
           WHAT=./cmd/kubectl-kcp make install
       - name: Cache go modules
         id: cache-mod


### PR DESCRIPTION
Checkout the v0.7.1 branch, which is currently kcp-stable, in
our github action workflow before running the make targets.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>