### PR TITLE
fix: use proper context

### DIFF
--- a/controllers/release/release_adapter.go
+++ b/controllers/release/release_adapter.go
@@ -354,7 +354,7 @@ func (a *Adapter) getActiveReleasePlanAdmission() (*v1alpha1.ReleasePlanAdmissio
 // the Get operation failed, an error will be returned.
 func (a *Adapter) getApplication(releasePlanAdmission *v1alpha1.ReleasePlanAdmission) (*hasv1alpha1.Application, error) {
 	application := &hasv1alpha1.Application{}
-	err := a.client.Get(a.context, types.NamespacedName{
+	err := a.client.Get(a.targetContext, types.NamespacedName{
 		Name:      releasePlanAdmission.Spec.Application,
 		Namespace: releasePlanAdmission.Namespace,
 	}, application)
@@ -374,7 +374,7 @@ func (a *Adapter) getApplicationComponents(application *hasv1alpha1.Application)
 		client.MatchingFields{"spec.application": application.Name},
 	}
 
-	err := a.client.List(a.context, applicationComponents, opts...)
+	err := a.client.List(a.targetContext, applicationComponents, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Two of the context used in functions loading resources from the cluster were using the wrong context. As a matter of fact, this is only true given the way in which load the Application, but the function loading the Application components should be more specific and provide a way to indicate the context as the Application passed as a parameter could come from the dev workspace. This will be addressed once we introduce a `loader.go` file where we will have functions to load resources from specific contexts.

Signed-off-by: David Moreno García <damoreno@redhat.com>