### PR TITLE
refactor: rewrite kcp script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ help: ## Display this help.
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 ifeq ($(CONTROL_PLANE), kcp)
-	hack/generate-kcp-api.sh ## Generate KCP APIResourceSchema from CRDs
+	hack/generate-kcp-api.sh ## Generate KCP APIExport and APIResourceSchemas from CRDs
 endif
 
 .PHONY: generate

--- a/config/kcp/apiexport_release.yaml
+++ b/config/kcp/apiexport_release.yaml
@@ -1,13 +1,10 @@
-# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
-# Please do not modify!
-
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
   name: release
 spec:
   latestResourceSchemas:
-    - v202208301555.releaseplanadmissions.appstudio.redhat.com
-    - v202208301555.releaseplans.appstudio.redhat.com
-    - v202208301555.releases.appstudio.redhat.com
-    - v202208301555.releasestrategies.appstudio.redhat.com
+    - md5-06f1498b5778196e58c2bc1fc88108b8.releaseplanadmissions.appstudio.redhat.com
+    - md5-9959e22acaaf6d162a03980c75b93dfe.releaseplans.appstudio.redhat.com
+    - md5-e3f55fb6efb4bca5c1b68c9813fe9a90.releases.appstudio.redhat.com
+    - md5-a1a202cb4819f0c40034030c40f8526f.releasestrategies.appstudio.redhat.com

--- a/config/kcp/apiresourceschema_release.yaml
+++ b/config/kcp/apiresourceschema_release.yaml
@@ -1,11 +1,8 @@
-# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
-# Please do not modify!
-
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202208301555.releaseplanadmissions.appstudio.redhat.com
+  name: md5-06f1498b5778196e58c2bc1fc88108b8.releaseplanadmissions.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -109,7 +106,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202208301555.releaseplans.appstudio.redhat.com
+  name: md5-9959e22acaaf6d162a03980c75b93dfe.releaseplans.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -194,7 +191,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202208301555.releases.appstudio.redhat.com
+  name: md5-e3f55fb6efb4bca5c1b68c9813fe9a90.releases.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -384,7 +381,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202208301555.releasestrategies.appstudio.redhat.com
+  name: md5-a1a202cb4819f0c40034030c40f8526f.releasestrategies.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:

--- a/config/kcp/kustomization.yaml
+++ b/config/kcp/kustomization.yaml
@@ -1,3 +1,3 @@
 resources:
-  - apiexport_release.yaml
-  - apiresourceschema_release.yaml
+  - api_export.yaml
+  - api_resource_schemas.yaml

--- a/hack/generate-kcp-api.sh
+++ b/hack/generate-kcp-api.sh
@@ -1,52 +1,10 @@
-#!/bin/sh
-
+#!/usr/bin/env bash
 set -e
 
