### PR TITLE
fix(RHTAPBUGS-560): ensure each pipelinerun uses its own subdir

### DIFF
--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -19,8 +19,9 @@ package release
 import (
 	"context"
 	"fmt"
-	"github.com/redhat-appstudio/operator-toolkit/controller"
 	"strings"
+
+	"github.com/redhat-appstudio/operator-toolkit/controller"
 
 	"github.com/go-logr/logr"
 	"github.com/redhat-appstudio/release-service/api/v1alpha1"
@@ -306,7 +307,7 @@ func (a *adapter) createReleasePipelineRun(resources *loader.ProcessingResources
 			resources.ReleasePlanAdmission, resources.ReleaseStrategy, resources.Snapshot).
 		WithOwner(a.release).
 		WithReleaseAndApplicationMetadata(a.release, resources.Snapshot.Spec.Application).
-		WithReleaseStrategy(resources.ReleaseStrategy).
+		WithReleaseStrategy(resources.ReleaseStrategy, a.release).
 		WithEnterpriseContractConfigMap(resources.EnterpriseContractConfigMap).
 		WithEnterpriseContractPolicy(resources.EnterpriseContractPolicy).
 		AsPipelineRun()

--- a/tekton/pipeline_run_test.go
+++ b/tekton/pipeline_run_test.go
@@ -190,7 +190,7 @@ var _ = Describe("PipelineRun", func() {
 		})
 
 		It("can add the ReleaseStrategy information and bundle resolver if present to a PipelineRun object ", func() {
-			releasePipelineRun.WithReleaseStrategy(strategy)
+			releasePipelineRun.WithReleaseStrategy(strategy, release)
 			Expect(releasePipelineRun.Spec.PipelineRef.ResolverRef).NotTo(Equal(tektonv1beta1.ResolverRef{}))
 			Expect(releasePipelineRun.Spec.PipelineRef.ResolverRef.Resolver).To(Equal(tektonv1beta1.ResolverName("bundles")))
 			Expect(releasePipelineRun.Spec.PipelineRef.ResolverRef.Params).To(HaveLen(3))
@@ -208,9 +208,10 @@ var _ = Describe("PipelineRun", func() {
 		})
 
 		It("can add a workspace to the PipelineRun using the given name and PVC", func() {
-			releasePipelineRun.WithWorkspace(workspace, persistentVolumeClaim)
+			releasePipelineRun.WithWorkspace(workspace, persistentVolumeClaim, release.Name)
 			Expect(releasePipelineRun.Spec.Workspaces).Should(ContainElement(HaveField("Name", Equal(workspace))))
 			Expect(releasePipelineRun.Spec.Workspaces).Should(ContainElement(HaveField("PersistentVolumeClaim.ClaimName", Equal(persistentVolumeClaim))))
+			Expect(releasePipelineRun.Spec.Workspaces).Should(ContainElement(HaveField("SubPath", Equal(release.Name+"-$(context.pipelineRun.uid)"))))
 		})
 
 		It("can add the EC task bundle parameter to the PipelineRun", func() {
@@ -248,7 +249,7 @@ var _ = Describe("PipelineRun", func() {
 				os.Setenv("DEFAULT_RELEASE_WORKSPACE_NAME", "")
 				os.Setenv("DEFAULT_RELEASE_PVC", "bar")
 				strategy.Spec.PersistentVolumeClaim = ""
-				releasePipelineRun.WithReleaseStrategy(strategy)
+				releasePipelineRun.WithReleaseStrategy(strategy, release)
 				Expect(releasePipelineRun.Spec.Workspaces).To(BeNil())
 			})
 		})
@@ -257,7 +258,7 @@ var _ = Describe("PipelineRun", func() {
 				os.Setenv("DEFAULT_RELEASE_WORKSPACE_NAME", "foo")
 				os.Setenv("DEFAULT_RELEASE_PVC", "")
 				strategy.Spec.PersistentVolumeClaim = ""
-				releasePipelineRun.WithReleaseStrategy(strategy)
+				releasePipelineRun.WithReleaseStrategy(strategy, release)
 				Expect(releasePipelineRun.Spec.Workspaces).To(BeNil())
 			})
 		})
@@ -266,7 +267,7 @@ var _ = Describe("PipelineRun", func() {
 				os.Setenv("DEFAULT_RELEASE_WORKSPACE_NAME", "foo")
 				os.Setenv("DEFAULT_RELEASE_PVC", "bar")
 				strategy.Spec.PersistentVolumeClaim = ""
-				releasePipelineRun.WithReleaseStrategy(strategy)
+				releasePipelineRun.WithReleaseStrategy(strategy, release)
 				Expect(releasePipelineRun.Spec.Workspaces).Should(ContainElement(HaveField("Name", Equal("foo"))))
 				Expect(releasePipelineRun.Spec.Workspaces).Should(ContainElement(HaveField("PersistentVolumeClaim.ClaimName", Equal("bar"))))
 			})


### PR DESCRIPTION
When release pipelineruns are created, they will always use the same shared workspace (provided by the default PVC, or one defined in the given ReleaseStrategy). This wasn't an issue before, but now that we started using the workspace to share snapshot and other data from task to task, we found one that two simultaneously running pipelineruns can alter each other's data. We need to prevent that.

This typically happens when you have two or more components in your app and so there are multiple pipeline runs, oftentimes running around the same time.

The solution is to use a subdir when passing the PVC in the PR. The subdir is based on the PR's UID, so it should always be unique.

Here's the accompanying PR to enable the failing test in e2e tests: https://github.com/redhat-appstudio/e2e-tests/pull/689