### PR TITLE
fix(hacbs-1313): use checkout v3 action in gosec workflow

### DIFF
--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
This should make nodejs 12 warning go away.
  "Node.js 12 actions are deprecated."

Signed-off-by: Jon Disnard <jdisnard@redhat.com>