### PR TITLE
feat(HACBS-2127): add automated label to metadata

### DIFF
--- a/metadata/labels.go
+++ b/metadata/labels.go
@@ -31,6 +31,9 @@ var (
 
 	// AuthorLabel is the label name for the user who creates a CR
 	AuthorLabel = fmt.Sprintf("release.%s/author", rhtapDomain)
+
+	// AutomatedLabel is the label name for marking a Release as automated
+	AutomatedLabel = fmt.Sprintf("release.%s/automated", rhtapDomain)
 )
 
 // Prefixes to be used by Release Pipeline Labels


### PR DESCRIPTION
I need to use this in my work in the integration-service, so I am adding it before the [hacbs-2127](https://issues.redhat.com//browse/hacbs-2127) work for release-service