### PR TITLE
feat(HACBS-2127): add automated to release status

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -66,6 +66,9 @@ type ReleaseStatus struct {
 	// +optional
 	Target string `json:"target,omitempty"`
 
+	// Automated indicates whether the Release was created as part of an automated process or manually by an end-user
+	Automated bool `json:"automated,omitempty"`
+
 	// CompletionTime is the time when a Release was completed
 	// +optional
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
@@ -173,6 +176,11 @@ func (r *Release) HasProcessingFinished() bool {
 // HasReleaseFinished checks whether the Release has finished, regardless of the result.
 func (r *Release) HasReleaseFinished() bool {
 	return r.hasPhaseFinished(releasedConditionType)
+}
+
+// IsAutomated checks whether the Release was marked as automated.
+func (r *Release) IsAutomated() bool {
+	return r.Status.Automated
 }
 
 // IsDeployed checks whether the Release was successfully deployed.
@@ -446,6 +454,15 @@ func (r *Release) MarkValidationFailed(message string) {
 
 	r.Status.Validation.Time = &metav1.Time{Time: time.Now()}
 	conditions.SetConditionWithMessage(&r.Status.Conditions, validatedConditionType, metav1.ConditionFalse, FailedReason, message)
+}
+
+// SetAutomated marks the Release as automated.
+func (r *Release) SetAutomated() {
+	if r.IsAutomated() {
+		return
+	}
+
+	r.Status.Automated = true
 }
 
 // getPhaseReason returns the current reason for the given ConditionType or empty string if no condition is found.

--- a/api/v1alpha1/release_types_test.go
+++ b/api/v1alpha1/release_types_test.go
@@ -156,6 +156,28 @@ var _ = Describe("Release type", func() {
 		})
 	})
 
+	Context("When IsAutomated method is called", func() {
+		var release *Release
+
+		BeforeEach(func() {
+			release = &Release{}
+		})
+
+		It("should return true when the automated field in the status is True", func() {
+			release.SetAutomated()
+			Expect(release.IsAutomated()).To(BeTrue())
+		})
+
+		It("should return false when the automated field in the status is False", func() {
+			release.Status.Automated = false
+			Expect(release.IsAutomated()).To(BeFalse())
+		})
+
+		It("should return false when the automated field in the status is missing", func() {
+			Expect(release.IsAutomated()).To(BeFalse())
+		})
+	})
+
 	Context("When IsDeployed method is called", func() {
 		var release *Release
 
@@ -1004,6 +1026,19 @@ var _ = Describe("Release type", func() {
 				"Reason":  Equal(FailedReason.String()),
 				"Status":  Equal(metav1.ConditionFalse),
 			}))
+		})
+	})
+
+	Context("When SetAutomated method is called", func() {
+		var release *Release
+
+		BeforeEach(func() {
+			release = &Release{}
+		})
+
+		It("should set the automated field in the status to True", func() {
+			release.SetAutomated()
+			Expect(release.Status.Automated).To(BeTrue())
 		})
 	})
 

--- a/config/crd/bases/appstudio.redhat.com_releases.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releases.yaml
@@ -63,6 +63,10 @@ spec:
           status:
             description: ReleaseStatus defines the observed state of Release.
             properties:
+              automated:
+                description: Automated indicates whether the Release was created as
+                  part of an automated process or manually by an end-user
+                type: boolean
               completionTime:
                 description: CompletionTime is the time when a Release was completed
                 format: date-time


### PR DESCRIPTION
@davidmogar not sure if you want me to create a `r.markAutomated` function that sets the status or just set the status directly in integration-service. Figured you'd have an opinion on it so only added the field until I hear it