### PR TITLE
fix: remove rewrite

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -18,7 +18,6 @@ spec:
     - name: infra-deployment-update-script
       value: |
         sed -i -e 's|\(https://github.com/redhat-appstudio/release-service/config/default?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/release/kustomization.yaml
-        sed -i -e 's|\(https://github.com/redhat-appstudio/release-service/config/grafana/?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/monitoring/grafana/base/release/kustomization.yaml
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest


### PR DESCRIPTION
We need the latest Release code to be merged before the dashboard is added to infra. This rewrite (or even the previous one) is preventing that to happen as the path doesn't exist yet.