### PR TITLE
fix(HACBS-1145): releases not being properly terminated

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -105,7 +105,7 @@ type ReleaseStatus struct {
 
 	// Target references where this relesae is intended to be released to
 	// +optional
-	Target kcp.NamespaceReference `json:"target"`
+	Target kcp.NamespaceReference `json:"target,omitempty"`
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
The function getReleasePipelineRun should return nil,nil when the Release PipelineRun is not found instead of nil, err which causes the operation to be Requeued.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>