### PR TITLE
feat(HACBS-2422): add finalizer to Release PRs

### DIFF
--- a/metadata/finalizers.go
+++ b/metadata/finalizers.go
@@ -1,0 +1,4 @@
+package metadata
+
+// ReleaseFinalizer is the finalizer name to be added to the Releases
+const ReleaseFinalizer string = "appstudio.redhat.com/release-finalizer"

--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strings"
 	"unicode"
 
@@ -123,9 +124,10 @@ func (r *ReleasePipelineRun) WithObjectReferences(objects ...client.Object) *Rel
 	return r
 }
 
-// WithOwner set's owner annotations to the release PipelineRun.
+// WithOwner sets owner annotations to the release PipelineRun and a finalizer to prevent its deletion.
 func (r *ReleasePipelineRun) WithOwner(release *v1alpha1.Release) *ReleasePipelineRun {
 	_ = libhandler.SetOwnerAnnotations(release, r)
+	controllerutil.AddFinalizer(r, metadata.ReleaseFinalizer)
 
 	return r
 }

--- a/tekton/pipeline_run_test.go
+++ b/tekton/pipeline_run_test.go
@@ -172,6 +172,7 @@ var _ = Describe("PipelineRun", func() {
 		It("can append owner release information to the object as annotations", func() {
 			releasePipelineRun.WithOwner(release)
 			Expect(releasePipelineRun.Annotations).NotTo(BeNil())
+			Expect(releasePipelineRun.Finalizers).NotTo(BeEmpty())
 		})
 
 		It("can append the release Name, Namespace, and Application to a PipelineRun object and that these label key names match the correct label format", func() {


### PR DESCRIPTION
This change adds a finalizer to Release PipelineRuns to avoid their deletion by external entities until the Release service has finished processing them.

Notice that tests relying on finalizeRelease don't check if the PipelineRun was successfully deleted anymore. The removal of the finalizer is not instant so to test that, we would have to use Eventually blocks, which we know are flaky.