### PR TITLE
feat(HACBS-1096): add a metric that details number of deployments

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -309,6 +309,14 @@ func (in *ReleaseStatus) DeepCopyInto(out *ReleaseStatus) {
 		in, out := &in.CompletionTime, &out.CompletionTime
 		*out = (*in).DeepCopy()
 	}
+	if in.DeploymentStartTime != nil {
+		in, out := &in.DeploymentStartTime, &out.DeploymentStartTime
+		*out = (*in).DeepCopy()
+	}
+	if in.DeploymentCompletionTime != nil {
+		in, out := &in.DeploymentCompletionTime, &out.DeploymentCompletionTime
+		*out = (*in).DeepCopy()
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]v1.Condition, len(*in))

--- a/config/crd/bases/appstudio.redhat.com_releases.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releases.yaml
@@ -37,6 +37,14 @@ spec:
       name: Completion Time
       priority: 1
       type: date
+    - jsonPath: .status.deploymentStartTime
+      name: Deployment Start Time
+      priority: 1
+      type: date
+    - jsonPath: .status.deploymentCompletionTime
+      name: Deployment Completion Time
+      priority: 1
+      type: date
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -149,6 +157,16 @@ spec:
                   - type
                   type: object
                 type: array
+              deploymentCompletionTime:
+                description: DeploymentCompletionTime is the time when the SnapshotEnvironmentBinding
+                  has all components deployed
+                format: date-time
+                type: string
+              deploymentStartTime:
+                description: DeploymentStartTime is the time when the SnapshotEnvironmentBinding
+                  was created
+                format: date-time
+                type: string
               releasePipelineRun:
                 description: ReleasePipelineRun contains the namespaced name of the
                   release PipelineRun executed as part of this release

--- a/controllers/release/release_adapter_test.go
+++ b/controllers/release/release_adapter_test.go
@@ -439,6 +439,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		It("skips the operation if the release has already being deployed", func() {
 			adapter.release.MarkRunning()
 			adapter.release.MarkSucceeded()
+			adapter.release.MarkDeploying(metav1.ConditionFalse, "", "")
 			adapter.release.MarkDeployed("", "")
 
 			result, err := adapter.EnsureSnapshotEnvironmentBindingExists()
@@ -597,6 +598,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			adapter.release.MarkRunning()
 			adapter.release.MarkSucceeded()
 			adapter.release.Status.SnapshotEnvironmentBinding = snapshotEnvironmentBinding.Namespace + "/" + snapshotEnvironmentBinding.Name
+			adapter.release.MarkDeploying(metav1.ConditionFalse, "", "")
 			adapter.release.MarkDeployed("", "")
 
 			result, err := adapter.EnsureSnapshotEnvironmentBindingIsTracked()
@@ -727,6 +729,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		})
 
 		It("registers the deployment status when the binding has been deployed", func() {
+			adapter.release.MarkDeploying(metav1.ConditionFalse, "", "")
 			newSnapshotEnvironmentBinding := snapshotEnvironmentBinding.DeepCopy()
 			newSnapshotEnvironmentBinding.Status.ComponentDeploymentConditions = []metav1.Condition{
 				{


### PR DESCRIPTION
This commit adds two metrics - one that measures the total number of deployments released to managed environments, and one that measures release durations from when the SnapshotEnvironmentBinding was created til the release is marked as deployed.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>