### PR TITLE
feat(HACBS-980): refactor Release status errors

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -51,6 +51,12 @@ const (
 	// ReleaseReasonPipelineFailed is the reason set when the release PipelineRun failed
 	ReleaseReasonPipelineFailed ReleaseReason = "ReleasePipelineFailed"
 
+	// ReleaseReasonTargetDisabledError is the reason set when there is a validation error with the ReleasePlan
+	ReleaseReasonReleasePlanValidationError ReleaseReason = "ReleasePlanValidationError"
+
+	// ReleaseReasonTargetDisabledError is the reason set when releases to the target are disabled
+	ReleaseReasonTargetDisabledError ReleaseReason = "ReleaseTargetDisabledError"
+
 	// ReleaseReasonRunning is the reason set when the release PipelineRun starts running
 	ReleaseReasonRunning ReleaseReason = "Running"
 

--- a/controllers/release/release_controller.go
+++ b/controllers/release/release_controller.go
@@ -18,6 +18,7 @@ package release
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	"github.com/kcp-dev/logicalcluster/v2"
 	libhandler "github.com/operator-framework/operator-lib/handler"
@@ -85,6 +86,7 @@ type AdapterInterface interface {
 	EnsureFinalizerIsAdded() (results.OperationResult, error)
 	EnsureReleasePipelineRunExists() (results.OperationResult, error)
 	EnsureReleasePipelineStatusIsTracked() (results.OperationResult, error)
+	EnsureReleasePlanAdmissionEnabled() (results.OperationResult, error)
 	EnsureSnapshotEnvironmentBindingIsCreated() (results.OperationResult, error)
 	EnsureTargetContextIsSet() (results.OperationResult, error)
 }
@@ -97,6 +99,7 @@ type ReconcileOperation func() (results.OperationResult, error)
 func (r *Reconciler) ReconcileHandler(adapter AdapterInterface) (ctrl.Result, error) {
 	operations := []ReconcileOperation{
 		adapter.EnsureTargetContextIsSet,
+		adapter.EnsureReleasePlanAdmissionEnabled,
 		adapter.EnsureFinalizersAreCalled,
 		adapter.EnsureFinalizerIsAdded,
 		adapter.EnsureReleasePipelineRunExists,


### PR DESCRIPTION
This commit adds a new type of Release status error called a
TargetDisabledError. This error is used to let the user know that the
connection with the target is unsuccessful. It does not make sense to
call this a ReleaseValidationError as is currently the case, since
there is nothing invalid about the Release itself.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>