### PR TITLE
fix: ensure binding snapshot matches the release one

### DIFF
--- a/controllers/release/release_adapter.go
+++ b/controllers/release/release_adapter.go
@@ -226,7 +226,7 @@ func (a *Adapter) EnsureSnapshotEnvironmentBindingExists() (reconciler.Operation
 	}
 
 	// Search for an existing binding
-	binding, err := a.loader.GetSnapshotEnvironmentBinding(a.ctx, a.client, releasePlanAdmission)
+	binding, err := a.loader.GetSnapshotEnvironmentBinding(a.ctx, a.client, a.release, releasePlanAdmission)
 	if err != nil && !errors.IsNotFound(err) {
 		return reconciler.RequeueWithError(err)
 	}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -25,7 +25,7 @@ type ObjectLoader interface {
 	GetReleasePlan(ctx context.Context, cli client.Client, release *v1alpha1.Release) (*v1alpha1.ReleasePlan, error)
 	GetReleaseStrategy(ctx context.Context, cli client.Client, releasePlanAdmission *v1alpha1.ReleasePlanAdmission) (*v1alpha1.ReleaseStrategy, error)
 	GetSnapshot(ctx context.Context, cli client.Client, release *v1alpha1.Release) (*applicationapiv1alpha1.Snapshot, error)
-	GetSnapshotEnvironmentBinding(ctx context.Context, cli client.Client, releasePlanAdmission *v1alpha1.ReleasePlanAdmission) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error)
+	GetSnapshotEnvironmentBinding(ctx context.Context, cli client.Client, release *v1alpha1.Release, releasePlanAdmission *v1alpha1.ReleasePlanAdmission) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error)
 	GetSnapshotEnvironmentBindingFromReleaseStatus(ctx context.Context, cli client.Client, release *v1alpha1.Release) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error)
 	GetSnapshotEnvironmentBindingResources(ctx context.Context, cli client.Client, release *v1alpha1.Release, releasePlanAdmission *v1alpha1.ReleasePlanAdmission) (*SnapshotEnvironmentBindingResources, error)
 }
@@ -182,7 +182,7 @@ func (l *loader) GetSnapshot(ctx context.Context, cli client.Client, release *v1
 // GetSnapshotEnvironmentBinding returns the SnapshotEnvironmentBinding associated with the given ReleasePlanAdmission.
 // That association is defined by both the Environment and Application matching between the ReleasePlanAdmission and
 // the SnapshotEnvironmentBinding. If the Get operation fails, an error will be returned.
-func (l *loader) GetSnapshotEnvironmentBinding(ctx context.Context, cli client.Client, releasePlanAdmission *v1alpha1.ReleasePlanAdmission) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error) {
+func (l *loader) GetSnapshotEnvironmentBinding(ctx context.Context, cli client.Client, release *v1alpha1.Release, releasePlanAdmission *v1alpha1.ReleasePlanAdmission) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error) {
 	bindingList := &applicationapiv1alpha1.SnapshotEnvironmentBindingList{}
 	err := cli.List(ctx, bindingList,
 		client.InNamespace(releasePlanAdmission.Namespace),
@@ -192,7 +192,7 @@ func (l *loader) GetSnapshotEnvironmentBinding(ctx context.Context, cli client.C
 	}
 
 	for _, binding := range bindingList.Items {
-		if binding.Spec.Application == releasePlanAdmission.Spec.Application {
+		if binding.Spec.Application == releasePlanAdmission.Spec.Application && binding.Spec.Snapshot == release.Spec.Snapshot {
 			return &binding, nil
 		}
 	}

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -163,9 +163,9 @@ func (l *mockLoader) GetSnapshot(ctx context.Context, cli client.Client, release
 }
 
 // GetSnapshotEnvironmentBinding returns the resource and error passed as values of the context.
-func (l *mockLoader) GetSnapshotEnvironmentBinding(ctx context.Context, cli client.Client, releasePlanAdmission *v1alpha1.ReleasePlanAdmission) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error) {
+func (l *mockLoader) GetSnapshotEnvironmentBinding(ctx context.Context, cli client.Client, release *v1alpha1.Release, releasePlanAdmission *v1alpha1.ReleasePlanAdmission) (*applicationapiv1alpha1.SnapshotEnvironmentBinding, error) {
 	if ctx.Value(SnapshotEnvironmentBindingContextKey) == nil {
-		return l.loader.GetSnapshotEnvironmentBinding(ctx, cli, releasePlanAdmission)
+		return l.loader.GetSnapshotEnvironmentBinding(ctx, cli, release, releasePlanAdmission)
 	}
 	return getMockedResourceAndErrorFromContext(ctx, SnapshotEnvironmentBindingContextKey, &applicationapiv1alpha1.SnapshotEnvironmentBinding{})
 }

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -251,7 +251,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   snapshotEnvironmentBinding,
 				},
 			})
