### PR TITLE
feat(HACBS-970): add label appstudio.openshift.io/application: <application-name>

### DIFF
--- a/controllers/release/release_adapter.go
+++ b/controllers/release/release_adapter.go
@@ -251,7 +251,7 @@ func (a *Adapter) createOrUpdateSnapshotEnvironmentBinding(releasePlanAdmission 
 func (a *Adapter) createReleasePipelineRun(releaseStrategy *v1alpha1.ReleaseStrategy, applicationSnapshot *appstudioshared.ApplicationSnapshot) (*v1beta1.PipelineRun, error) {
 	pipelineRun := tekton.NewReleasePipelineRun("release-pipelinerun", releaseStrategy.Namespace).
 		WithOwner(a.release).
-		WithReleaseLabels(a.release.Name, a.release.Namespace, a.release.GetAnnotations()[logicalcluster.AnnotationKey]).
+		WithReleaseAndApplicationLabels(a.release.Name, a.release.Namespace, a.release.GetAnnotations()[logicalcluster.AnnotationKey], applicationSnapshot.Spec.Application).
 		WithReleaseStrategy(releaseStrategy).
 		WithApplicationSnapshot(applicationSnapshot).
 		AsPipelineRun()

--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -35,6 +35,9 @@ import (
 type PipelineType string
 
 const (
+	// appstudioLabelPrefix is the prefix of the application label
+	appstudioLabelPrefix = "appstudio.openshift.io"
+
 	// pipelinesLabelPrefix is the prefix of the pipelines label
 	pipelinesLabelPrefix = "pipelines.appstudio.openshift.io"
 
@@ -46,6 +49,9 @@ const (
 )
 
 var (
+	// ApplicationNameLabel is the label used to specify the application associated with the PipelineRun
+	ApplicationNameLabel = fmt.Sprintf("%s/%s", appstudioLabelPrefix, "application")
+
 	// PipelinesTypeLabel is the label used to describe the type of pipeline
 	PipelinesTypeLabel = fmt.Sprintf("%s/%s", pipelinesLabelPrefix, "type")
 
@@ -122,13 +128,14 @@ func (r *ReleasePipelineRun) WithOwner(release *v1alpha1.Release) *ReleasePipeli
 }
 
 // WithReleaseLabels adds Release name, namespace, and workspace as labels to the release PipelineRun.
-func (r *ReleasePipelineRun) WithReleaseLabels(releaseName, releaseNamespace, releaseWorkspace string) *ReleasePipelineRun {
+func (r *ReleasePipelineRun) WithReleaseAndApplicationLabels(releaseName, releaseNamespace, releaseWorkspace string, applicationName string) *ReleasePipelineRun {
 	r.ObjectMeta.Labels = map[string]string{
 		PipelinesTypeLabel:    PipelineTypeRelease,
 		ReleaseNameLabel:      releaseName,
 		ReleaseNamespaceLabel: releaseNamespace,
 		// PipelineRun does not allow labels with : in the value, which KCP workspaces have
 		ReleaseWorkspaceLabel: strings.ReplaceAll(releaseWorkspace, ":", "__"),
+		ApplicationNameLabel:  applicationName,
 	}
 
 	return r

--- a/tekton/pipeline_run_test.go
+++ b/tekton/pipeline_run_test.go
@@ -51,6 +51,7 @@ var _ = Describe("PipelineRun", func() {
 		persistentVolumeClaim = "test-pvc"
 		serviceAccountName    = "test-service-account"
 		apiVersion            = "appstudio.redhat.com/v1alpha1"
+		applicationName       = "test-application"
 	)
 	var (
 		release                            *v1alpha1.Release
@@ -96,7 +97,7 @@ var _ = Describe("PipelineRun", func() {
 				Kind:       "ApplicationSnapshot",
 			},
 			Spec: appstudioshared.ApplicationSnapshotSpec{
-				Application: "testapplication",
+				Application: applicationName,
 				DisplayName: "Test application",
 				Components:  []appstudioshared.ApplicationSnapshotComponent{},
 			},
@@ -158,13 +159,19 @@ var _ = Describe("PipelineRun", func() {
 		})
 
 		It("can append the release Name, Namespace, and Workspace to a ReleasePipelineRun object and that these label key names match the correct label format", func() {
-			releasePipelineRun.WithReleaseLabels(release.Name, release.Namespace, release.GetAnnotations()[logicalcluster.AnnotationKey])
+			releasePipelineRun.WithReleaseAndApplicationLabels(
+				release.Name,
+				release.Namespace,
+				release.GetAnnotations()[logicalcluster.AnnotationKey],
+				applicationName)
 			Expect(releasePipelineRun.Labels["release.appstudio.openshift.io/name"]).
 				To(Equal(release.Name))
 			Expect(releasePipelineRun.Labels["release.appstudio.openshift.io/namespace"]).
 				To(Equal(release.Namespace))
 			Expect(releasePipelineRun.Labels["release.appstudio.openshift.io/workspace"]).
 				To(Equal("kcp__test-cluster__dev"))
+			Expect(releasePipelineRun.Labels["appstudio.openshift.io/application"]).
+				To(Equal(applicationName))
 		})
 
 		It("can return a PipelineRun object from a ReleasePipelineRun object", func() {
@@ -186,7 +193,7 @@ var _ = Describe("PipelineRun", func() {
 				&unmarshaledApplicationSnapshotSpec)).Should(Succeed())
 
 			// check if the unmarshaled data has what we expect
-			Expect(unmarshaledApplicationSnapshotSpec.Application).To(Equal("testapplication"))
+			Expect(unmarshaledApplicationSnapshotSpec.Application).To(Equal(applicationName))
 		})
 
 		It("can add the ReleaseStrategy information to a PipelineRun object and ", func() {

--- a/tekton/predicates_test.go
+++ b/tekton/predicates_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Predicates", func() {
 
 	const (
 		pipelineRunPrefixName = "test-pipeline"
+		applicationName       = "test-application"
 		apiVersion            = "appstudio.redhat.com/v1alpha1"
 		namespace             = "default"
 	)
@@ -115,7 +116,8 @@ var _ = Describe("Predicates", func() {
 			contextEvent := event.UpdateEvent{
 				ObjectOld: releasePipelineRun.AsPipelineRun(),
 				ObjectNew: releasePipelineRun.WithServiceAccount("test-service-account").
-					WithReleaseLabels(release.Name, release.Namespace, release.GetAnnotations()[logicalcluster.AnnotationKey]).AsPipelineRun(),
+					WithReleaseAndApplicationLabels(release.Name, release.Namespace, release.GetAnnotations()[logicalcluster.AnnotationKey], applicationName).
+					AsPipelineRun(),
 			}
 			releasePipelineRun.Status.MarkRunning("Predicate function tests", "Set it to Unknown")
 			Expect(instance.Update(contextEvent)).To(BeFalse())

--- a/tekton/utils_test.go
+++ b/tekton/utils_test.go
@@ -33,6 +33,7 @@ var _ = Describe("Utils", func() {
 
 	const (
 		pipelineRunPrefixName = "test-pipeline"
+		applicationName       = "test-application"
 		apiVersion            = "appstudio.redhat.com/v1alpha1"
 		namespace             = "default"
 	)
@@ -88,7 +89,7 @@ var _ = Describe("Utils", func() {
 	Context("when using utility functions on PipelineRun objects", func() {
 		It("is a PipelineRun object and contains the required labels that identifies it as one", func() {
 			Expect(isReleasePipelineRun(releasePipelineRun.
-				WithReleaseLabels(release.Name, release.Namespace, release.GetAnnotations()[logicalcluster.AnnotationKey]).
+				WithReleaseAndApplicationLabels(release.Name, release.Namespace, release.GetAnnotations()[logicalcluster.AnnotationKey], applicationName).
 				AsPipelineRun())).To(Equal(true))
 		})
 


### PR DESCRIPTION
- adds the new label `appstudio.openshift.io/application: <application-name>`

Signed-off-by: Leandro Mendes <lmendes@redhat.com>