### PR TITLE
feat(HACBS-1274): add gitops predicate for snapshotenvironmentbindings

### DIFF
--- a/gitops/predicates.go
+++ b/gitops/predicates.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitops
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// DeploymentFinishedPredicate returns a predicate which filters out update events to a
+// SnapshotEnvironmentBinding where the component deployment status goes from unknown to true/false.
+func DeploymentFinishedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return hasDeploymentFinished(e.ObjectOld, e.ObjectNew)
+		},
+	}
+}

--- a/gitops/predicates_test.go
+++ b/gitops/predicates_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2022 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitops
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/release-service/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Predicates", Ordered, func() {
+
+	const (
+		namespace       = "default"
+		applicationName = "test-application"
+		environmentName = "test-environment"
+		snapshotName    = "test-snapshot"
+	)
+
+	var bindingUnknownStatus, bindingTrueStatus *applicationapiv1alpha1.SnapshotEnvironmentBinding
+
+	BeforeAll(func() {
+		bindingUnknownStatus = &applicationapiv1alpha1.SnapshotEnvironmentBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "bindingunknownstatus",
+				Namespace:  namespace,
+				Generation: 1,
+			},
+			Spec: applicationapiv1alpha1.SnapshotEnvironmentBindingSpec{
+				Application: applicationName,
+				Environment: environmentName,
+				Snapshot:    snapshotName,
+				Components:  []applicationapiv1alpha1.BindingComponent{},
+			},
+		}
+		bindingTrueStatus = &applicationapiv1alpha1.SnapshotEnvironmentBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "bindingtruestatus",
+				Namespace:  namespace,
+				Generation: 1,
+			},
+			Spec: applicationapiv1alpha1.SnapshotEnvironmentBindingSpec{
+				Application: applicationName,
+				Environment: environmentName,
+				Snapshot:    snapshotName,
+				Components:  []applicationapiv1alpha1.BindingComponent{},
+			},
+		}
+		ctx := context.Background()
+
+		Expect(k8sClient.Create(ctx, bindingUnknownStatus)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, bindingTrueStatus)).Should(Succeed())
+
+		// Set the binding statuses after they are created
+		bindingUnknownStatus.Status.ComponentDeploymentConditions = []metav1.Condition{
+			{
+				Type:   v1alpha1.BindingDeploymentStatusConditionType,
+				Status: metav1.ConditionUnknown,
+			},
+		}
+		bindingTrueStatus.Status.ComponentDeploymentConditions = []metav1.Condition{
+			{
+				Type:   v1alpha1.BindingDeploymentStatusConditionType,
+				Status: metav1.ConditionTrue,
+			},
+		}
+	})
+
+	AfterAll(func() {
+		err := k8sClient.Delete(ctx, bindingUnknownStatus)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, bindingTrueStatus)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	Context("when testing DeploymentFinishedPredicate predicate", func() {
+		instance := DeploymentFinishedPredicate()
+
+		It("returns true when the old SnapshotEnvironmentBinding has unknown status and the new one has true status", func() {
+			contextEvent := event.UpdateEvent{
+				ObjectOld: bindingUnknownStatus,
+				ObjectNew: bindingTrueStatus,
+			}
+			Expect(instance.Update(contextEvent)).To(BeTrue())
+		})
+	})
+})