-			resource, err := loader.GetSnapshotEnvironmentBinding(mockContext, nil, nil)
+			resource, err := loader.GetSnapshotEnvironmentBinding(mockContext, nil, nil, nil)
 			Expect(resource).To(Equal(snapshotEnvironmentBinding))
 			Expect(err).To(BeNil())
 		})

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		It("returns an active release plan admission", func() {
 			returnedObject, err := loader.GetActiveReleasePlanAdmission(ctx, k8sClient, releasePlan)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(returnedObject).NotTo(Equal(&v1alpha1.ReleasePlanAdmission{}))
+			Expect(returnedObject).NotTo(BeNil())
 			Expect(returnedObject.Name).To(Equal(releasePlanAdmission.Name))
 		})
 
@@ -114,7 +114,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		It("returns an active release plan admission", func() {
 			returnedObject, err := loader.GetActiveReleasePlanAdmissionFromRelease(ctx, k8sClient, release)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(returnedObject).NotTo(Equal(&v1alpha1.ReleasePlanAdmission{}))
+			Expect(returnedObject).NotTo(BeNil())
 			Expect(returnedObject.Name).To(Equal(releasePlanAdmission.Name))
 		})
 
@@ -178,7 +178,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		It("returns a PipelineRun if the labels match with the release data", func() {
 			returnedObject, err := loader.GetReleasePipelineRun(ctx, k8sClient, release)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(returnedObject).NotTo(Equal(&v1beta1.PipelineRun{}))
+			Expect(returnedObject).NotTo(BeNil())
 			Expect(returnedObject.Name).To(Equal(pipelineRun.Name))
 		})
 
@@ -221,17 +221,26 @@ var _ = Describe("Release Adapter", Ordered, func() {
 
 	Context("When calling GetSnapshotEnvironmentBinding", func() {
 		It("returns a snapshot environment binding if the environment field value matches the release plan admission one", func() {
-			returnedObject, err := loader.GetSnapshotEnvironmentBinding(ctx, k8sClient, releasePlanAdmission)
+			returnedObject, err := loader.GetSnapshotEnvironmentBinding(ctx, k8sClient, release, releasePlanAdmission)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(returnedObject).NotTo(Equal(&applicationapiv1alpha1.SnapshotEnvironmentBinding{}))
+			Expect(returnedObject).NotTo(BeNil())
 			Expect(returnedObject.Name).To(Equal(snapshotEnvironmentBinding.Name))
+		})
+
+		It("fails to return a snapshot environment binding if the snapshot field value doesn't match the one in the release", func() {
+			modifiedRelease := release.DeepCopy()
+			modifiedRelease.Spec.Snapshot = "non-existing-snapshot"
+
+			returnedObject, err := loader.GetSnapshotEnvironmentBinding(ctx, k8sClient, modifiedRelease, releasePlanAdmission)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(returnedObject).To(BeNil())
 		})
 
 		It("fails to return a snapshot environment binding if the environment field value doesn't match the release plan admission one", func() {
 			modifiedReleasePlanAdmission := releasePlanAdmission.DeepCopy()
 			modifiedReleasePlanAdmission.Spec.Environment = "non-existing-environment"
 
-			returnedObject, err := loader.GetSnapshotEnvironmentBinding(ctx, k8sClient, modifiedReleasePlanAdmission)
+			returnedObject, err := loader.GetSnapshotEnvironmentBinding(ctx, k8sClient, release, modifiedReleasePlanAdmission)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(returnedObject).To(BeNil())
 		})
@@ -251,7 +260,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 
 			returnedObject, err := loader.GetSnapshotEnvironmentBindingFromReleaseStatus(ctx, k8sClient, modifiedRelease)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(returnedObject).NotTo(Equal(&applicationapiv1alpha1.SnapshotEnvironmentBinding{}))
+			Expect(returnedObject).NotTo(BeNil())
 			Expect(returnedObject.Name).To(Equal(snapshotEnvironmentBinding.Name))
 		})
 	})


### PR DESCRIPTION
We need to create a binding per snapshot. Without this check we would be returning bindings that are maybe not related with the release at all.

Signed-off-by: David Moreno García <damoreno@redhat.com>