### PR TITLE
feat(HACBS-2427): update network policy to add additional port to CIDR

### DIFF
--- a/config/manager/network_policy.yaml
+++ b/config/manager/network_policy.yaml
@@ -20,7 +20,9 @@ spec:
           protocol: TCP
     - to:
       - ipBlock:
-          cidr: 172.20.0.1/32
+          cidr: 172.20.0.1/32  # CIDR of Kubernetes API Endpoint.
       ports:
         - port: 6443
+          protocol: TCP
+        - port: 443
           protocol: TCP


### PR DESCRIPTION
This commit will add a additional kubernates CIDR
to allow traffic to as per the requirement from ROSA cluster.