### PR TITLE
feat(HACBS-1097): add check to skip Binding creation

### DIFF
--- a/controllers/release/release_adapter.go
+++ b/controllers/release/release_adapter.go
@@ -195,12 +195,17 @@ func (a *Adapter) EnsureSnapshotEnvironmentBindingIsCreated() (results.Operation
 		return results.ContinueProcessing()
 	}
 
-	err := a.syncResources()
+	releasePlanAdmission, err := a.getActiveReleasePlanAdmission()
 	if err != nil {
 		return results.RequeueWithError(err)
 	}
 
-	releasePlanAdmission, err := a.getActiveReleasePlanAdmission()
+	// If no environment is set in the ReleasePlanAdmission, skip the Binding creation
+	if releasePlanAdmission.Spec.Environment == "" {
+		return results.ContinueProcessing()
+	}
+
+	err = a.syncResources()
 	if err != nil {
 		return results.RequeueWithError(err)
 	}


### PR DESCRIPTION
Whenever the Environment is not set in the ReleasePlanAdmission the controller should not create a Binding. This allows to have strategies without the deployment part. This commit adds a check to skip processing the Binding creation for those scenarios.

Signed-off-by: David Moreno García <damoreno@redhat.com>