### PR TITLE
feat(HACBS-1645): also watch binding status going from nil to true/false

### DIFF
--- a/gitops/utils.go
+++ b/gitops/utils.go
@@ -27,22 +27,23 @@ import (
 // is a SnapshotEnvironmentBinding with the componentDeployment status Unknown and the second
 // passed object is a SnapshotEnvironmentBinding with the componentDeployment status True/False.
 func hasDeploymentFinished(objectOld, objectNew client.Object) bool {
+	var ok bool
+	var oldBinding, newBinding *applicationapiv1alpha1.SnapshotEnvironmentBinding
 	var oldCondition, newCondition *metav1.Condition
 
-	if oldBinding, ok := objectOld.(*applicationapiv1alpha1.SnapshotEnvironmentBinding); ok {
-		oldCondition = meta.FindStatusCondition(oldBinding.Status.ComponentDeploymentConditions,
-			applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed)
-		if oldCondition == nil {
-			return false
-		}
+	if oldBinding, ok = objectOld.(*applicationapiv1alpha1.SnapshotEnvironmentBinding); !ok {
+		return false
 	}
-	if newBinding, ok := objectNew.(*applicationapiv1alpha1.SnapshotEnvironmentBinding); ok {
-		newCondition = meta.FindStatusCondition(newBinding.Status.ComponentDeploymentConditions,
-			applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed)
-		if newCondition == nil {
-			return false
-		}
+	if newBinding, ok = objectNew.(*applicationapiv1alpha1.SnapshotEnvironmentBinding); !ok {
+		return false
 	}
 
-	return oldCondition.Status == metav1.ConditionUnknown && newCondition.Status != metav1.ConditionUnknown
+	oldCondition = meta.FindStatusCondition(oldBinding.Status.ComponentDeploymentConditions,
+		applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed)
+
+	newCondition = meta.FindStatusCondition(newBinding.Status.ComponentDeploymentConditions,
+		applicationapiv1alpha1.ComponentDeploymentConditionAllComponentsDeployed)
+
+	return (oldCondition == nil || oldCondition.Status == metav1.ConditionUnknown) &&
+		(newCondition != nil && newCondition.Status != metav1.ConditionUnknown)
 }


### PR DESCRIPTION
The release controller should reconcile for SnapshotEnvironmentBindings that it owns and has the AllComponentsDeployed status condition go from nonexisting to true/false, similarly to how it reconciles when the condition goes from unknown to true/false. This commit adds that functionality.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>