### PR TITLE
feat(HACBS-1083): add KCP Permission Claims

### DIFF
--- a/config/kcp/apiexport_release.yaml
+++ b/config/kcp/apiexport_release.yaml
@@ -3,6 +3,27 @@ kind: APIExport
 metadata:
   name: release
 spec:
+  # The identityHash values should be populated with proper values at
+  # deployment time.
+  permissionClaims:
+  - resource: "applications"
+    group: "appstudio.redhat.com"
+    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+  - resource: "components"
+    group: "appstudio.redhat.com"
+    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+  - resource: "applicationsnapshots"
+    group: "appstudio.redhat.com"
+    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+  - resource: "environments"
+    group: "appstudio.redhat.com"
+    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+  - resource: "applicationsnapshotenvironmentbindings"
+    group: "appstudio.redhat.com"
+    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+  - resource: "pipelineruns"
+    group: "tekton.dev"
+    identityHash: null
   latestResourceSchemas:
     - md5-06f1498b5778196e58c2bc1fc88108b8.releaseplanadmissions.appstudio.redhat.com
     - md5-9959e22acaaf6d162a03980c75b93dfe.releaseplans.appstudio.redhat.com

--- a/config/samples/kcp/managed_workspace/apibinding_permissionclaims.yaml
+++ b/config/samples/kcp/managed_workspace/apibinding_permissionclaims.yaml
@@ -1,0 +1,21 @@
+# The intent of this file is to show what the APIBinding looks like if you run
+# a setup using permission claims instead of all the APIs provided by one APIExport.
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIBinding
+metadata:
+  name: managed
+spec:
+  reference:
+    workspace:
+      path: root:users:someuser:dev
+      exportName: release
+  permissionClaims:
+  - group: "tekton.dev"
+    identityHash: null # Must be set before applying, but value depends on APIExport
+    resource: "pipelineruns"
+    state: "Accepted"
+  - group: "appstudio.redhat.com"
+    identityHash: null # Must be set before applying, but value depends on APIExport
+    resource: "applicationsnapshots"
+    state: "Accepted"
+---

--- a/hack/generate-kcp-api.sh
+++ b/hack/generate-kcp-api.sh
@@ -10,6 +10,27 @@ kind: APIExport
 metadata:
   name: release
 spec:
+  # The identityHash values should be populated with proper values at
+  # deployment time.
+  permissionClaims:
+  - resource: "applications"
+    group: "appstudio.redhat.com"
+    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+  - resource: "components"
+    group: "appstudio.redhat.com"
+    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+  - resource: "applicationsnapshots"
+    group: "appstudio.redhat.com"
+    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+  - resource: "environments"
+    group: "appstudio.redhat.com"
+    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+  - resource: "applicationsnapshotenvironmentbindings"
+    group: "appstudio.redhat.com"
+    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+  - resource: "pipelineruns"
+    group: "tekton.dev"
+    identityHash: null
   latestResourceSchemas:
 EOF
 )"


### PR DESCRIPTION
This commit adds permission claims to the KCP release APIExport for the CRDs we depend on, but do not maintain. These are pipelineruns, applicationsnapshots, environments, applications, components, and
applicationsnapshotenvironmentbindings.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>