--- a/gitops/utils.go
+++ b/gitops/utils.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitops
+
+import (
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/release-service/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// hasDeploymentFinished returns a boolean that is only true if the first passed object
+// is a SnapshotEnvironmentBinding with the componentDeployment status Unknown and the second
+// passed object is a SnapshotEnvironmentBinding with the componentDeployment status True/False.
+func hasDeploymentFinished(objectOld, objectNew client.Object) bool {
+	var oldCondition, newCondition *metav1.Condition
+
+	if oldBinding, ok := objectOld.(*applicationapiv1alpha1.SnapshotEnvironmentBinding); ok {
+		oldCondition = meta.FindStatusCondition(oldBinding.Status.ComponentDeploymentConditions, v1alpha1.BindingDeploymentStatusConditionType)
+		if oldCondition == nil {
+			return false
+		}
+	}
+	if newBinding, ok := objectNew.(*applicationapiv1alpha1.SnapshotEnvironmentBinding); ok {
+		newCondition = meta.FindStatusCondition(newBinding.Status.ComponentDeploymentConditions, v1alpha1.BindingDeploymentStatusConditionType)
+		if newCondition == nil {
+			return false
+		}
+	}
+
+	return oldCondition.Status == metav1.ConditionUnknown && newCondition.Status != metav1.ConditionUnknown
+}

--- a/gitops/utils_test.go
+++ b/gitops/utils_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2022 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitops
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/release-service/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Utils", Ordered, func() {
+	const (
+		namespace       = "default"
+		applicationName = "test-application"
+		environmentName = "test-environment"
+		snapshotName    = "test-snapshot"
+	)
+
+	var pod *corev1.Pod
+	var binding, bindingUnknownStatus *applicationapiv1alpha1.SnapshotEnvironmentBinding
+
+	BeforeAll(func() {
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    namespace,
+				GenerateName: "testpod-",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "test",
+						Image: "test",
+					},
+				},
+			},
+		}
+		binding = &applicationapiv1alpha1.SnapshotEnvironmentBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding",
+				Namespace: namespace,
+			},
+			Spec: applicationapiv1alpha1.SnapshotEnvironmentBindingSpec{
+				Application: applicationName,
+				Environment: environmentName,
+				Snapshot:    snapshotName,
+				Components:  []applicationapiv1alpha1.BindingComponent{},
+			},
+		}
+		bindingUnknownStatus = &applicationapiv1alpha1.SnapshotEnvironmentBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bindingunknownstatus",
+				Namespace: namespace,
+			},
+			Spec: applicationapiv1alpha1.SnapshotEnvironmentBindingSpec{
+				Application: applicationName,
+				Environment: environmentName,
+				Snapshot:    snapshotName,
+				Components:  []applicationapiv1alpha1.BindingComponent{},
+			},
+		}
+		ctx := context.Background()
+
+		Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, binding)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, bindingUnknownStatus)).Should(Succeed())
+
+		// Set the status of the unknown status binding after it is created
+		bindingUnknownStatus.Status.ComponentDeploymentConditions = []metav1.Condition{
+			{
+				Type:   v1alpha1.BindingDeploymentStatusConditionType,
+				Status: metav1.ConditionUnknown,
+			},
+		}
+	})
+
+	AfterAll(func() {
+		err := k8sClient.Delete(ctx, pod)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, binding)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, bindingUnknownStatus)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	Context("when using utility functions on SnapshotEnvironmentBinding objects", func() {
+		It("returns false when called with an object that isn't a SnapshotEnvironmentBinding", func() {
+			Expect(hasDeploymentFinished(pod, binding)).To(Equal(false))
+		})
+
+		It("returns false when a SnapshotEnvironmentBinding has no status field", func() {
+			Expect(hasDeploymentFinished(binding, binding)).To(Equal(false))
+		})
+
+		It("returns false when the new SnapshotEnvironmentBinding does not have status set to true or false", func() {
+			Expect(hasDeploymentFinished(bindingUnknownStatus, bindingUnknownStatus)).To(Equal(false))
+		})
+
+		It("returns true when the old SnapshotEnvironmentBinding has unknown status and the new one has false status", func() {
+			binding.Status.ComponentDeploymentConditions = []metav1.Condition{
+				{
+					Type:   v1alpha1.BindingDeploymentStatusConditionType,
+					Status: metav1.ConditionFalse,
+				},
+			}
+			Expect(hasDeploymentFinished(bindingUnknownStatus, binding)).To(Equal(true))
+		})
+
+		It("returns true when the old SnapshotEnvironmentBinding has unknown status and the new one has true status", func() {
+			binding.Status.ComponentDeploymentConditions = []metav1.Condition{
+				{
+					Type:   v1alpha1.BindingDeploymentStatusConditionType,
+					Status: metav1.ConditionTrue,
+				},
+			}
+			Expect(hasDeploymentFinished(bindingUnknownStatus, binding)).To(Equal(true))
+		})
+	})
+})

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.5.0
 	github.com/onsi/gomega v1.24.1
 	github.com/operator-framework/operator-lib v0.10.0
-	github.com/redhat-appstudio/application-api v0.0.0-20221114151952-77cba9006505
+	github.com/redhat-appstudio/application-api v0.0.0-20221128221845-7c860969cbb4
 	github.com/redhat-appstudio/operator-goodies v0.0.0-20221130123324-4d6b185e3b32
 	github.com/tektoncd/pipeline v0.41.0
 	k8s.io/api v0.25.3

--- a/go.sum
+++ b/go.sum
@@ -321,8 +321,8 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/statsd_exporter v0.22.7/go.mod h1:N/TevpjkIh9ccs6nuzY3jQn9dFqnUakOjnEuMPJJJnI=
 github.com/prometheus/statsd_exporter v0.22.8 h1:Qo2D9ZzaQG+id9i5NYNGmbf1aa/KxKbB9aKfMS+Yib0=
 github.com/prometheus/statsd_exporter v0.22.8/go.mod h1:/DzwbTEaFTE0Ojz5PqcSk6+PFHOPWGxdXVr6yC8eFOM=
-github.com/redhat-appstudio/application-api v0.0.0-20221114151952-77cba9006505 h1:8x+HtXDPJ9xmQbtWMdV5ntb0T+uEXjsmzzLgxpKFR1M=
-github.com/redhat-appstudio/application-api v0.0.0-20221114151952-77cba9006505/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
+github.com/redhat-appstudio/application-api v0.0.0-20221128221845-7c860969cbb4 h1:ZV0FOyBZtLeUpS25bcupVJ7Lbk1VjLpFrMX+dIUzkCc=
+github.com/redhat-appstudio/application-api v0.0.0-20221128221845-7c860969cbb4/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/redhat-appstudio/integration-service v0.0.0-20221130110641-f5453dea9623 h1:TRWT++4u8YPLNl825OBM6MHV1KX7OfM+kwnt/jvx+PQ=
 github.com/redhat-appstudio/integration-service v0.0.0-20221130110641-f5453dea9623/go.mod h1:r93vQXKEv3zFOV/8ZGs+fZTYPx2xu4CtGvlNoAO0BAY=
 github.com/redhat-appstudio/operator-goodies v0.0.0-20221130123324-4d6b185e3b32 h1:neieTv5wWzSf7vBV0A1/aFG+8xpKa78OPXl8NrNrZbk=


### PR DESCRIPTION
This commit adds predicates to the gitops package that allow the controller to react to changes in SnapshotEnvironmentBindings when the status reflects the component deployment status going from unknown to true or false."

Signed-off-by: Johnny Bieren <jbieren@redhat.com>