### PR TITLE
feat(HACBS-1098): make changes to fix controller in infra-deployments

### DIFF
--- a/config/kcp/kustomization.yaml
+++ b/config/kcp/kustomization.yaml
@@ -1,3 +1,28 @@
+bases:
+- ../manager
+- ../rbac
+
+patches:
+# Add APIExport flag to the operator arguments list
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --api-export-name=release-service
+  target:
+    kind: Deployment
+    name: controller-manager
+# Disable webhooks by default on KCP
+# Webhooks can be optionally enabled after deploy
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/env/-
+      value:
+        name: ENABLE_WEBHOOKS
+        value: "false"
+  target:
+    kind: Deployment
+    name: controller-manager
+
 resources:
   - apiexport_release.yaml
   - apiresourceschema_release.yaml

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,3 +1,5 @@
+namePrefix: release-service-
+
 resources:
 - manager.yaml
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,7 +18,7 @@ rules:
   resources:
   - apiexports/content
   verbs:
-  - update
+  - '*'
 - apiGroups:
   - appstudio.redhat.com
   resources:

--- a/controllers/release/release_controller.go
+++ b/controllers/release/release_controller.go
@@ -57,7 +57,7 @@ func NewReleaseReconciler(client client.Client, logger *logr.Logger, scheme *run
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releases/finalizers,verbs=update
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/finalizers,verbs=update
 //+kubebuilder:rbac:groups=apis.kcp.dev,resources=apiexports,verbs=get;list;watch
-//+kubebuilder:rbac:groups=apis.kcp.dev,resources=apiexports/content,verbs=update
+//+kubebuilder:rbac:groups=apis.kcp.dev,resources=apiexports/content,verbs=*
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
This commit makes changes to enable the controller to run on the kcp version of infra-deployments. Namely, it fixes apiexport content permissions and adds to the kustomization files.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>