### PR TITLE
fix: remove double prefix on rbac resources

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,5 +1,3 @@
-namePrefix: release-service-
-
 resources:
 # All RBAC will be applied under this service account in
 # the deployment namespace. You may comment out this resource


### PR DESCRIPTION
For kcp we needed to move the name-prefix to the rbac kustomization. Now that kcp is gone, we are getting double prefixes on our deployments. This is causing problems in some resources which end up with a really long name.

Signed-off-by: David Moreno García <damoreno@redhat.com>