### PR TITLE
chore: changes outstanding Update() to Patch() in the release_adapter

### DIFF
--- a/controllers/release/release_adapter.go
+++ b/controllers/release/release_adapter.go
@@ -81,8 +81,9 @@ func (a *Adapter) EnsureFinalizersAreCalled() (results.OperationResult, error) {
 			return results.RequeueWithError(err)
 		}
 
+		patch := client.MergeFrom(a.release.DeepCopy())
 		controllerutil.RemoveFinalizer(a.release, finalizerName)
-		err := a.client.Update(a.context, a.release)
+		err := a.client.Patch(a.context, a.release, patch)
 		if err != nil {
 			return results.RequeueWithError(err)
 		}
@@ -103,8 +104,9 @@ func (a *Adapter) EnsureFinalizerIsAdded() (results.OperationResult, error) {
 
 	if !finalizerFound {
 		a.logger.Info("Adding Finalizer to the Release")
+		patch := client.MergeFrom(a.release.DeepCopy())
 		controllerutil.AddFinalizer(a.release, finalizerName)
-		err := a.client.Update(a.context, a.release)
+		err := a.client.Patch(a.context, a.release, patch)
 
 		return results.RequeueOnErrorOrContinue(err)
 	}


### PR DESCRIPTION
Changes `Update()` to `Patch()` in the `release_adapter` as they are still causing errors (update with pending update) in the tests.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>