### PR TITLE
feat(HACBS-1274): add deploy status helper functions to release CRD

### DIFF
--- a/config/crd/bases/appstudio.redhat.com_releases.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releases.yaml
@@ -170,7 +170,7 @@ spec:
                 format: date-time
                 type: string
               target:
-                description: Target references where this relesae is intended to be
+                description: Target references where this release is intended to be
                   released to
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string

--- a/controllers/release/release_adapter.go
+++ b/controllers/release/release_adapter.go
@@ -199,7 +199,7 @@ func (a *Adapter) EnsureReleasePipelineStatusIsTracked() (reconciler.OperationRe
 // EnsureSnapshotEnvironmentBindingIsCreated is an operation that will ensure that a SnapshotEnvironmentBinding is created
 // or updated for the current Release.
 func (a *Adapter) EnsureSnapshotEnvironmentBindingIsCreated() (reconciler.OperationResult, error) {
-	if !a.release.HasSucceeded() || a.release.HasBeenDeployed() {
+	if !a.release.HasSucceeded() || a.release.Status.SnapshotEnvironmentBinding != "" {
 		return reconciler.ContinueProcessing()
 	}
 


### PR DESCRIPTION
This commit adds functions to the Release CRD to help set its status to reflect the deployment status of the SnapshotEnvironmentBinding.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>