-if ! which kubectl-kcp; then
-  echo "kubectl-kcp required on path"
-  echo "you can install it with running:"
-  echo "    $ git clone https://github.com/kcp-dev/kcp && cd kcp && make install"
-  exit 1
-fi
-
-THIS_DIR="$(dirname "$(realpath "$0")")"
-CRD_DIR="$( realpath ${THIS_DIR}/../config/crd/bases)"
-KCP_API_DIR="$( realpath ${THIS_DIR}/../config/kcp)"
-
-KCP_API_SCHEMA_FILE_CURRENT="${KCP_API_DIR}/apiresourceschema_release.yaml"
-KCP_API_SCHEMA_FILE_NEW="${KCP_API_DIR}/apiresourceschema_release.yaml_new"
-cat << EOF > ${KCP_API_SCHEMA_FILE_NEW}
-# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
-# Please do not modify!
-
-EOF
-
-# APIResourceSchema is immutable so when we want to update something, we actually have to create new version.
-# Version is defined by this prefix, which is taken from date. This will allow us to do new version each minute, which
-# should be hopefully enough granularity :)
-PREFIX=$( TZ="Etc/UTC" date +%Y%m%d%H%M )
-
-I=0
-for CRD in $( ls ${CRD_DIR} | sort -V ); do
-  kubectl-kcp crd snapshot -f "${CRD_DIR}/${CRD}" --prefix v${PREFIX} >> ${KCP_API_SCHEMA_FILE_NEW}
-done
-
-# If there are some changes in new generated file, we replace old one. Otherwise just remove new file.
-# The regex is there to ignore name change, because we're updating date there so it is expected to change.
-# Ignored line looks like this:
-# '  name: v202206151654.applications.appstudio.redhat.com'
-if ! diff -I '^  name: v[0-9]\{12\}\..*\.appstudio\.redhat\.com$' ${KCP_API_SCHEMA_FILE_CURRENT} ${KCP_API_SCHEMA_FILE_NEW} > /dev/null; then
-  mv ${KCP_API_SCHEMA_FILE_NEW} ${KCP_API_SCHEMA_FILE_CURRENT}
-  echo "updated KCP APIResourceSchema for release saved at '${KCP_API_SCHEMA_FILE_CURRENT}'"
-else
-  echo "no changes in KCP API"
-  rm ${KCP_API_SCHEMA_FILE_NEW}
-fi
-
-
-# now create APIExport and link all created APIResourceSchemas there
-KCP_API_EXPORT_FILE="${KCP_API_DIR}/apiexport_release.yaml"
-cat << EOF > ${KCP_API_EXPORT_FILE}
+ROOT=$(dirname "$(dirname "$(readlink -fm "$0")")")
+CRD_DIRECTORY=$(realpath "$ROOT"/config/crd/bases)
+KCP_API_EXPORT_FILE=$(realpath "$ROOT"/config/kcp/apiexport_release.yaml)
+KCP_API_EXPORT_HEADER="$(cat << EOF
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
@@ -54,15 +12,41 @@ metadata:
 spec:
   latestResourceSchemas:
 EOF
+)"
+KCP_API_SCHEMA_FILE=$(realpath "$ROOT"/config/kcp/apiresourceschema_release.yaml)
+REQUIREMENTS="kubectl-kcp md5sum"
+SCHEMA_REGEX="md5-[a-f0-9]{32}.*\.appstudio\.redhat\.com"
 
-# match APIResourceSchema name pattern with date prefix
-for SCHEMA in $( cat ${KCP_API_SCHEMA_FILE_CURRENT} | grep -o "v[0-9]\{12\}\..*\.appstudio\.redhat\.com" ); do
-  echo "    - ${SCHEMA}" >> ${KCP_API_EXPORT_FILE}
-done
+generate_api_export() {
+    echo "$KCP_API_EXPORT_HEADER" > "$KCP_API_EXPORT_FILE"
 
-cat << EOF > ${KCP_API_EXPORT_FILE}
-# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
-# Please do not modify!
+    grep -Eo "$SCHEMA_REGEX" < "$KCP_API_SCHEMA_FILE" | while IFS= read -r schema; do
+        echo "    - ${schema}" >> "$KCP_API_EXPORT_FILE"
+    done
+}
 
-$( cat ${KCP_API_EXPORT_FILE} )
-EOF
+generate_schemas() {
+    rm -rf "$KCP_API_SCHEMA_FILE"
+
+    for crd in $(find "$CRD_DIRECTORY" -name '*.yaml' | sort -V); do
+        prefix="md5-$(md5sum "$crd" | awk '{print $1}')"
+        kubectl-kcp crd snapshot -f "$crd" --prefix "$prefix" >> "$KCP_API_SCHEMA_FILE"
+    done
+}
+
+check_requirements() {
+    for tool in $REQUIREMENTS; do
+        if ! [ -x "$(command -v "$tool")" ]; then
+            echo "Error: $tool is not installed" >&2
+            if [ "$tool" == "kubectl-kcp" ]; then
+                echo "The tool can be installed by running the following command:"
+                echo "    $ git clone https://github.com/kcp-dev/kcp && cd kcp && make install"
+            fi
+            exit 1
+        fi
+    done
+}
+
+check_requirements
+generate_schemas
+generate_api_export


### PR DESCRIPTION
The script was buggy and was causing problems to our CI. In addition, it was difficult to read and was using timestamps for the name prefixes instead of something better like md5 hashes.

This commit rewrites the script and updates some file names.

Signed-off-by: David Moreno García <damoreno@redhat.com>