### PR TITLE
fix: remove monitoring label

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-    openshift.io/cluster-monitoring: "true"
   name: system
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
The label cannot be defined here as per the documentation [1].

[1] https://github.com/redhat-appstudio/infra-deployments/tree/main/components/monitoring