### PR TITLE
Aggregate clusterroles

### DIFF
--- a/config/rbac/release_editor_role.yaml
+++ b/config/rbac/release_editor_role.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: release-editor-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
 rules:
 - apiGroups:
   - appstudio.redhat.com

--- a/config/rbac/release_viewer_role.yaml
+++ b/config/rbac/release_viewer_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: release-viewer-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
 rules:
 - apiGroups:
   - appstudio.redhat.com

--- a/config/rbac/releaseplan_editor_role.yaml
+++ b/config/rbac/releaseplan_editor_role.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: releaseplan-editor-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
 rules:
 - apiGroups:
   - appstudio.redhat.com

--- a/config/rbac/releaseplan_viewer_role.yaml
+++ b/config/rbac/releaseplan_viewer_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: releaseplan-viewer-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
 rules:
 - apiGroups:
   - appstudio.redhat.com

--- a/config/rbac/releaseplanadmission_editor_role.yaml
+++ b/config/rbac/releaseplanadmission_editor_role.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: releaseplanadmission-editor-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
 rules:
 - apiGroups:
   - appstudio.redhat.com

--- a/config/rbac/releaseplanadmission_viewer_role.yaml
+++ b/config/rbac/releaseplanadmission_viewer_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: releaseplanadmission-viewer-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
 rules:
 - apiGroups:
   - appstudio.redhat.com

--- a/config/rbac/releasestrategy_editor_role.yaml
+++ b/config/rbac/releasestrategy_editor_role.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: releasestrategy-editor-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
 rules:
 - apiGroups:
   - appstudio.redhat.com

--- a/config/rbac/releasestrategy_viewer_role.yaml
+++ b/config/rbac/releasestrategy_viewer_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: releasestrategy-viewer-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
 rules:
 - apiGroups:
   - appstudio.redhat.com


### PR DESCRIPTION
This change should cause these roles to be aggregated into the system wide view, edit, and admin clusterroles.

Notably, it will also cause the roles to be aggregated into the dedicated-admin role, which is what I'm really after.

Note, if for some reason the aggregation into the more basic ClusterRoles is not desirable, this change can be refined to use `managed.openshift.io/aggregate-to-dedicated-admins: "true"` instead.