### PR TITLE
feat: make use of the toolkit validator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/gomega v1.24.1
 	github.com/operator-framework/operator-lib v0.10.0
 	github.com/redhat-appstudio/application-api v0.0.0-20230427114540-a91722251e0a
-	github.com/redhat-appstudio/operator-toolkit v0.0.0-20230705141436-de654b7a7aed
+	github.com/redhat-appstudio/operator-toolkit v0.0.0-20230901144515-eeb937692f03
 	github.com/tektoncd/pipeline v0.41.0
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.3

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/redhat-appstudio/application-api v0.0.0-20230427114540-a91722251e0a/g
 github.com/redhat-appstudio/integration-service v0.0.0-20221130110641-f5453dea9623 h1:TRWT++4u8YPLNl825OBM6MHV1KX7OfM+kwnt/jvx+PQ=
 github.com/redhat-appstudio/integration-service v0.0.0-20221130110641-f5453dea9623/go.mod h1:r93vQXKEv3zFOV/8ZGs+fZTYPx2xu4CtGvlNoAO0BAY=
 github.com/redhat-appstudio/operator-goodies v0.0.0-20221127150647-a39dc9da8d18 h1:406ioF+WblVzI6S6SzaSrzpcE86nj9rMEJzbE0iOhHY=
-github.com/redhat-appstudio/operator-toolkit v0.0.0-20230705141436-de654b7a7aed h1:4RQmIIyZPm7dZuwtPUvbTLQCNIkUR13zLIVlUE9nunA=
-github.com/redhat-appstudio/operator-toolkit v0.0.0-20230705141436-de654b7a7aed/go.mod h1:6lVK58G/zkoxMoHAmYxzF6La8rMmCeZwOQk6i0dpYZo=
+github.com/redhat-appstudio/operator-toolkit v0.0.0-20230901144515-eeb937692f03 h1:3cHK+a1D+VwhzGoAnC2HXbjkywT/b8jDDaiew2KgpPw=
+github.com/redhat-appstudio/operator-toolkit v0.0.0-20230901144515-eeb937692f03/go.mod h1:7cX2+4KGZLJ4Yoj+1v0iV5hkCGBzbSd9wkNJQjCdDJs=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=


### PR DESCRIPTION
The Operator Toolkit validator allow us to define the validation functions and helps on testing the EnsureReleaseIsValid operation as now those validation functions can be mocked.

Signed-off-by: David Moreno García <damoreno@redhat.com>