### PR TITLE
chore(actions): bump versions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
       - name: Run tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,11 +13,11 @@ jobs:
       OPERATOR_SDK_VERSION: v1.18.0
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Check if dockerimage build is working
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Dependabot opened PRs for bumping the versions of some actions. The dependabot PRs don't meet our gitlint standards, so until we have a solution for that, we should probably manually bump the versions it recommends. This takes care of that for the github actions.