### PR TITLE
chore: remove redundant conversion

### DIFF
--- a/test/paths.go
+++ b/test/paths.go
@@ -48,7 +48,7 @@ func GetRelativeDependencyPath(moduleName string) string {
 	scanner := bufio.NewScanner(goModReadFile)
 	for scanner.Scan() {
 		if strings.Contains(scanner.Text(), moduleName) {
-			crdPath = strings.Trim(string(scanner.Text()), "\t")
+			crdPath = strings.Trim(scanner.Text(), "\t")
 			break
 		}
 	}


### PR DESCRIPTION
There was a redundant conversion of string to string.

Signed-off-by: David Moreno García <damoreno@redhat.com>