### PR TITLE
fix: disables binding of metrics server for syncer and gitops tests

### DIFF
--- a/gitops/gitops_suite_test.go
+++ b/gitops/gitops_suite_test.go
@@ -87,7 +87,9 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).NotTo(BeNil())
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: clientsetscheme.Scheme,
+		Scheme:             clientsetscheme.Scheme,
+		MetricsBindAddress: "0", // this disables metrics
+		LeaderElection:     false,
 	})
 	Expect(err).NotTo(HaveOccurred())
 

--- a/syncer/syncer_suite_test.go
+++ b/syncer/syncer_suite_test.go
@@ -87,7 +87,9 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).NotTo(BeNil())
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: clientsetscheme.Scheme,
+		Scheme:             clientsetscheme.Scheme,
+		MetricsBindAddress: "0", // this disables metrics
+		LeaderElection:     false,
 	})
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
disables port binding of metrics server for syncer and gitops tests

Signed-off-by: Leandro Mendes <lmendes@redhat.com>