### PR TITLE
chore: import binding deployment status constant

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"time"
 
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/release-service/metrics"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,10 +44,6 @@ type ReleaseReason string
 const (
 	// releaseConditionType is the type used when setting a release status condition
 	releaseConditionType string = "Succeeded"
-
-	// BindingDeploymentStatusConditionType is the condition type to retrieve from the ComponentDeploymentConditions
-	// in the SnapshotEnvironmentBinding's status to copy into the Release status
-	BindingDeploymentStatusConditionType string = "AllComponentsDeployed"
 
 	// ReleaseReasonValidationError is the reason set when the Release validation failed
 	ReleaseReasonValidationError ReleaseReason = "ReleaseValidationError"
@@ -133,7 +130,7 @@ type Release struct {
 
 // HasBeenDeployed checks whether the Release has been deployed via GitOps.
 func (r *Release) HasBeenDeployed() bool {
-	condition := meta.FindStatusCondition(r.Status.Conditions, BindingDeploymentStatusConditionType)
+	condition := meta.FindStatusCondition(r.Status.Conditions, applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed)
 	return condition != nil && condition.Status != metav1.ConditionUnknown
 }
 
@@ -156,13 +153,15 @@ func (r *Release) IsDone() bool {
 // MarkDeployed sets the AllComponentsDeployed status in the Release to True or False with the provided reason and message.
 func (r *Release) MarkDeployed(status metav1.ConditionStatus, reason, message string) {
 	if status != metav1.ConditionUnknown {
-		r.setStatusConditionWithMessage(BindingDeploymentStatusConditionType, status, ReleaseReason(reason), message)
+		r.setStatusConditionWithMessage(applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed,
+			status, ReleaseReason(reason), message)
 	}
 }
 
 // MarkDeploying sets the AllComponentsDeployed status in the Release to Unknown with the provided reason and message.
 func (r *Release) MarkDeploying(reason, message string) {
-	r.setStatusConditionWithMessage(BindingDeploymentStatusConditionType, metav1.ConditionUnknown, ReleaseReason(reason), message)
+	r.setStatusConditionWithMessage(applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed,
+		metav1.ConditionUnknown, ReleaseReason(reason), message)
 }
 
 // MarkFailed registers the completion time and changes the Succeeded condition to False with

--- a/api/v1alpha1/release_types_test.go
+++ b/api/v1alpha1/release_types_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -57,25 +58,25 @@ var _ = Describe("Release type", func() {
 	})
 
 	Context("When HasBeenDeployed method is called", func() {
-		It("should return true when BindingDeploymentStatusConditionType is True in release status", func() {
+		It("should return true when AllComponentsDeployed is True in release status", func() {
 			r.Status.Conditions[0] = metav1.Condition{
-				Type:   BindingDeploymentStatusConditionType,
+				Type:   applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed,
 				Status: metav1.ConditionTrue,
 			}
 			Expect(r.HasBeenDeployed()).To(BeTrue())
 		})
 
-		It("should return true when BindingDeploymentStatusConditionType is False in release status", func() {
+		It("should return true when AllComponentsDeployed is False in release status", func() {
 			r.Status.Conditions[0] = metav1.Condition{
-				Type:   BindingDeploymentStatusConditionType,
+				Type:   applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed,
 				Status: metav1.ConditionFalse,
 			}
 			Expect(r.HasBeenDeployed()).To(BeTrue())
 		})
 
-		It("should return false BindingDeploymentStatusConditionType is Unknown in release status", func() {
+		It("should return false AllComponentsDeployed is Unknown in release status", func() {
 			r.Status.Conditions[0] = metav1.Condition{
-				Type:   BindingDeploymentStatusConditionType,
+				Type:   applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed,
 				Status: metav1.ConditionUnknown,
 			}
 			Expect(r.HasBeenDeployed()).To(BeFalse())
@@ -141,7 +142,8 @@ var _ = Describe("Release type", func() {
 	Context("When MarkDeployed method is called", func() {
 		It("should properly register the status if passed status is true or false", func() {
 			r.MarkDeployed(metav1.ConditionTrue, "CommitsSynced", "3 of 3 components deployed")
-			statusCondition := meta.FindStatusCondition(r.Status.Conditions, BindingDeploymentStatusConditionType)
+			statusCondition := meta.FindStatusCondition(r.Status.Conditions,
+				applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed)
 			Expect(*statusCondition).To(MatchFields(IgnoreExtras, Fields{
 				"Status":  Equal(metav1.ConditionTrue),
 				"Reason":  Equal("CommitsSynced"),
@@ -151,7 +153,8 @@ var _ = Describe("Release type", func() {
 
 		It("should not change the release status if passed status that is neither true nor false", func() {
 			r.MarkDeployed(metav1.ConditionUnknown, "CommitsSynced", "3 of 3 components deployed")
-			statusCondition := meta.FindStatusCondition(r.Status.Conditions, BindingDeploymentStatusConditionType)
+			statusCondition := meta.FindStatusCondition(r.Status.Conditions,
+				applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed)
 			Expect(statusCondition).To(BeNil())
 		})
 	})
@@ -159,7 +162,8 @@ var _ = Describe("Release type", func() {
 	Context("When MarkDeploying method is called", func() {
 		It("should properly register the status to the release", func() {
 			r.MarkDeploying("CommitsUnsynced", "1 of 3 components deployed")
-			statusCondition := meta.FindStatusCondition(r.Status.Conditions, BindingDeploymentStatusConditionType)
+			statusCondition := meta.FindStatusCondition(r.Status.Conditions,
+				applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed)
 			Expect(*statusCondition).To(MatchFields(IgnoreExtras, Fields{
 				"Status":  Equal(metav1.ConditionUnknown),
 				"Reason":  Equal("CommitsUnsynced"),

--- a/controllers/release/release_adapter.go
+++ b/controllers/release/release_adapter.go
@@ -581,7 +581,8 @@ func (a *Adapter) registerGitOpsDeploymentStatus(binding *applicationapiv1alpha1
 	if binding != nil {
 		patch := client.MergeFrom(a.release.DeepCopy())
 
-		condition := meta.FindStatusCondition(binding.Status.ComponentDeploymentConditions, v1alpha1.BindingDeploymentStatusConditionType)
+		condition := meta.FindStatusCondition(binding.Status.ComponentDeploymentConditions,
+			applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed)
 		if condition.Status == metav1.ConditionUnknown {
 			a.release.MarkDeploying(condition.Reason, condition.Message)
 		} else {

--- a/controllers/release/release_adapter_test.go
+++ b/controllers/release/release_adapter_test.go
@@ -889,7 +889,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		// Check that release status properly shows that the binding is deploying
 		binding.Status.ComponentDeploymentConditions = []metav1.Condition{
 			{
-				Type:   appstudiov1alpha1.BindingDeploymentStatusConditionType,
+				Type:   applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed,
 				Status: metav1.ConditionUnknown,
 				Reason: "a", // status.conditions.reason in body should be at least 1 chars long
 			},
@@ -897,13 +897,14 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		err = adapter.registerGitOpsDeploymentStatus(binding)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(!release.HasBeenDeployed()).To(BeTrue())
-		releaseBindingStatus := meta.FindStatusCondition(release.Status.Conditions, appstudiov1alpha1.BindingDeploymentStatusConditionType)
+		releaseBindingStatus := meta.FindStatusCondition(release.Status.Conditions,
+			applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed)
 		Expect(releaseBindingStatus).ToNot(BeNil())
 
 		// Check that the release status properly shows that the binding has deployed
 		binding.Status.ComponentDeploymentConditions = []metav1.Condition{
 			{
-				Type:   appstudiov1alpha1.BindingDeploymentStatusConditionType,
+				Type:   applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed,
 				Status: metav1.ConditionTrue,
 				Reason: "a", // status.conditions.reason in body should be at least 1 chars long
 			},

--- a/gitops/predicates_test.go
+++ b/gitops/predicates_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	"github.com/redhat-appstudio/release-service/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -76,13 +75,13 @@ var _ = Describe("Predicates", Ordered, func() {
 		// Set the binding statuses after they are created
 		bindingUnknownStatus.Status.ComponentDeploymentConditions = []metav1.Condition{
 			{
-				Type:   v1alpha1.BindingDeploymentStatusConditionType,
+				Type:   applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed,
 				Status: metav1.ConditionUnknown,
 			},
 		}
 		bindingTrueStatus.Status.ComponentDeploymentConditions = []metav1.Condition{
 			{
-				Type:   v1alpha1.BindingDeploymentStatusConditionType,
+				Type:   applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed,
 				Status: metav1.ConditionTrue,
 			},
 		}

--- a/gitops/utils.go
+++ b/gitops/utils.go
@@ -18,7 +18,6 @@ package gitops
 
 import (
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	"github.com/redhat-appstudio/release-service/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,13 +30,15 @@ func hasDeploymentFinished(objectOld, objectNew client.Object) bool {
 	var oldCondition, newCondition *metav1.Condition
 
 	if oldBinding, ok := objectOld.(*applicationapiv1alpha1.SnapshotEnvironmentBinding); ok {
-		oldCondition = meta.FindStatusCondition(oldBinding.Status.ComponentDeploymentConditions, v1alpha1.BindingDeploymentStatusConditionType)
+		oldCondition = meta.FindStatusCondition(oldBinding.Status.ComponentDeploymentConditions,
+			applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed)
 		if oldCondition == nil {
 			return false
 		}
 	}
 	if newBinding, ok := objectNew.(*applicationapiv1alpha1.SnapshotEnvironmentBinding); ok {
-		newCondition = meta.FindStatusCondition(newBinding.Status.ComponentDeploymentConditions, v1alpha1.BindingDeploymentStatusConditionType)
+		newCondition = meta.FindStatusCondition(newBinding.Status.ComponentDeploymentConditions,
+			applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed)
 		if newCondition == nil {
 			return false
 		}

--- a/gitops/utils_test.go
+++ b/gitops/utils_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	"github.com/redhat-appstudio/release-service/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -87,7 +86,7 @@ var _ = Describe("Utils", Ordered, func() {
 		// Set the status of the unknown status binding after it is created
 		bindingUnknownStatus.Status.ComponentDeploymentConditions = []metav1.Condition{
 			{
-				Type:   v1alpha1.BindingDeploymentStatusConditionType,
+				Type:   applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed,
 				Status: metav1.ConditionUnknown,
 			},
 		}
@@ -118,7 +117,7 @@ var _ = Describe("Utils", Ordered, func() {
 		It("returns true when the old SnapshotEnvironmentBinding has unknown status and the new one has false status", func() {
 			binding.Status.ComponentDeploymentConditions = []metav1.Condition{
 				{
-					Type:   v1alpha1.BindingDeploymentStatusConditionType,
+					Type:   applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed,
 					Status: metav1.ConditionFalse,
 				},
 			}
@@ -128,7 +127,7 @@ var _ = Describe("Utils", Ordered, func() {
 		It("returns true when the old SnapshotEnvironmentBinding has unknown status and the new one has true status", func() {
 			binding.Status.ComponentDeploymentConditions = []metav1.Condition{
 				{
-					Type:   v1alpha1.BindingDeploymentStatusConditionType,
+					Type:   applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed,
 					Status: metav1.ConditionTrue,
 				},
 			}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.6.0
 	github.com/onsi/gomega v1.24.1
 	github.com/operator-framework/operator-lib v0.10.0
-	github.com/redhat-appstudio/application-api v0.0.0-20221220162209-43696a6ce42f
+	github.com/redhat-appstudio/application-api v0.0.0-20230111181119-3144e2878df0
 	github.com/redhat-appstudio/operator-goodies v0.0.0-20221130140446-010c05bd7471
 	github.com/tektoncd/pipeline v0.41.0
 	k8s.io/api v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,8 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/statsd_exporter v0.22.7/go.mod h1:N/TevpjkIh9ccs6nuzY3jQn9dFqnUakOjnEuMPJJJnI=
 github.com/prometheus/statsd_exporter v0.22.8 h1:Qo2D9ZzaQG+id9i5NYNGmbf1aa/KxKbB9aKfMS+Yib0=
 github.com/prometheus/statsd_exporter v0.22.8/go.mod h1:/DzwbTEaFTE0Ojz5PqcSk6+PFHOPWGxdXVr6yC8eFOM=
-github.com/redhat-appstudio/application-api v0.0.0-20221220162209-43696a6ce42f h1:W9pn2ajgSsPt9A96ept/JF2eLNI3yhUpE7qi7AxsOr4=
-github.com/redhat-appstudio/application-api v0.0.0-20221220162209-43696a6ce42f/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
+github.com/redhat-appstudio/application-api v0.0.0-20230111181119-3144e2878df0 h1:hOg8NOdkofcy2sMC4RJy7erKNk8q4szdDU9ds6TWLoQ=
+github.com/redhat-appstudio/application-api v0.0.0-20230111181119-3144e2878df0/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/redhat-appstudio/integration-service v0.0.0-20221130110641-f5453dea9623 h1:TRWT++4u8YPLNl825OBM6MHV1KX7OfM+kwnt/jvx+PQ=
 github.com/redhat-appstudio/integration-service v0.0.0-20221130110641-f5453dea9623/go.mod h1:r93vQXKEv3zFOV/8ZGs+fZTYPx2xu4CtGvlNoAO0BAY=
 github.com/redhat-appstudio/operator-goodies v0.0.0-20221130140446-010c05bd7471 h1:BB/XtDbzL4txupSVRkPvGf1Jm5tFsK+/yKgLQuDIDc0=


### PR DESCRIPTION
This commit removes the constant that defines the
SnapshotEnvironmentBinding's ComponentDeploymentConditions from the release package and instead imports it from the application-api package.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>