### PR TITLE
feat(HACBS-1085): set owner reference to the binding

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,12 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
+  - applications/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
   - releases
   verbs:
   - create

--- a/controllers/release/release_controller.go
+++ b/controllers/release/release_controller.go
@@ -55,6 +55,7 @@ func NewReleaseReconciler(client client.Client, logger *logr.Logger, scheme *run
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releases/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releases/finalizers,verbs=update
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
The binding needs to have an owner reference so it's deleted when the Application is deleted. As we are the ones creating this bindings, there's no need to set the onwer reference when the binding is updated. If the owner reference is not present, it was removed manually and there must be a reason for that.

Tests will be added as part of HACBS-1085.

Signed-off-by: David Moreno García <damoreno@redhat.com>