### PR TITLE
fix(HACBS-1720): release not updated when binding goes false to true

### DIFF
--- a/controllers/release/release_adapter.go
+++ b/controllers/release/release_adapter.go
@@ -353,10 +353,10 @@ func (a *Adapter) registerGitOpsDeploymentStatus(binding *applicationapiv1alpha1
 
 	patch := client.MergeFrom(a.release.DeepCopy())
 
-	if condition.Status == metav1.ConditionUnknown {
-		a.release.MarkDeploying(condition.Reason, condition.Message)
+	if condition.Status == metav1.ConditionTrue {
+		a.release.MarkDeployed(condition.Reason, condition.Message)
 	} else {
-		a.release.MarkDeployed(condition.Status, condition.Reason, condition.Message)
+		a.release.MarkDeploying(condition.Status, condition.Reason, condition.Message)
 	}
 
 	return a.client.Status().Patch(a.ctx, a.release, patch)

--- a/controllers/release/release_adapter_test.go
+++ b/controllers/release/release_adapter_test.go
@@ -439,7 +439,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		It("skips the operation if the release has already being deployed", func() {
 			adapter.release.MarkRunning()
 			adapter.release.MarkSucceeded()
-			adapter.release.MarkDeployed(metav1.ConditionTrue, "", "")
+			adapter.release.MarkDeployed("", "")
 
 			result, err := adapter.EnsureSnapshotEnvironmentBindingExists()
 			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
@@ -584,7 +584,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			adapter.release.MarkRunning()
 			adapter.release.MarkSucceeded()
 			adapter.release.Status.SnapshotEnvironmentBinding = snapshotEnvironmentBinding.Namespace + "/" + snapshotEnvironmentBinding.Name
-			adapter.release.MarkDeployed(metav1.ConditionTrue, "", "")
+			adapter.release.MarkDeployed("", "")
 
 			result, err := adapter.EnsureSnapshotEnvironmentBindingIsTracked()
 			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())


### PR DESCRIPTION
The release status should be updated when the AllComponentsDeployed status condition on the SnapshotEnvironmentBinding goes from False to True. This fixes that functionality.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>