### PR TITLE
chore(hacbs_1032): move ReleasePlan and ReleasePlanAdmission label to a proper place

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"time"
+
 	"github.com/redhat-appstudio/release-service/conditions"
 	"github.com/redhat-appstudio/release-service/metrics"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,11 +38,6 @@ type ReleaseSpec struct {
 	// +required
 	ReleasePlan string `json:"releasePlan"`
 }
-
-const (
-	// AutoReleaseLabel is the label name for the auto-release setting
-	AutoReleaseLabel = "release.appstudio.openshift.io/auto-release"
-)
 
 // ReleaseStatus defines the observed state of Release.
 type ReleaseStatus struct {

--- a/api/v1alpha1/release_webhook.go
+++ b/api/v1alpha1/release_webhook.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/redhat-appstudio/release-service/metadata"
 	"gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,8 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
-
-const authorLabel = "release.rhtap.openshift.io/author"
 
 // releaseHandler describes the handler for the Release low level webhook
 type releaseHandler struct {
@@ -66,7 +65,7 @@ func (r *releaseHandler) Handle(ctx context.Context, req admission.Request) admi
 		if !reflect.DeepEqual(releaseNew.Spec, releaseOld.Spec) {
 			return failedResponse(req.UID, "release resources spec cannot be updated")
 		}
-		if releaseNew.GetLabels()[authorLabel] != releaseOld.GetLabels()[authorLabel] {
+		if releaseNew.GetLabels()[metadata.AuthorLabel] != releaseOld.GetLabels()[metadata.AuthorLabel] {
 			return failedResponse(req.UID, "release author label cannnot be updated")
 		}
 	}
@@ -108,7 +107,7 @@ func patchAuthorResponse(req admission.Request) admission.Response {
 		Operation: "replace",
 		Path:      "/metadata/labels",
 		Value: map[string]string{
-			authorLabel: author,
+			metadata.AuthorLabel: author,
 		},
 	})
 	patchBytes, err := json.Marshal(patch)

--- a/api/v1alpha1/release_webhook_test.go
+++ b/api/v1alpha1/release_webhook_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-appstudio/release-service/metadata"
 	"gomodules.xyz/jsonpatch/v2"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -79,7 +80,7 @@ var _ = Describe("Release webhook", Ordered, func() {
 			Expect(patch.Operation).To(Equal("replace"))
 			Expect(patch.Path).To(Equal("/metadata/labels"))
 			Expect(patch.Value).To(Equal(map[string]interface{}{
-				authorLabel: "admin",
+				metadata.AuthorLabel: "admin",
 			}))
 		})
 		It("should overwrite the author label value when one is provided by user", func() {
@@ -92,7 +93,7 @@ var _ = Describe("Release webhook", Ordered, func() {
 					Name:      "test-release",
 					Namespace: "default",
 					Labels: map[string]string{
-						authorLabel: "user",
+						metadata.AuthorLabel: "user",
 					},
 				},
 				Spec: ReleaseSpec{
@@ -116,7 +117,7 @@ var _ = Describe("Release webhook", Ordered, func() {
 			Expect(patch.Operation).To(Equal("replace"))
 			Expect(patch.Path).To(Equal("/metadata/labels"))
 			Expect(patch.Value).To(Equal(map[string]interface{}{
-				authorLabel: "admin",
+				metadata.AuthorLabel: "admin",
 			}))
 		})
 	})
@@ -156,7 +157,7 @@ var _ = Describe("Release webhook", Ordered, func() {
 		})
 		It("should allow changes to metadata besides the author label", func() {
 			release.ObjectMeta.Labels = map[string]string{
-				authorLabel: "admin",
+				metadata.AuthorLabel: "admin",
 			}
 			releaseMetadataChange := &Release{
 				TypeMeta: metav1.TypeMeta{
@@ -167,7 +168,7 @@ var _ = Describe("Release webhook", Ordered, func() {
 					Name:      "test-release",
 					Namespace: "default",
 					Labels: map[string]string{
-						authorLabel: "admin",
+						metadata.AuthorLabel: "admin",
 					},
 					Annotations: map[string]string{
 						"foo": "bar",
@@ -200,7 +201,7 @@ var _ = Describe("Release webhook", Ordered, func() {
 					Name:      "test-release",
 					Namespace: "default",
 					Labels: map[string]string{
-						authorLabel: "user",
+						metadata.AuthorLabel: "user",
 					},
 				},
 				Spec: ReleaseSpec{
@@ -271,7 +272,7 @@ var _ = Describe("Release webhook", Ordered, func() {
 			Expect(len(jsonPatch)).To(Equal(1))
 			patch := jsonPatch[0]
 			Expect(patch.Value).To(Equal(map[string]interface{}{
-				authorLabel: "a_b",
+				metadata.AuthorLabel: "a_b",
 			}))
 		})
 		It("should convert 'system:serviceaccount' to 'sa' in the author", func() {
@@ -284,7 +285,7 @@ var _ = Describe("Release webhook", Ordered, func() {
 			Expect(len(jsonPatch)).To(Equal(1))
 			patch := jsonPatch[0]
 			Expect(patch.Value).To(Equal(map[string]interface{}{
-				authorLabel: "sa_foo",
+				metadata.AuthorLabel: "sa_foo",
 			}))
 		})
 		It("should convert only use the first 63 characters of the author", func() {
@@ -297,7 +298,7 @@ var _ = Describe("Release webhook", Ordered, func() {
 			Expect(len(jsonPatch)).To(Equal(1))
 			patch := jsonPatch[0]
 			Expect(patch.Value).To(Equal(map[string]interface{}{
-				authorLabel: "abcdefghijklmnopqrstuvwxyz_abcdefghijklmnopqrstuvwxyz_123456789",
+				metadata.AuthorLabel: "abcdefghijklmnopqrstuvwxyz_abcdefghijklmnopqrstuvwxyz_123456789",
 			}))
 		})
 	})

--- a/api/v1alpha1/releaseplan_webhook.go
+++ b/api/v1alpha1/releaseplan_webhook.go
@@ -18,9 +18,12 @@ package v1alpha1
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/redhat-appstudio/release-service/metadata"
 )
 
 func (rp *ReleasePlan) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -35,10 +38,10 @@ var _ webhook.Defaulter = &ReleasePlan{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (rp *ReleasePlan) Default() {
-	if _, found := rp.GetLabels()[AutoReleaseLabel]; !found {
+	if _, found := rp.GetLabels()[metadata.AutoReleaseLabel]; !found {
 		if rp.Labels == nil {
 			rp.Labels = map[string]string{
-				AutoReleaseLabel: "true",
+				metadata.AutoReleaseLabel: "true",
 			}
 		}
 	}
@@ -65,9 +68,9 @@ func (rp *ReleasePlan) ValidateDelete() error {
 
 // validateAutoReleaseLabel throws an error if the auto-release label value is set to anything besides true or false.
 func (rp *ReleasePlan) validateAutoReleaseLabel() error {
-	if value, found := rp.GetLabels()[AutoReleaseLabel]; found {
+	if value, found := rp.GetLabels()[metadata.AutoReleaseLabel]; found {
 		if value != "true" && value != "false" {
-			return fmt.Errorf("'%s' label can only be set to true or false", AutoReleaseLabel)
+			return fmt.Errorf("'%s' label can only be set to true or false", metadata.AutoReleaseLabel)
 		}
 	}
 	return nil

--- a/api/v1alpha1/releaseplan_webhook_test.go
+++ b/api/v1alpha1/releaseplan_webhook_test.go
@@ -18,8 +18,11 @@ package v1alpha1
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/redhat-appstudio/release-service/metadata"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	//+kubebuilder:scaffold:imports
@@ -60,7 +63,7 @@ var _ = Describe("ReleasePlan webhook", func() {
 					Namespace: releasePlan.Namespace,
 				}, releasePlan)
 
-				labelValue, ok := releasePlan.GetLabels()[AutoReleaseLabel]
+				labelValue, ok := releasePlan.GetLabels()[metadata.AutoReleaseLabel]
 
 				return err == nil && ok && labelValue == "true"
 			}, timeout).Should(BeTrue())
@@ -69,10 +72,10 @@ var _ = Describe("ReleasePlan webhook", func() {
 
 	Context("When a ReleasePlan is created with an invalid auto-release label value", func() {
 		It("should get rejected until the value is valid", func() {
-			releasePlan.Labels = map[string]string{AutoReleaseLabel: "foo"}
+			releasePlan.Labels = map[string]string{metadata.AutoReleaseLabel: "foo"}
 			err := k8sClient.Create(ctx, releasePlan)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", AutoReleaseLabel))
+			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", metadata.AutoReleaseLabel))
 		})
 	})
 
@@ -80,7 +83,7 @@ var _ = Describe("ReleasePlan webhook", func() {
 		It("shouldn't be modified", func() {
 			// Using value "true"
 			localReleasePlan := releasePlan.DeepCopy()
-			localReleasePlan.Labels = map[string]string{AutoReleaseLabel: "true"}
+			localReleasePlan.Labels = map[string]string{metadata.AutoReleaseLabel: "true"}
 			Expect(k8sClient.Create(ctx, localReleasePlan)).Should(Succeed())
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{
@@ -88,7 +91,7 @@ var _ = Describe("ReleasePlan webhook", func() {
 					Namespace: localReleasePlan.Namespace,
 				}, localReleasePlan)
 
-				labelValue, ok := localReleasePlan.GetLabels()[AutoReleaseLabel]
+				labelValue, ok := localReleasePlan.GetLabels()[metadata.AutoReleaseLabel]
 
 				return err == nil && ok && labelValue == "true"
 			}, timeout).Should(BeTrue())
@@ -97,7 +100,7 @@ var _ = Describe("ReleasePlan webhook", func() {
 
 			// Using value "false"
 			localReleasePlan = releasePlan.DeepCopy()
-			localReleasePlan.Labels = map[string]string{AutoReleaseLabel: "false"}
+			localReleasePlan.Labels = map[string]string{metadata.AutoReleaseLabel: "false"}
 			Expect(k8sClient.Create(ctx, localReleasePlan)).Should(Succeed())
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{
@@ -105,7 +108,7 @@ var _ = Describe("ReleasePlan webhook", func() {
 					Namespace: localReleasePlan.Namespace,
 				}, localReleasePlan)
 
-				labelValue, ok := localReleasePlan.GetLabels()[AutoReleaseLabel]
+				labelValue, ok := localReleasePlan.GetLabels()[metadata.AutoReleaseLabel]
 
 				return err == nil && ok && labelValue == "false"
 			}, timeout).Should(BeTrue())
@@ -115,10 +118,10 @@ var _ = Describe("ReleasePlan webhook", func() {
 	Context("When a ReleasePlan is updated using an invalid auto-release label value", func() {
 		It("shouldn't be modified", func() {
 			Expect(k8sClient.Create(ctx, releasePlan)).Should(Succeed())
-			releasePlan.GetLabels()[AutoReleaseLabel] = "foo"
+			releasePlan.GetLabels()[metadata.AutoReleaseLabel] = "foo"
 			err := k8sClient.Update(ctx, releasePlan)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", AutoReleaseLabel))
+			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", metadata.AutoReleaseLabel))
 		})
 	})
 

--- a/api/v1alpha1/releaseplanadmission_webhook.go
+++ b/api/v1alpha1/releaseplanadmission_webhook.go
@@ -18,9 +18,12 @@ package v1alpha1
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/redhat-appstudio/release-service/metadata"
 )
 
 func (rp *ReleasePlanAdmission) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -35,10 +38,10 @@ var _ webhook.Defaulter = &ReleasePlanAdmission{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (rp *ReleasePlanAdmission) Default() {
-	if _, found := rp.GetLabels()[AutoReleaseLabel]; !found {
+	if _, found := rp.GetLabels()[metadata.AutoReleaseLabel]; !found {
 		if rp.Labels == nil {
 			rp.Labels = map[string]string{
-				AutoReleaseLabel: "true",
+				metadata.AutoReleaseLabel: "true",
 			}
 		}
 	}
@@ -65,9 +68,9 @@ func (rp *ReleasePlanAdmission) ValidateDelete() error {
 
 // validateAutoReleaseLabel throws an error if the auto-release label value is set to anything besides true or false.
 func (rp *ReleasePlanAdmission) validateAutoReleaseLabel() error {
-	if value, found := rp.GetLabels()[AutoReleaseLabel]; found {
+	if value, found := rp.GetLabels()[metadata.AutoReleaseLabel]; found {
 		if value != "true" && value != "false" {
-			return fmt.Errorf("'%s' label can only be set to true or false", AutoReleaseLabel)
+			return fmt.Errorf("'%s' label can only be set to true or false", metadata.AutoReleaseLabel)
 		}
 	}
 	return nil

--- a/api/v1alpha1/releaseplanadmission_webhook_test.go
+++ b/api/v1alpha1/releaseplanadmission_webhook_test.go
@@ -21,6 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/redhat-appstudio/release-service/metadata"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	//+kubebuilder:scaffold:imports
 )
@@ -62,7 +64,7 @@ var _ = Describe("ReleasePlanAdmission webhook", func() {
 					Namespace: releasePlanAdmission.Namespace,
 				}, releasePlanAdmission)
 
-				labelValue, ok := releasePlanAdmission.GetLabels()[AutoReleaseLabel]
+				labelValue, ok := releasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel]
 
 				return err == nil && ok && labelValue == "true"
 			}, timeout).Should(BeTrue())
@@ -71,10 +73,10 @@ var _ = Describe("ReleasePlanAdmission webhook", func() {
 
 	Context("When a ReleasePlanAdmission is created with an invalid auto-release label value", func() {
 		It("should get rejected until the value is valid", func() {
-			releasePlanAdmission.Labels = map[string]string{AutoReleaseLabel: "foo"}
+			releasePlanAdmission.Labels = map[string]string{metadata.AutoReleaseLabel: "foo"}
 			err := k8sClient.Create(ctx, releasePlanAdmission)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", AutoReleaseLabel))
+			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", metadata.AutoReleaseLabel))
 		})
 	})
 
@@ -82,7 +84,7 @@ var _ = Describe("ReleasePlanAdmission webhook", func() {
 		It("shouldn't be modified", func() {
 			By("setting label to true")
 			localReleasePlanAdmission := releasePlanAdmission.DeepCopy()
-			localReleasePlanAdmission.Labels = map[string]string{AutoReleaseLabel: "true"}
+			localReleasePlanAdmission.Labels = map[string]string{metadata.AutoReleaseLabel: "true"}
 			Expect(k8sClient.Create(ctx, localReleasePlanAdmission)).Should(Succeed())
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{
@@ -90,7 +92,7 @@ var _ = Describe("ReleasePlanAdmission webhook", func() {
 					Namespace: localReleasePlanAdmission.Namespace,
 				}, localReleasePlanAdmission)
 
-				labelValue, ok := localReleasePlanAdmission.GetLabels()[AutoReleaseLabel]
+				labelValue, ok := localReleasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel]
 
 				return err == nil && ok && labelValue == "true"
 			}, timeout).Should(BeTrue())
@@ -99,7 +101,7 @@ var _ = Describe("ReleasePlanAdmission webhook", func() {
 
 			By("setting label to false")
 			localReleasePlanAdmission = releasePlanAdmission.DeepCopy()
-			localReleasePlanAdmission.Labels = map[string]string{AutoReleaseLabel: "false"}
+			localReleasePlanAdmission.Labels = map[string]string{metadata.AutoReleaseLabel: "false"}
 			Expect(k8sClient.Create(ctx, localReleasePlanAdmission)).Should(Succeed())
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{
@@ -107,7 +109,7 @@ var _ = Describe("ReleasePlanAdmission webhook", func() {
 					Namespace: localReleasePlanAdmission.Namespace,
 				}, localReleasePlanAdmission)
 
-				labelValue, ok := localReleasePlanAdmission.GetLabels()[AutoReleaseLabel]
+				labelValue, ok := localReleasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel]
 
 				return err == nil && ok && labelValue == "false"
 			}, timeout).Should(BeTrue())
@@ -117,10 +119,10 @@ var _ = Describe("ReleasePlanAdmission webhook", func() {
 	Context("When a ReleasePlanAdmission is updated using an invalid auto-release label value", func() {
 		It("shouldn't be modified", func() {
 			Expect(k8sClient.Create(ctx, releasePlanAdmission)).Should(Succeed())
-			releasePlanAdmission.GetLabels()[AutoReleaseLabel] = "foo"
+			releasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel] = "foo"
 			err := k8sClient.Update(ctx, releasePlanAdmission)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", AutoReleaseLabel))
+			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", metadata.AutoReleaseLabel))
 		})
 	})
 

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
+
 	"github.com/operator-framework/operator-lib/handler"
 	"github.com/redhat-appstudio/release-service/api/v1alpha1"
 	"github.com/redhat-appstudio/release-service/loader"
-	"github.com/redhat-appstudio/release-service/tekton"
+	"github.com/redhat-appstudio/release-service/metadata"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -761,9 +762,9 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		})
 
 		It("has release labels", func() {
-			Expect(pipelineRun.GetLabels()[tekton.PipelinesTypeLabel]).To(Equal("release"))
-			Expect(pipelineRun.GetLabels()[tekton.ReleaseNameLabel]).To(Equal(adapter.release.Name))
-			Expect(pipelineRun.GetLabels()[tekton.ReleaseNamespaceLabel]).To(Equal(testNamespace))
+			Expect(pipelineRun.GetLabels()[metadata.PipelinesTypeLabel]).To(Equal("release"))
+			Expect(pipelineRun.GetLabels()[metadata.ReleaseNameLabel]).To(Equal(adapter.release.Name))
+			Expect(pipelineRun.GetLabels()[metadata.ReleaseNamespaceLabel]).To(Equal(testNamespace))
 		})
 
 		It("references the pipeline specified in the ReleaseStrategy", func() {
@@ -1236,7 +1237,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 				Name:      "release-plan-admission",
 				Namespace: "default",
 				Labels: map[string]string{
-					v1alpha1.AutoReleaseLabel: "true",
+					metadata.AutoReleaseLabel: "true",
 				},
 			},
 			Spec: v1alpha1.ReleasePlanAdmissionSpec{

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -8,7 +8,7 @@ import (
 	ecapiv1alpha1 "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/release-service/api/v1alpha1"
-	"github.com/redhat-appstudio/release-service/tekton"
+	"github.com/redhat-appstudio/release-service/metadata"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,7 +73,7 @@ func (l *loader) GetActiveReleasePlanAdmission(ctx context.Context, cli client.C
 				releasePlan.Spec.Target, releasePlan.Spec.Application)
 		}
 
-		labelValue, found := releasePlanAdmission.GetLabels()[v1alpha1.AutoReleaseLabel]
+		labelValue, found := releasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel]
 		if found && labelValue == "false" {
 			return nil, fmt.Errorf("found ReleasePlanAdmission '%s' with auto-release label set to false",
 				releasePlanAdmission.Name)
@@ -150,8 +150,8 @@ func (l *loader) GetReleasePipelineRun(ctx context.Context, cli client.Client, r
 	err := cli.List(ctx, pipelineRuns,
 		client.Limit(1),
 		client.MatchingLabels{
-			tekton.ReleaseNameLabel:      release.Name,
-			tekton.ReleaseNamespaceLabel: release.Namespace,
+			metadata.ReleaseNameLabel:      release.Name,
+			metadata.ReleaseNamespaceLabel: release.Namespace,
 		})
 	if err == nil && len(pipelineRuns.Items) > 0 {
 		return &pipelineRuns.Items[0], nil

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/release-service/api/v1alpha1"
-	"github.com/redhat-appstudio/release-service/tekton"
+	"github.com/redhat-appstudio/release-service/metadata"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,7 +97,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 
 		It("fails to return an active release plan admission if the auto release label is set to false", func() {
 			disabledReleasePlanAdmission := releasePlanAdmission.DeepCopy()
-			disabledReleasePlanAdmission.Labels[v1alpha1.AutoReleaseLabel] = "false"
+			disabledReleasePlanAdmission.Labels[metadata.AutoReleaseLabel] = "false"
 			disabledReleasePlanAdmission.Name = "disabled-release-plan-admission"
 			disabledReleasePlanAdmission.ResourceVersion = ""
 			Expect(k8sClient.Create(ctx, disabledReleasePlanAdmission)).To(Succeed())
@@ -382,7 +382,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 				Name:      "release-plan-admission",
 				Namespace: "default",
 				Labels: map[string]string{
-					v1alpha1.AutoReleaseLabel: "true",
+					metadata.AutoReleaseLabel: "true",
 				},
 			},
 			Spec: v1alpha1.ReleasePlanAdmissionSpec{
@@ -434,8 +434,8 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		pipelineRun = &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					tekton.ReleaseNameLabel:      release.Name,
-					tekton.ReleaseNamespaceLabel: release.Namespace,
+					metadata.ReleaseNameLabel:      release.Name,
+					metadata.ReleaseNamespaceLabel: release.Namespace,
 				},
 				Name:      "pipeline-run",
 				Namespace: "default",

--- a/metadata/labels.go
+++ b/metadata/labels.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import "fmt"
+
+// Common constants
+const (
+	// rhtapDomain is the prefix of the application label
+	rhtapDomain = "appstudio.openshift.io"
+)
+
+// Labels used by the release api package
+var (
+	// AutoReleaseLabel is the label name for the auto-release setting
+	AutoReleaseLabel = fmt.Sprintf("release.%s/auto-release", rhtapDomain)
+
+	// AuthorLabel is the label name for the user who creates a CR
+	AuthorLabel = fmt.Sprintf("release.%s/author", rhtapDomain)
+)
+
+// Prefixes to be used by Release Pipeline Labels
+var (
+	// pipelinesLabelPrefix is the prefix of the pipelines label
+	pipelinesLabelPrefix = fmt.Sprintf("pipelines.%s", rhtapDomain)
+
+	// releaseLabelPrefix is the prefix of the release labels
+	releaseLabelPrefix = fmt.Sprintf("release.%s", rhtapDomain)
+)
+
+// Labels to be used within Release PipelineRuns
+var (
+	// ApplicationNameLabel is the label used to specify the application associated with the PipelineRun
+	ApplicationNameLabel = fmt.Sprintf("%s/%s", rhtapDomain, "application")
+
+	// PipelinesTypeLabel is the label used to describe the type of pipeline
+	PipelinesTypeLabel = fmt.Sprintf("%s/%s", pipelinesLabelPrefix, "type")
+
+	// ReleaseNameLabel is the label used to specify the name of the Release associated with the PipelineRun
+	ReleaseNameLabel = fmt.Sprintf("%s/%s", releaseLabelPrefix, "name")
+
+	// ReleaseNamespaceLabel is the label used to specify the namespace of the Release associated with the PipelineRun
+	ReleaseNamespaceLabel = fmt.Sprintf("%s/%s", releaseLabelPrefix, "namespace")
+)

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -17,12 +17,13 @@ limitations under the License.
 package metadata
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/redhat-appstudio/release-service/api/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestMetadata(t *testing.T) {
@@ -148,26 +149,26 @@ var _ = Describe("Metadata", func() {
 	})
 
 	Context("AddLabels function", func() {
-		When("called with a pipelineRun containing nil Labels", func() {
-			pipelineRun := &v1beta1.PipelineRun{
+		When("called with an object containing nil Labels", func() {
+			pod := &corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: nil,
 					Labels:      nil,
 				},
 			}
-			AddLabels(pipelineRun, map[string]string{})
+			AddLabels(pod, map[string]string{})
 			It("should create the Labels map", func() {
-				Expect(pipelineRun.GetLabels()).ToNot(BeNil())
+				Expect(pod.GetLabels()).ToNot(BeNil())
 			})
 			It("should do nothing with the Annotations map", func() {
-				Expect(pipelineRun.GetAnnotations()).To(BeNil())
+				Expect(pod.GetAnnotations()).To(BeNil())
 			})
 		})
 	})
 
 	Context("GetAnnotationsWithPrefix function", func() {
 		When("calling filterByPrefix with GetAnnotations()", func() {
-			release := &v1alpha1.Release{
+			pod := &corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{
 						"pet/dog": "bark",
@@ -177,7 +178,7 @@ var _ = Describe("Metadata", func() {
 					},
 				},
 			}
-			dst := GetAnnotationsWithPrefix(release, "pet/")
+			dst := GetAnnotationsWithPrefix(pod, "pet/")
 			It("should only fetch Annotations", func() {
 				Expect(dst["pet/dog"]).To(Equal("bark"))
 			})
@@ -189,7 +190,7 @@ var _ = Describe("Metadata", func() {
 
 	Context("GetLabelsWithPrefix function", func() {
 		When("calling filterByPrefix with GetLabels()", func() {
-			release := &v1alpha1.Release{
+			pod := &corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{
 						"foo": "bar",
@@ -199,7 +200,7 @@ var _ = Describe("Metadata", func() {
 					},
 				},
 			}
-			dst := GetLabelsWithPrefix(release, "pet/")
+			dst := GetLabelsWithPrefix(pod, "pet/")
 			It("should only fetch Labels", func() {
 				Expect(dst["pet/dog"]).To(Equal("bark"))
 			})

--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -18,7 +18,6 @@ package tekton
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"unicode"
 
@@ -38,31 +37,8 @@ import (
 type PipelineType string
 
 const (
-	// appstudioLabelPrefix is the prefix of the application label
-	appstudioLabelPrefix = "appstudio.openshift.io"
-
-	// pipelinesLabelPrefix is the prefix of the pipelines label
-	pipelinesLabelPrefix = "pipelines.appstudio.openshift.io"
-
-	// releaseLabelPrefix is the prefix of the release labels
-	releaseLabelPrefix = "release.appstudio.openshift.io"
-
-	//PipelineTypeRelease is the type for PipelineRuns created to run a release Pipeline
+	// PipelineTypeRelease is the type for PipelineRuns created to run a release Pipeline
 	PipelineTypeRelease = "release"
-)
-
-var (
-	// ApplicationNameLabel is the label used to specify the application associated with the PipelineRun
-	ApplicationNameLabel = fmt.Sprintf("%s/%s", appstudioLabelPrefix, "application")
-
-	// PipelinesTypeLabel is the label used to describe the type of pipeline
-	PipelinesTypeLabel = fmt.Sprintf("%s/%s", pipelinesLabelPrefix, "type")
-
-	// ReleaseNameLabel is the label used to specify the name of the Release associated with the PipelineRun
-	ReleaseNameLabel = fmt.Sprintf("%s/%s", releaseLabelPrefix, "name")
-
-	// ReleaseNamespaceLabel is the label used to specify the namespace of the Release associated with the PipelineRun
-	ReleaseNamespaceLabel = fmt.Sprintf("%s/%s", releaseLabelPrefix, "namespace")
 )
 
 // ReleasePipelineRun is a PipelineRun alias, so we can add new methods to it in this file.
@@ -125,10 +101,10 @@ func (r *ReleasePipelineRun) WithOwner(release *v1alpha1.Release) *ReleasePipeli
 // WithReleaseAndApplicationMetadata adds Release and Application metadata to the release PipelineRun.
 func (r *ReleasePipelineRun) WithReleaseAndApplicationMetadata(release *v1alpha1.Release, applicationName string) *ReleasePipelineRun {
 	r.ObjectMeta.Labels = map[string]string{
-		PipelinesTypeLabel:    PipelineTypeRelease,
-		ReleaseNameLabel:      release.Name,
-		ReleaseNamespaceLabel: release.Namespace,
-		ApplicationNameLabel:  applicationName,
+		metadata.PipelinesTypeLabel:    PipelineTypeRelease,
+		metadata.ReleaseNameLabel:      release.Name,
+		metadata.ReleaseNamespaceLabel: release.Namespace,
+		metadata.ApplicationNameLabel:  applicationName,
 	}
 	metadata.AddAnnotations(r.AsPipelineRun(), metadata.GetAnnotationsWithPrefix(release, integrationServiceGitopsPkg.PipelinesAsCodePrefix))
 	metadata.AddLabels(r.AsPipelineRun(), metadata.GetLabelsWithPrefix(release, integrationServiceGitopsPkg.PipelinesAsCodePrefix))

--- a/tekton/utils.go
+++ b/tekton/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tekton
 
 import (
+	"github.com/redhat-appstudio/release-service/metadata"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,7 +30,7 @@ func isReleasePipelineRun(object client.Object) bool {
 		return false
 	}
 
-	labelValue, found := object.GetLabels()[PipelinesTypeLabel]
+	labelValue, found := object.GetLabels()[metadata.PipelinesTypeLabel]
 
 	return found && labelValue == PipelineTypeRelease
 }


### PR DESCRIPTION
Looking around some `k8s` projects I noticed they use `labels.go` to keep their labels in. Not sure about the proper place and if should we move any other label here so far.

- moves release related labels to `labels.go` at `api/v1alpha1`

Signed-off-by: Leandro Mendes <lmendes@redhat.com>