### PR TITLE
feat(HACBS-1764): cleanup tls errors from webhook in manager pod

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -8,21 +8,6 @@ resources:
 - bases/appstudio.redhat.com_releasestrategies.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
-# patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_releasestrategies.yaml
-- patches/webhook_in_releaseplans.yaml
-- patches/webhook_in_releaseplanadmissions.yaml
-#+kubebuilder:scaffold:crdkustomizewebhookpatch
-
-# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
-# patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_releasestrategies.yaml
-#- patches/cainjection_in_releaseplans.yaml
-#- patches/cainjection_in_releaseplanadmissions.yaml
-#+kubebuilder:scaffold:crdkustomizecainjectionpatch
-
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml


### PR DESCRIPTION
This commit removes the webhook and cainjection files from the crd kustomization file. This removes the tls cert errors that currently pollute the manager pod log. The webhooks still work properly with this change.