### PR TITLE
feat(HACBS-2129): add release reference as a Pipeline parameter

### DIFF
--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -291,6 +291,7 @@ func (a *Adapter) createReleasePipelineRun(releaseStrategy *v1alpha1.ReleaseStra
 	enterpriseContractPolicy *ecapiv1alpha1.EnterpriseContractPolicy,
 	snapshot *applicationapiv1alpha1.Snapshot) (*v1beta1.PipelineRun, error) {
 	pipelineRun := tekton.NewReleasePipelineRun("release-pipelinerun", releaseStrategy.Namespace).
+		WithObjectReferences(a.release).
 		WithOwner(a.release).
 		WithReleaseAndApplicationMetadata(a.release, snapshot.Spec.Application).
 		WithReleaseStrategy(releaseStrategy).

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/operator-framework/operator-lib/handler"
 	"github.com/redhat-appstudio/release-service/api/v1alpha1"
@@ -754,6 +755,12 @@ var _ = Describe("Release Adapter", Ordered, func() {
 
 		It("returns a PipelineRun", func() {
 			Expect(reflect.TypeOf(pipelineRun)).To(Equal(reflect.TypeOf(&v1beta1.PipelineRun{})))
+		})
+
+		It("has the release reference", func() {
+			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Name", strings.ToLower(adapter.release.Kind))))
+			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal",
+				fmt.Sprintf("%s%c%s", adapter.release.Namespace, types.Separator, adapter.release.Name))))
 		})
 
 		It("has owner annotations", func() {


### PR DESCRIPTION
This change adds a new function to declare new Pipeline parameters. This function allows to pass any number of client.Objects. The kind of the object will be used as the parameter name while the value will contain the namespaced name of the object.

In addition, every new ReleasePipelineRun will contain a reference to the Release.