### PR TITLE
feat(HACBS-1098): modify kcp resources for infra-deployments

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -21,7 +21,8 @@ spec:
       value: Dockerfile
     - name: infra-deployment-update-script
       value: |
-        sed -i -e 's|\(https://github.com/redhat-appstudio/release-service/config/default?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/release/kustomization.yaml
+        sed -i -e 's|\(https://github.com/redhat-appstudio/release-service/config/kcp?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/hacbs/release-service/base/kustomization.yaml
+        ./hack/generate-apiexport-overlays.sh components/hacbs/release-service/
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest

--- a/config/kcp/apiexport_release.yaml
+++ b/config/kcp/apiexport_release.yaml
@@ -1,29 +1,29 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
-  name: release
+  name: release-service
 spec:
   # The identityHash values should be populated with proper values at
   # deployment time.
   permissionClaims:
   - resource: "applications"
     group: "appstudio.redhat.com"
-    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+    identityHash: application-api
   - resource: "components"
     group: "appstudio.redhat.com"
-    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+    identityHash: application-api
   - resource: "applicationsnapshots"
     group: "appstudio.redhat.com"
-    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+    identityHash: application-api
   - resource: "environments"
     group: "appstudio.redhat.com"
-    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+    identityHash: application-api
   - resource: "applicationsnapshotenvironmentbindings"
     group: "appstudio.redhat.com"
-    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+    identityHash: application-api
   - resource: "pipelineruns"
     group: "tekton.dev"
-    identityHash: null
+    identityHash: pipeline-service
   latestResourceSchemas:
     - md5-06f1498b5778196e58c2bc1fc88108b8.releaseplanadmissions.appstudio.redhat.com
     - md5-9959e22acaaf6d162a03980c75b93dfe.releaseplans.appstudio.redhat.com

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,20 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - apis.kcp.dev
+  resources:
+  - apiexports
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apis.kcp.dev
+  resources:
+  - apiexports/content
+  verbs:
+  - update
+- apiGroups:
   - appstudio.redhat.com
   resources:
   - applications/finalizers

--- a/controllers/release/release_controller.go
+++ b/controllers/release/release_controller.go
@@ -56,6 +56,8 @@ func NewReleaseReconciler(client client.Client, logger *logr.Logger, scheme *run
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releases/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releases/finalizers,verbs=update
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/finalizers,verbs=update
+//+kubebuilder:rbac:groups=apis.kcp.dev,resources=apiexports,verbs=get;list;watch
+//+kubebuilder:rbac:groups=apis.kcp.dev,resources=apiexports/content,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/hack/generate-kcp-api.sh
+++ b/hack/generate-kcp-api.sh
@@ -8,29 +8,29 @@ KCP_API_EXPORT_HEADER="$(cat << EOF
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
-  name: release
+  name: release-service
 spec:
   # The identityHash values should be populated with proper values at
   # deployment time.
   permissionClaims:
   - resource: "applications"
     group: "appstudio.redhat.com"
-    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+    identityHash: application-api
   - resource: "components"
     group: "appstudio.redhat.com"
-    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+    identityHash: application-api
   - resource: "applicationsnapshots"
     group: "appstudio.redhat.com"
-    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+    identityHash: application-api
   - resource: "environments"
     group: "appstudio.redhat.com"
-    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+    identityHash: application-api
   - resource: "applicationsnapshotenvironmentbindings"
     group: "appstudio.redhat.com"
-    identityHash: "APPLICATION_API_IDENTITY_HASH_PLACEHOLDER"
+    identityHash: application-api
   - resource: "pipelineruns"
     group: "tekton.dev"
-    identityHash: null
+    identityHash: pipeline-service
   latestResourceSchemas:
 EOF
 )"


### PR DESCRIPTION
This commit makes some changes to have the APIExport defined in the release-service both function properly and automatically update in infra-deployments on push.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>

See https://github.com/redhat-appstudio/application-service/pull/192/ for a similar PR