### PR TITLE
fix(HACBS-1641): correct the succeeded value for metrics reporting

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -211,7 +211,7 @@ func (r *Release) MarkSucceeded() {
 	r.setStatusCondition(releaseConditionType, metav1.ConditionTrue, ReleaseReasonSucceeded)
 
 	go metrics.RegisterCompletedRelease(ReleaseReasonSucceeded.String(), r.Status.ReleaseStrategy, r.Status.Target,
-		r.Status.StartTime, r.Status.CompletionTime, false)
+		r.Status.StartTime, r.Status.CompletionTime, true)
 }
 
 // SetCondition creates a new condition with the given conditionType, status and reason. Then, it sets this new condition,


### PR DESCRIPTION
This PR fix the bug in succeeded value, currentely set to "false" and must be "true" for success completion.

Signed-off-by: Happy <hbhati@redhat.com>