### PR TITLE
fix(HACBS-2481): set readOnlyRootFilesystem for controller-manager

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -27,6 +27,8 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
+        securityContext:
+          readOnlyRootFilesystem: true
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,7 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This is addressing an issue reported by kube-linter, see [1] for rule description.

[1]https://github.com/stackrox/kube-linter/blob/main/docs/generated/checks.md#no-read-only-root-fs