### PR TITLE
fix(HACBS-1027): use a Red Hat provided image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17 as builder
 
-WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -22,11 +21,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 ARG ENABLE_WEBHOOKS=true
 ENV ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS}
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /workspace/manager .
+# Use ubi-minimal as minimal base image to package the manager binary
+# Refer to https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8 for more details
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+COPY --from=builder /opt/app-root/src/manager /
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
The current image was causing problems while building the operator as buildah doesn't use Docker Hub by default.

Signed-off-by: David Moreno García <damoreno@redhat.com>