### PR TITLE
feat(HACBS-1307): add rbac wildcard check to ci

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -84,6 +84,12 @@ jobs:
             git --no-pager diff ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen'
             exit 1
           fi
+      - name: Check RBAC wildcards
+        run: |
+          if grep -n "*" config/rbac/*.yaml ; then
+            echo "RBAC files contain wildcards (*)"
+            exit 1
+          fi
       - name: Run Go Tests
         run: make test
       - name: Upload coverage to Codecov


### PR DESCRIPTION
Based on the least privilege principle,
wildcards shouldn't be used anywhere
in RBAC definitions.

Signed-off-by: Martin Malina <mmalina@redhat.com>