### PR TITLE
fix(HACBS-1257): add namePrefix to rbac resources

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
+namePrefix: release-service-
+
 resources:
 # All RBAC will be applied under this service account in
 # the deployment namespace. You may comment out this resource


### PR DESCRIPTION
The release-service has overlapping cluster roles with the integration service. This commit adds a namePrefix to the cluster roles in this repo so that they do not conflict with the integration service.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>