### PR TITLE
chore: STONEBLD-777 - tekton-ci: update bundle

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -17,7 +17,7 @@ spec:
       value: 'quay.io/redhat-appstudio/pull-request-builds:release-service-{{ revision }}'
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -15,17 +15,13 @@ spec:
       value: "{{ revision }}"
     - name: output-image
       value: 'quay.io/redhat-appstudio/release-service:{{ revision }}'
-    - name: path-context
-      value: .
-    - name: dockerfile
-      value: Dockerfile
     - name: infra-deployment-update-script
       value: |
         sed -i -e 's|\(https://github.com/redhat-appstudio/release-service/config/default?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/release/kustomization.yaml
         sed -i -e 's|\(https://github.com/redhat-appstudio/release-service/config/monitoring/?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/monitoring/grafana/base/release-service/kustomization.yaml
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:


### PR DESCRIPTION
Switching to new bundle since development of old one was stopped before attempt to migrate to kcp. New bundle is removing dependency on shared secret.