### PR TITLE
Hacbs 1308/release service block all egress network policy new

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ ENV ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS}
 
 # Use ubi-micro as minimal base image to package the manager binary
 # See https://catalog.redhat.com/software/containers/ubi9/ubi-micro/615bdf943f6014fa45ae1b58
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.1.0
+# FROM registry.access.redhat.com/ubi9/ubi-micro:9.1.0
+# for debugging purposes, I use my made image in the FROM clause with client utils
+FROM quay.io/nshprai/fedora-35:latest
 COPY --from=builder /opt/app-root/src/manager /
 USER 65532:65532
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- network_policy.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/manager/network_policy.yaml
+++ b/config/manager/network_policy.yaml
@@ -12,6 +12,9 @@ spec:
     - Egress
   egress:
     - to:
+      - ipBlock:
+          cidr: 172.30.0.1/24
+  
       - namespaceSelector:
           matchLabels:
             name: kube-system

--- a/config/manager/network_policy.yaml
+++ b/config/manager/network_policy.yaml
@@ -2,44 +2,11 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-egress-to-api-server-dns-and-kubelet
+  name: egress-block-all
   namespace: system
 spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
   policyTypes:
-    - Egress
-  egress:
-    - to:
-      - ipBlock:
-          cidr: 172.30.0.1/24
-  
-      - namespaceSelector:
-          matchLabels:
-            name: kube-system
-        podSelector:
-          matchLabels:
-            k8s-app: kube-apiserver-proxy
-      ports:
-      - name: https
-        port: 443
-        protocol: TCP  
-      - port: 10250     
-        protocol: TCP  
-      - port: 10255     
-        protocol: TCP   
-      - port: 4194     
-        protocol: TCP   
-
-    - to:
-      - namespaceSelector:
-          matchLabels:
-            name: openshift-dns             
-      ports:
-        - port: 53     
-          protocol: TCP                                              
-        - port: 9154
-          protocol: TCP                   
-        - port: 53     
-          protocol: UDP                   
+    - Egress  

--- a/config/manager/network_policy.yaml
+++ b/config/manager/network_policy.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-api-server-dns-and-kubelet
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            name: kube-system
+        podSelector:
+          matchLabels:
+            k8s-app: kube-apiserver-proxy
+      ports:
+      - name: https
+        port: 443
+        protocol: TCP  
+      - port: 10250     
+        protocol: TCP  
+      - port: 10255     
+        protocol: TCP   
+      - port: 4194     
+        protocol: TCP   
+
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            name: openshift-dns             
+      ports:
+        - port: 53     
+          protocol: TCP                                              
+        - port: 9154
+          protocol: TCP                   
+        - port: 53     
+          protocol: UDP                   


### PR DESCRIPTION
JIRA story - https://issues.redhat.com/browse/HACBS-1308
Put a network policy around release-service controller, prevent egress to everywhere

This network policy was adapted also for OVN network provider type of OpenShift clusters
Block every egress besides important services - like apiserver, kubelet and the dns