### PR TITLE
chore(HACBS-2270): use go 1.19

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:
@@ -71,9 +71,9 @@ jobs:
             git --no-pager diff ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen'
             exit 1
           fi
-      - uses: dominikh/staticcheck-action@v1.2.0
+      - uses: dominikh/staticcheck-action@v1.3.0
         with:
-          version: "2022.1"
+          version: "2023.1.3"
           install-go: false
       - name: Check manifests
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.18 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19 as builder
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-appstudio/release-service
 
-go 1.18
+go 1.19
 
 require (
 	github.com/enterprise-contract/enterprise-contract-controller/api v0.0.0-20230327185456-5befd172d558


### PR DESCRIPTION
Bumping go version to 1.19 as integration-service is about to bump version to 1.19 and new dependencies may not be buildable with 1.18 if you bump version of integration-service in future