### PR TITLE
fix: auto guess the fs path for pseudo versioned modules

### DIFF
--- a/controllers/release/release_suite_test.go
+++ b/controllers/release/release_suite_test.go
@@ -18,10 +18,11 @@ package release
 
 import (
 	"context"
-	hasv1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	"go/build"
 	"path/filepath"
 	"testing"
+
+	hasv1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 
 	"k8s.io/client-go/rest"
 
@@ -34,6 +35,7 @@ import (
 
 	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
 	appstudiov1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
+	appstudiotest "github.com/redhat-appstudio/release-service/test"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,13 +75,11 @@ var _ = BeforeSuite(func() {
 			),
 			filepath.Join(
 				build.Default.GOPATH,
-				"pkg", "mod", "github.com", "redhat-appstudio",
-				"application-service@v0.0.0-20220310134421-5864c77a3d17", "config", "crd", "bases",
+				"pkg", "mod", appstudiotest.GetRelativeDependencyPath("application-service"), "config", "crd", "bases",
 			),
 			filepath.Join(
 				build.Default.GOPATH,
-				"pkg", "mod", "github.com", "redhat-appstudio", "managed-gitops",
-				"appstudio-shared@v0.0.0-20220603115212-1fb4d804a8c2", "config", "crd", "bases",
+				"pkg", "mod", appstudiotest.GetRelativeDependencyPath("appstudio-shared"), "config", "crd", "bases",
 			),
 		},
 		ErrorIfCRDPathMissing: true,

--- a/tekton/tekton_suite_test.go
+++ b/tekton/tekton_suite_test.go
@@ -32,6 +32,7 @@ import (
 
 	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
 	appstudiov1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
+	appstudiotest "github.com/redhat-appstudio/release-service/test"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 
@@ -68,8 +69,7 @@ var _ = BeforeSuite(func() {
 			),
 			filepath.Join(
 				build.Default.GOPATH,
-				"pkg", "mod", "github.com", "redhat-appstudio", "managed-gitops",
-				"appstudio-shared@v0.0.0-20220603115212-1fb4d804a8c2", "config", "crd", "bases",
+				"pkg", "mod", appstudiotest.GetRelativeDependencyPath("appstudio-shared"), "config", "crd", "bases",
 			),
 		},
 		ErrorIfCRDPathMissing: true,

--- a/test/paths.go
+++ b/test/paths.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// GetRelativeDependencyPath returns the relative path for a given module or an empty string on error.
+func GetRelativeDependencyPath(moduleName string) string {
+	var crdPath string
+	currentWorkDir, _ := os.Getwd()
+
+	goModFilepath, err := FindGoModFilepath(currentWorkDir)
+	if err != nil {
+		return ""
+	}
+
+	goModReadFile, err := os.Open(filepath.Clean(goModFilepath))
+	if err != nil {
+		return ""
+	}
+	defer func() {
+		err := goModReadFile.Close()
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	scanner := bufio.NewScanner(goModReadFile)
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), moduleName) {
+			crdPath = strings.Trim(string(scanner.Text()), "\t")
+			break
+		}
+	}
+
+	return strings.ReplaceAll(crdPath, " ", "@")
+}
+
+// FindGoModFilepath returns the go.mod file system path for the current project or empty string and an error when file is not found.
+func FindGoModFilepath(currentWorkDir string) (string, error) {
+	for {
+		currentWorkDir = filepath.Dir(currentWorkDir)
+		if currentWorkDir != "/" {
+			goModFilepath := currentWorkDir + "/go.mod"
+			_, err := os.Stat(goModFilepath)
+			if err == nil {
+				return goModFilepath, nil
+			}
+		} else {
+			return "", errors.New("go.mod file not found")
+		}
+	}
+}

--- a/test/paths_test.go
+++ b/test/paths_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtilTest(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Utilities Suite")
+}
+
+var _ = Describe("Test utilities", func() {
+	Context("When GetRelativeDependencyPath is called", func() {
+		It("returns the module path of a given pseudo versioned dependent module", func() {
+			moduleRelativePath := GetRelativeDependencyPath("appstudio-shared")
+			Expect(moduleRelativePath).Should(ContainSubstring("appstudio-shared@v0.0.0"))
+		})
+
+		It("returns an empty string when the given dependent module is not found", func() {
+			moduleRelativePath := GetRelativeDependencyPath("nonexistent")
+			Expect(moduleRelativePath).Should(BeEmpty())
+		})
+	})
+
+	Context("When FindGoModFilepath is called", func() {
+		It("returns the filepath of the go.mod file", func() {
+			currentWorkDir, _ := os.Getwd()
+			goModFilepath, err := FindGoModFilepath(currentWorkDir)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(goModFilepath).Should(ContainSubstring("go.mod"))
+		})
+
+		It("returns an empty string and an error when go.mod is not found", func() {
+			goModFilepath, err := FindGoModFilepath("/var/tmp")
+			Expect(goModFilepath).Should(BeEmpty())
+			Expect(err).Should(And(HaveOccurred()), Equal("go.mod file not found"))
+		})
+
+		It("return an empty string and an error when the given directory does not exist", func() {
+			goModFilepath, err := FindGoModFilepath("/nonexistent/dir")
+			Expect(goModFilepath).Should(BeEmpty())
+			Expect(err).Should(And(HaveOccurred()), Equal("go.mod file not found"))
+		})
+	})
+})


### PR DESCRIPTION
fix: auto guess the fs path for pseudo versioned modules
    
- adds `GetRelativeDependencyPath` function to return the fs path of
  pseudo-versioned modules required by the test suites.
- adds unit tests
    
Signed-off-by: Leandro Mendes <lmendes@redhat.com>