### PR TITLE
feat(HACBS-2125): capture user who creates Release

### DIFF
--- a/api/v1alpha1/release_webhook.go
+++ b/api/v1alpha1/release_webhook.go
@@ -17,38 +17,116 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"fmt"
-	"k8s.io/apimachinery/pkg/runtime"
+	"context"
+	"encoding/json"
 	"reflect"
+	"strings"
+
+	"gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-func (r *Release) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
-		Complete()
+const authorLabel = "release.rhtap.openshift.io/author"
+
+// releaseHandler describes the handler for the Release low level webhook
+type releaseHandler struct {
+	Client client.Client
 }
 
-//+kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-release,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=releases,verbs=create;update,versions=v1alpha1,name=vrelease.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-appstudio-redhat-com-v1alpha1-release,mutating=true,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=releases,verbs=create;update,versions=v1alpha1,name=mrelease.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Validator = &Release{}
-
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *Release) ValidateCreate() error {
-	return nil
+// SetupReleaseLowLevelWebhook registers the Release low level webhook with the passed manager.
+func SetupReleaseLowlevelWebhook(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register("/mutate-appstudio-redhat-com-v1alpha1-release", &webhook.Admission{Handler: &releaseHandler{Client: mgr.GetClient()}})
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *Release) ValidateUpdate(old runtime.Object) error {
-	if !reflect.DeepEqual(r.Spec, old.(*Release).Spec) {
-		return fmt.Errorf("release resources spec cannot be updated")
+// Handle takes an incoming admission request and returns an admission response. Create requests add
+// an author label with the current user. Update requests are rejected if the spec or author label
+// are being modified. All other requests are accepted without action.
+func (r *releaseHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	switch req.AdmissionRequest.Operation {
+	case admissionv1.Create:
+		return patchAuthorResponse(req)
+	case admissionv1.Update:
+		var releaseOld, releaseNew Release
+		err := json.Unmarshal(req.Object.Raw, &releaseNew)
+		if err != nil {
+			failedResponse(req.UID, "could not unmarshal the raw incoming Release object")
+		}
+		err = json.Unmarshal(req.OldObject.Raw, &releaseOld)
+		if err != nil {
+			failedResponse(req.UID, "could not unmarshal the raw old Release object")
+		}
+		if !reflect.DeepEqual(releaseNew.Spec, releaseOld.Spec) {
+			return failedResponse(req.UID, "release resources spec cannot be updated")
+		}
+		if releaseNew.GetLabels()[authorLabel] != releaseOld.GetLabels()[authorLabel] {
+			return failedResponse(req.UID, "release author label cannnot be updated")
+		}
 	}
-
-	return nil
+	return admission.Response{
+		AdmissionResponse: admissionv1.AdmissionResponse{
+			UID:     req.UID,
+			Allowed: true,
+			Result: &metav1.Status{
+				Status: "Success",
+			},
+		},
+	}
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *Release) ValidateDelete() error {
-	return nil
+// patchAuthorResponse returns a failed admission.Response that blocks the requested operation.
+func failedResponse(uid types.UID, message string) admission.Response {
+	return admission.Response{
+		AdmissionResponse: admissionv1.AdmissionResponse{
+			UID:     uid,
+			Allowed: false,
+			Result: &metav1.Status{
+				Status:  "Failure",
+				Message: message,
+			},
+		},
+	}
+}
+
+// patchAuthorResponse returns an admission.Response that modifies the CR author label to be
+// the user who issued the request.
+func patchAuthorResponse(req admission.Request) admission.Response {
+	author := strings.Replace(req.UserInfo.Username, ":", "_", -1)     // Colons disallowed in labels
+	author = strings.Replace(author, "system_serviceaccount", "sa", 1) // Effort to shorten long usernames
+	if len(author) > 63 {
+		author = string(author)[0:63] // Max length of label value is 63 chars
+	}
+	var patch []jsonpatch.JsonPatchOperation
+	patch = append(patch, jsonpatch.JsonPatchOperation{
+		Operation: "replace",
+		Path:      "/metadata/labels",
+		Value: map[string]string{
+			authorLabel: author,
+		},
+	})
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return failedResponse(req.UID, "creation of JSON patch adding author label failed")
+	}
+	return admission.Response{
+		AdmissionResponse: admissionv1.AdmissionResponse{
+			UID:     req.UID,
+			Allowed: true,
+			Result: &metav1.Status{
+				Status: "Success",
+			},
+			Patch: patchBytes,
+			PatchType: func() *admissionv1.PatchType {
+				pt := admissionv1.PatchTypeJSONPatch
+				return &pt
+			}(),
+		},
+	}
 }

--- a/api/v1alpha1/release_webhook_test.go
+++ b/api/v1alpha1/release_webhook_test.go
@@ -16,27 +16,41 @@
 package v1alpha1
 
 import (
-	"context"
+	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gomodules.xyz/jsonpatch/v2"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	//+kubebuilder:scaffold:imports
 )
 
-var _ = Describe("Release validation webhook", func() {
+var _ = Describe("Release webhook", Ordered, func() {
 	var release *Release
+	var rHandler *releaseHandler
+	var admissionRequest admission.Request
+	var err error
 
-	BeforeEach(func() {
+	BeforeAll(func() {
+		rHandler = &releaseHandler{
+			Client: mgr.GetClient(),
+		}
+
+		admissionRequest.UserInfo.Username = "admin"
+		admissionRequest.UID = types.UID("123")
+
 		release = &Release{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "appstudio.redhat.com/v1alpha1",
 				Kind:       "Release",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-release-",
-				Namespace:    "default",
+				Name:      "test-release",
+				Namespace: "default",
 			},
 			Spec: ReleaseSpec{
 				Snapshot:    "test-snapshot",
@@ -45,42 +59,246 @@ var _ = Describe("Release validation webhook", func() {
 		}
 	})
 
-	AfterEach(func() {
-		_ = k8sClient.Delete(ctx, release)
-	})
-
-	Context("Update Release CR fields", func() {
-		It("Should error out when updating the resource", func() {
-			ctx := context.Background()
-
-			Expect(k8sClient.Create(ctx, release)).Should(Succeed())
-
-			// Try to update the Release snapshot
-			release.Spec.Snapshot = "another-snapshot"
-
-			err := k8sClient.Update(ctx, release)
-			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("release resources spec cannot be updated"))
+	Context("When a Release is created", func() {
+		BeforeEach(func() {
+			admissionRequest.AdmissionRequest.Operation = admissionv1.Create
 		})
+		It("should add admin as the value for the author label", func() {
+			admissionRequest.Object.Raw, err = json.Marshal(release)
+			Expect(err).NotTo(HaveOccurred())
 
-		It("Should not error out when updating the resource metadata", func() {
-			ctx := context.Background()
+			rsp := rHandler.Handle(ctx, admissionRequest)
+			Expect(rsp.AdmissionResponse.UID).To(Equal(types.UID("123")))
+			Expect(rsp.AdmissionResponse.Allowed).To(BeTrue())
 
-			Expect(k8sClient.Create(ctx, release)).Should(Succeed())
-
-			// Try to update the Release annotations
-			release.ObjectMeta.Annotations = map[string]string{
-				"foo": "bar",
+			var jsonPatch []jsonpatch.JsonPatchOperation
+			err = json.Unmarshal(rsp.AdmissionResponse.Patch, &jsonPatch)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(jsonPatch)).To(Equal(1))
+			patch := jsonPatch[0]
+			Expect(patch.Operation).To(Equal("replace"))
+			Expect(patch.Path).To(Equal("/metadata/labels"))
+			Expect(patch.Value).To(Equal(map[string]interface{}{
+				authorLabel: "admin",
+			}))
+		})
+		It("should overwrite the author label value when one is provided by user", func() {
+			releaseDifferentAuthor := &Release{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Release",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-release",
+					Namespace: "default",
+					Labels: map[string]string{
+						authorLabel: "user",
+					},
+				},
+				Spec: ReleaseSpec{
+					Snapshot:    "test-snapshot",
+					ReleasePlan: "test-releaseplan",
+				},
 			}
 
-			Expect(k8sClient.Update(ctx, release)).ShouldNot(HaveOccurred())
+			admissionRequest.Object.Raw, err = json.Marshal(releaseDifferentAuthor)
+			Expect(err).NotTo(HaveOccurred())
+
+			rsp := rHandler.Handle(ctx, admissionRequest)
+			Expect(rsp.AdmissionResponse.UID).To(Equal(types.UID("123")))
+			Expect(rsp.AdmissionResponse.Allowed).To(BeTrue())
+
+			var jsonPatch []jsonpatch.JsonPatchOperation
+			err = json.Unmarshal(rsp.AdmissionResponse.Patch, &jsonPatch)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(jsonPatch)).To(Equal(1))
+			patch := jsonPatch[0]
+			Expect(patch.Operation).To(Equal("replace"))
+			Expect(patch.Path).To(Equal("/metadata/labels"))
+			Expect(patch.Value).To(Equal(map[string]interface{}{
+				authorLabel: "admin",
+			}))
 		})
 	})
 
-	Describe("When ValidateDelete method is called", func() {
-		It("should return nil", func() {
-			release := &Release{}
-			Expect(release.ValidateDelete()).To(BeNil())
+	Context("When a Release is updated", func() {
+		BeforeEach(func() {
+			admissionRequest.AdmissionRequest.Operation = admissionv1.Update
+		})
+		It("should not allow spec updates", func() {
+			releaseSpecChange := &Release{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Release",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-release",
+					Namespace: "default",
+				},
+				Spec: ReleaseSpec{
+					Snapshot:    "new-snapshot",
+					ReleasePlan: "test-releaseplan",
+				},
+			}
+
+			admissionRequest.Object.Raw, err = json.Marshal(release)
+			Expect(err).NotTo(HaveOccurred())
+			admissionRequest.OldObject.Raw, err = json.Marshal(releaseSpecChange)
+			Expect(err).NotTo(HaveOccurred())
+
+			rsp := rHandler.Handle(ctx, admissionRequest)
+			Expect(rsp.AdmissionResponse.UID).To(Equal(types.UID("123")))
+			Expect(rsp.AdmissionResponse.Allowed).To(BeFalse())
+			Expect(rsp.AdmissionResponse.Result).To(Equal(&metav1.Status{
+				Status:  "Failure",
+				Message: "release resources spec cannot be updated",
+			}))
+		})
+		It("should allow changes to metadata besides the author label", func() {
+			release.ObjectMeta.Labels = map[string]string{
+				authorLabel: "admin",
+			}
+			releaseMetadataChange := &Release{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Release",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-release",
+					Namespace: "default",
+					Labels: map[string]string{
+						authorLabel: "admin",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: ReleaseSpec{
+					Snapshot:    "test-snapshot",
+					ReleasePlan: "test-releaseplan",
+				},
+			}
+
+			admissionRequest.Object.Raw, err = json.Marshal(release)
+			Expect(err).NotTo(HaveOccurred())
+			admissionRequest.OldObject.Raw, err = json.Marshal(releaseMetadataChange)
+			Expect(err).NotTo(HaveOccurred())
+
+			rsp := rHandler.Handle(ctx, admissionRequest)
+			Expect(rsp.AdmissionResponse.Allowed).To(BeTrue())
+			Expect(rsp.AdmissionResponse.Result).To(Equal(&metav1.Status{
+				Status: "Success",
+			}))
+		})
+		It("should not allow the author label to be set to a different value", func() {
+			releaseMetadataChange := &Release{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Release",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-release",
+					Namespace: "default",
+					Labels: map[string]string{
+						authorLabel: "user",
+					},
+				},
+				Spec: ReleaseSpec{
+					Snapshot:    "test-snapshot",
+					ReleasePlan: "test-releaseplan",
+				},
+			}
+
+			admissionRequest.Object.Raw, err = json.Marshal(release)
+			Expect(err).NotTo(HaveOccurred())
+			admissionRequest.OldObject.Raw, err = json.Marshal(releaseMetadataChange)
+			Expect(err).NotTo(HaveOccurred())
+
+			rsp := rHandler.Handle(ctx, admissionRequest)
+			Expect(rsp.AdmissionResponse.UID).To(Equal(types.UID("123")))
+			Expect(rsp.AdmissionResponse.Allowed).To(BeFalse())
+			Expect(rsp.AdmissionResponse.Result).To(Equal(&metav1.Status{
+				Status:  "Failure",
+				Message: "release author label cannnot be updated",
+			}))
+		})
+	})
+
+	Context("When a Release is deleted", func() {
+		BeforeEach(func() {
+			admissionRequest.AdmissionRequest.Operation = admissionv1.Delete
+		})
+		It("should allow the operation not include a patch in the response", func() {
+			rsp := rHandler.Handle(ctx, admissionRequest)
+			Expect(rsp.AdmissionResponse.UID).To(Equal(types.UID("123")))
+			Expect(rsp.AdmissionResponse.Allowed).To(BeTrue())
+			Expect(rsp.AdmissionResponse.Result).To(Equal(&metav1.Status{
+				Status: "Success",
+			}))
+		})
+	})
+
+	Context("When failedResponse is called", func() {
+		It("should return a failed admission response", func() {
+			rsp := failedResponse(types.UID("111"), "message")
+			Expect(rsp.AdmissionResponse.UID).To(Equal(types.UID("111")))
+			Expect(rsp.AdmissionResponse.Allowed).To(BeFalse())
+			Expect(rsp.AdmissionResponse.Result).To(Equal(&metav1.Status{
+				Status:  "Failure",
+				Message: "message",
+			}))
+		})
+	})
+
+	Context("When patchAuthorResponse is called", func() {
+		It("should return an admission response containing a patch", func() {
+			rsp := patchAuthorResponse(admissionRequest)
+			Expect(rsp.AdmissionResponse.UID).To(Equal(types.UID("123")))
+			Expect(rsp.AdmissionResponse.Allowed).To(BeTrue())
+			Expect(rsp.AdmissionResponse.Result).To(Equal(&metav1.Status{
+				Status: "Success",
+			}))
+			Expect(rsp.AdmissionResponse.Patch).NotTo(BeNil())
+			Expect(rsp.AdmissionResponse.PatchType).NotTo(BeNil())
+		})
+		It("should convert : to _ in the author", func() {
+			admissionRequest.UserInfo.Username = "a:b"
+			rsp := patchAuthorResponse(admissionRequest)
+
+			var jsonPatch []jsonpatch.JsonPatchOperation
+			err = json.Unmarshal(rsp.AdmissionResponse.Patch, &jsonPatch)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(jsonPatch)).To(Equal(1))
+			patch := jsonPatch[0]
+			Expect(patch.Value).To(Equal(map[string]interface{}{
+				authorLabel: "a_b",
+			}))
+		})
+		It("should convert 'system:serviceaccount' to 'sa' in the author", func() {
+			admissionRequest.UserInfo.Username = "system:serviceaccount_foo"
+			rsp := patchAuthorResponse(admissionRequest)
+
+			var jsonPatch []jsonpatch.JsonPatchOperation
+			err = json.Unmarshal(rsp.AdmissionResponse.Patch, &jsonPatch)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(jsonPatch)).To(Equal(1))
+			patch := jsonPatch[0]
+			Expect(patch.Value).To(Equal(map[string]interface{}{
+				authorLabel: "sa_foo",
+			}))
+		})
+		It("should convert only use the first 63 characters of the author", func() {
+			admissionRequest.UserInfo.Username = "abcdefghijklmnopqrstuvwxyz_abcdefghijklmnopqrstuvwxyz_1234567890"
+			rsp := patchAuthorResponse(admissionRequest)
+
+			var jsonPatch []jsonpatch.JsonPatchOperation
+			err = json.Unmarshal(rsp.AdmissionResponse.Patch, &jsonPatch)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(jsonPatch)).To(Equal(1))
+			patch := jsonPatch[0]
+			Expect(patch.Value).To(Equal(map[string]interface{}{
+				authorLabel: "abcdefghijklmnopqrstuvwxyz_abcdefghijklmnopqrstuvwxyz_123456789",
+			}))
 		})
 	})
 })

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -45,6 +46,7 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 var ctx context.Context
 var cancel context.CancelFunc
+var mgr manager.Manager
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -84,7 +86,7 @@ var _ = BeforeSuite(func() {
 
 	// start webhook server using Manager
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+	mgr, err = ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:             scheme,
 		Host:               webhookInstallOptions.LocalServingHost,
 		Port:               webhookInstallOptions.LocalServingPort,
@@ -94,7 +96,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	Expect((&Release{}).SetupWebhookWithManager(mgr)).To(Succeed())
+	SetupReleaseLowlevelWebhook(mgr)
 	Expect((&ReleasePlanAdmission{}).SetupWebhookWithManager(mgr)).To(Succeed())
 	Expect((&ReleasePlan{}).SetupWebhookWithManager(mgr)).To(Succeed())
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -11,6 +11,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-appstudio-redhat-com-v1alpha1-release
+  failurePolicy: Fail
+  name: mrelease.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - releases
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-appstudio-redhat-com-v1alpha1-releaseplan
   failurePolicy: Fail
   name: mreleaseplan.kb.io
@@ -50,26 +70,6 @@ metadata:
   creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-appstudio-redhat-com-v1alpha1-release
-  failurePolicy: Fail
-  name: vrelease.kb.io
-  rules:
-  - apiGroups:
-    - appstudio.redhat.com
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - releases
-  sideEffects: None
 - admissionReviewVersions:
   - v1
   clientConfig:

--- a/gitops/gitops_suite_test.go
+++ b/gitops/gitops_suite_test.go
@@ -18,11 +18,12 @@ package gitops
 
 import (
 	"context"
-	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	goodies "github.com/redhat-appstudio/operator-goodies/test"
 	"go/build"
 	"path/filepath"
 	"testing"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	goodies "github.com/redhat-appstudio/operator-goodies/test"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,7 +36,6 @@ import (
 	appstudiov1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 
-	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	//+kubebuilder:scaffold:imports
 )
@@ -85,16 +85,6 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:             clientsetscheme.Scheme,
-		MetricsBindAddress: "0", // this disables metrics
-		LeaderElection:     false,
-	})
-	Expect(err).NotTo(HaveOccurred())
-
-	err = (&appstudiov1alpha1.Release{}).SetupWebhookWithManager(k8sManager)
-	Expect(err).NotTo(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0
 	google.golang.org/api v0.100.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20221014213838-99cd37c6964a // indirect

--- a/main.go
+++ b/main.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"flag"
-	"go.uber.org/zap/zapcore"
 	"os"
+
+	"go.uber.org/zap/zapcore"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -115,11 +116,6 @@ func main() {
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		setupLog.Info("setting up webhooks")
 
-		if err = (&appstudiov1alpha1.Release{}).SetupWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "Release")
-			os.Exit(1)
-		}
-
 		if err = (&appstudiov1alpha1.ReleasePlanAdmission{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "ReleasePlanAdmission")
 			os.Exit(1)
@@ -129,6 +125,8 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "ReleasePlan")
 			os.Exit(1)
 		}
+
+		appstudiov1alpha1.SetupReleaseLowlevelWebhook(mgr)
 	}
 
 	//+kubebuilder:scaffold:builder

--- a/syncer/syncer_suite_test.go
+++ b/syncer/syncer_suite_test.go
@@ -18,11 +18,12 @@ package syncer
 
 import (
 	"context"
-	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	goodies "github.com/redhat-appstudio/operator-goodies/test"
 	"go/build"
 	"path/filepath"
 	"testing"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	goodies "github.com/redhat-appstudio/operator-goodies/test"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,7 +36,6 @@ import (
 	appstudiov1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 
-	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	//+kubebuilder:scaffold:imports
 )
@@ -85,16 +85,6 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:             clientsetscheme.Scheme,
-		MetricsBindAddress: "0", // this disables metrics
-		LeaderElection:     false,
-	})
-	Expect(err).NotTo(HaveOccurred())
-
-	err = (&appstudiov1alpha1.Release{}).SetupWebhookWithManager(k8sManager)
-	Expect(err).NotTo(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {

--- a/tekton/tekton_suite_test.go
+++ b/tekton/tekton_suite_test.go
@@ -18,11 +18,12 @@ package tekton
 
 import (
 	"context"
-	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	goodies "github.com/redhat-appstudio/operator-goodies/test"
 	"go/build"
 	"path/filepath"
 	"testing"
+
+	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	goodies "github.com/redhat-appstudio/operator-goodies/test"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -101,8 +102,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = (&appstudiov1alpha1.Release{}).SetupWebhookWithManager(k8sManager)
-	Expect(err).NotTo(HaveOccurred())
+	appstudiov1alpha1.SetupReleaseLowlevelWebhook(k8sManager) // why do we need the webhooks here??
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
This commit modifies the Release webhook to be a low level one. The main reason for this is so that whenever a Release CR is created or modified, a label is set which depicts the username of who created or modified the CR. This value will end up being used in release pipelines.