### PR TITLE
feat(HACBS-1308): add an egress network policy

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- network_policy.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/manager/network_policy.yaml
+++ b/config/manager/network_policy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-controller-manager
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Egress
+  egress:
+    - to:
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            apiserver: "true"
+            app: openshift-kube-apiserver
+      ports:
+        - port: 6443
+          protocol: TCP
+    - to:
+      - ipBlock:
+          cidr: 172.20.0.1/32
+      ports:
+        - port: 6443
+          protocol: TCP


### PR DESCRIPTION
This commit adds an Egress Network Policy
to block all outgoing(Egress) traffic from release service
pod(controller-manager)

The `spec.podSelector` contains the name of a pod 
on which we want to apply network policy
`spec.egress` have Whitelist rules to allow the necessary
 traffic to certain pods and namespaces.

## Note
This change is tested on the hyper-shift child cluster(OVN) and
QuickLab SDN and OVN clusters.

Child Hypershift cluster requires adding an endpoint in  
`ipBlock:` `cidr`. 

To get `CIDR` perform `oc get ep -n default` and add
Kubernetes endpoints in `ipBlock`.  This will allow the pod to talk with
k8s API. 

***Reach out to the PR owner if you want to test on the Hypershift cluster.***

## How to test the change

* For testing this change you need to have an Openshift cluster
* Clone your fork of infra-deployment and login into your cluster
* setup `preview.env` follow[ this](https://redhat-appstudio.github.io/infra-deployments/docs/development/deployment.html#setting-preview-mode) for instructions
* In preview.env add this information to the Release service section ~line#44
for testing this PR.
File hack/preview.env should never be included in the commit.
```
## Release service
### Change of the image
export RELEASE_IMAGE_REPO=quay.io/hbhati/release
export RELEASE_IMAGE_TAG=0.37
export RELEASE_SERVICE_PR_OWNER=happybhati
export RELEASE_SERVICE_PR_SHA=8f7114a5dddcc1015309851e3a591c55a4967c30
```
* Run Bootstrap script `./hack/bootstrap-cluster.sh preview ` follow doc for [guide](https://redhat-appstudio.github.io/infra-deployments/docs/development/deployment.html#getting-started)
* once done you can go to Openshift UI and on the side panel click on Networking --> NetworkPolicy
 to verify if you can see `release-service-egress-controller-manager` in the network policy.
* check the controller pod and Argocd UI to verify everything is work normal.
