### PR TITLE
feat(HACBS-2427): update network policy to add additional port

### DIFF
--- a/config/manager/network_policy.yaml
+++ b/config/manager/network_policy.yaml
@@ -24,3 +24,5 @@ spec:
       ports:
         - port: 6443
           protocol: TCP
+        - port: 443
+          protocol: TCP


### PR DESCRIPTION
This commit will add an additional port to CIDR Block to allow traffic as per the requirement from ROSA cluster.