### PR TITLE
feat: add KCP sample yamls

### DIFF
--- a/config/samples/kcp/dev_workspace/apiexport.yaml
+++ b/config/samples/kcp/dev_workspace/apiexport.yaml
@@ -1,0 +1,12 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIExport
+metadata:
+  name: release
+spec:
+  latestResourceSchemas:
+    - rev-1492075.releaseplanadmissions.appstudio.redhat.com
+    - rev-1492080.applicationsnapshots.appstudio.redhat.com
+    - rev-1492087.pipelineruns.tekton.dev
+    - rev-1492107.releases.appstudio.redhat.com
+    - rev-1492112.releaseplans.appstudio.redhat.com
+    - rev-1492119.releasestrategies.appstudio.redhat.com

--- a/config/samples/kcp/dev_workspace/appstudio_v1alpha1_applicationsnapshot.yaml
+++ b/config/samples/kcp/dev_workspace/appstudio_v1alpha1_applicationsnapshot.yaml
@@ -1,0 +1,14 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ApplicationSnapshot
+metadata:
+  name: snapshot
+  namespace: default
+spec:
+  application: app
+  images:
+    - component: component1
+      pullSpec: pullspec1
+    - component: component2
+      pullSpec: pullspec2
+    - component: component3
+      pullSpec: pullspec3

--- a/config/samples/kcp/dev_workspace/appstudio_v1alpha1_release.yaml
+++ b/config/samples/kcp/dev_workspace/appstudio_v1alpha1_release.yaml
@@ -1,0 +1,8 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: release
+  namespace: default
+spec:
+  releasePlan: default
+  applicationSnapshot: snapshot

--- a/config/samples/kcp/dev_workspace/appstudio_v1alpha1_releaseplan.yaml
+++ b/config/samples/kcp/dev_workspace/appstudio_v1alpha1_releaseplan.yaml
@@ -1,0 +1,11 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  name: default
+  namespace: default
+spec:
+  displayName: Users's ReleasePlan
+  application: app
+  target:
+    namespace: managed
+    workspace: root:users:someuser:managed

--- a/config/samples/kcp/dev_workspace/namespace.yaml
+++ b/config/samples/kcp/dev_workspace/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default

--- a/config/samples/kcp/managed_workspace/apibinding.yaml
+++ b/config/samples/kcp/managed_workspace/apibinding.yaml
@@ -1,0 +1,9 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIBinding
+metadata:
+  name: managed
+spec:
+  reference:
+    workspace:
+      path: root:users:someuser:dev
+      exportName: release

--- a/config/samples/kcp/managed_workspace/appstudio_v1alpha1_releaseplanadmission.yaml
+++ b/config/samples/kcp/managed_workspace/appstudio_v1alpha1_releaseplanadmission.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: managed
+  namespace: managed
+spec:
+  displayName: Managed Workspace's ReleasePlanAdmission
+  application: app
+  origin:
+    namespace: default
+    workspace: root:users:someuser:dev
+  releaseStrategy: strategy

--- a/config/samples/kcp/managed_workspace/appstudio_v1alpha1_releasestrategy.yaml
+++ b/config/samples/kcp/managed_workspace/appstudio_v1alpha1_releasestrategy.yaml
@@ -1,0 +1,11 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseStrategy
+metadata:
+  name: strategy
+  namespace: managed
+spec:
+  pipeline: release-pipeline-example
+  policy: somepolicy
+  params:
+  - name: mapping-file
+    value: https://raw.githubusercontent.com/johnbieren/release-service/test_mapping_file/test_mapping.yaml

--- a/config/samples/kcp/managed_workspace/namespace.yaml
+++ b/config/samples/kcp/managed_workspace/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: managed

--- a/config/samples/kcp/syncer_clusterrole.yaml
+++ b/config/samples/kcp/syncer_clusterrole.yaml
@@ -1,0 +1,54 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kcp-syncer-jbieren-quicklabs-s46oqxua
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - "create"
+  - "list"
+  - "watch"
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "get"
+  - "watch"
+  - "list"
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  verbs:
+  - "*"
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  verbs:
+  - "*"
+## Add the following to allow the synctarget to become ready.
+## This does not seem to have any effect on the CRDs becoming
+## available or permissions accessing them in KCP, however.
+- apiGroups:
+  - "tekton.dev"
+  resources:
+  - pipeineruns
+  verbs:
+  - "*"
+- apiGroups:
+  - "appstudio.redhat.com"
+  resources:
+  - applicationsnapshots
+  - releases
+  - releaseplans
+  - releaseplanadmissions
+  - releasestrategies
+  verbs:
+  - "*"

--- a/config/samples/kcp/syncer_deployment.yaml
+++ b/config/samples/kcp/syncer_deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kcp-syncer-omitted
+  namespace: kcp-syncer-omitted
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: kcp-syncer-omitted
+  template:
+    metadata:
+      labels:
+        app: kcp-syncer-omitted
+    spec:
+      containers:
+      - name: kcp-syncer
+        command:
+        - /ko-app/syncer
+        args:
+        - --from-kubeconfig=/kcp/kubeconfig
+        - --sync-target-name=computercluster
+        - --sync-target-uid=omitted
+        - --from-cluster=root:users:someuser:dev
+        - --resources=configmaps
+        - --resources=deployments.apps
+        - --resources=secrets
+        - --resources=serviceaccounts
+        - --resources=pipelineruns.tekton.dev
+        - --resources=applicationsnapshots.appstudio.redhat.com
+        - --resources=releases.appstudio.redhat.com
+        - --resources=releaseplans.appstudio.redhat.com
+        - --resources=releaseplanadmissions.appstudio.redhat.com
+        - --resources=releasestrategies.appstudio.redhat.com
+        - --qps=30
+        - --burst=20
+        image: ghcr.io/kcp-dev/kcp/syncer:v0.7.10
+        imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: kcp-config
+          mountPath: /kcp/
+          readOnly: true
+      serviceAccountName: omitted
+      volumes:
+        - name: kcp-config
+          secret:
+            secretName: omitted
+            optional: false


### PR DESCRIPTION
This commit adds some resource yaml files to the config/samples/kcp
directory. These are for showing how to have the controller
reconcile a simple release in a KCP environment that includes both
a dev and managed workspace. They do not use permission claims,
but may be updated to at a later date.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>