### PR TITLE
feat (HACBS-1306) : Confirm HTTPS is used to communicate on the network and block all egress

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- network_policy.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/manager/network_policy.yaml
+++ b/config/manager/network_policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-ingress-https-only-and-block-egress
+  name: allow-https-only-for-specific-ports-ingress
   namespace: system
 spec:
   podSelector:
@@ -12,10 +12,19 @@ spec:
   - Ingress
   - Egress
   ingress:
-  - ports:
-    - protocol: TCP
-      port: 443,444,8080,8443,4443,9443
-      tls:
-        termination: passthrough
+  - matchExpressions:
+    - key: port
+      operator: In
+      values:
+      - "443"
+      - "444"
+      - "4443"
+      - "8080"
+      - "8081"
+      - "8443"
+      - "9443"
+    - key: scheme
+      operator: In
+      values:
+      - https
   egress: []
----

--- a/config/manager/network_policy.yaml
+++ b/config/manager/network_policy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-https-only-and-block-egress
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 443,444,8080,8443,4443,9443
+      tls:
+        termination: passthrough
+  egress: []
+---


### PR DESCRIPTION
The network policy allows ingress traffic on TCP ports 443, 444, 8080, 8443, 4443, and 9443 (HTTPS) if the TLS termination is set to "passthrough" And blocks all egress traffic for pods with the label "control-plane: controller-manager" In the system namespace.

Signed-Off-By: Naftaly Shprai <naftalysh@gmail.com>