### PR TITLE
refactor(HACBS-2550): pass git resolver info for verify-ec task

### DIFF
--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -20,9 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strings"
 	"unicode"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,16 +71,16 @@ func (r *ReleasePipelineRun) AsPipelineRun() *tektonv1beta1.PipelineRun {
 	return &r.PipelineRun
 }
 
-// WithEnterpriseContractConfigMap adds a param providing the verify ec task bundle to the release PipelineRun.
-func (r *ReleasePipelineRun) WithEnterpriseContractConfigMap(configMap *corev1.ConfigMap) *ReleasePipelineRun {
-	enterpriseContractConfigMapBundleField := "verify_ec_task_bundle"
+// WithEnterpriseContractConfigMap adds a param providing the verify ec task git resolver information to the release PipelineRun.
+func (r *ReleasePipelineRun) WithEnterpriseContractConfigMap(ecConfig *corev1.ConfigMap) *ReleasePipelineRun {
+	gitResolverFields := []string{"verify_ec_task_git_url", "verify_ec_task_git_revision", "verify_ec_task_git_pathInRepo"}
 
-	ecTaskBundle := configMap.Data[enterpriseContractConfigMapBundleField]
-
-	r.WithExtraParam(enterpriseContractConfigMapBundleField, tektonv1beta1.ArrayOrString{
-		Type:      tektonv1beta1.ParamTypeString,
-		StringVal: string(ecTaskBundle),
-	})
+	for _, field := range gitResolverFields {
+		r.WithExtraParam(field, tektonv1beta1.ArrayOrString{
+			Type:      tektonv1beta1.ParamTypeString,
+			StringVal: ecConfig.Data[string(field)],
+		})
+	}
 
 	return r
 }

--- a/tekton/pipeline_run_test.go
+++ b/tekton/pipeline_run_test.go
@@ -91,7 +91,9 @@ var _ = Describe("PipelineRun", func() {
 				Kind: "ConfigMap",
 			},
 			Data: map[string]string{
-				"verify_ec_task_bundle": "test-bundle",
+				"verify_ec_task_git_url":        "https://github.com/org/repo.git",
+				"verify_ec_task_git_revision":   "abcdefghijklmnopqrstuvwxyz",
+				"verify_ec_task_git_pathInRepo": "catalog/tasks/verify-ec/task.yaml",
 			},
 		}
 		enterpriseContractPolicy = &ecapiv1alpha1.EnterpriseContractPolicy{
@@ -214,9 +216,26 @@ var _ = Describe("PipelineRun", func() {
 			Expect(releasePipelineRun.Spec.Workspaces).Should(ContainElement(HaveField("PersistentVolumeClaim.ClaimName", Equal(persistentVolumeClaim))))
 		})
 
-		It("can add the EC task bundle parameter to the PipelineRun", func() {
+		It("can add the EC task git resolver parameters to the PipelineRun", func() {
 			releasePipelineRun.WithEnterpriseContractConfigMap(enterpriseContractConfigMap)
-			Expect(releasePipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", Equal(string("test-bundle")))))
+			params := releasePipelineRun.Spec.Params
+			checked := 0
+
+			for i := range params {
+				if params[i].Name == "verify_ec_task_git_url" {
+					Expect(params[i].Value.StringVal).To(Equal("https://github.com/org/repo.git"))
+					checked++
+				}
+				if params[i].Name == "verify_ec_task_git_revision" {
+					Expect(params[i].Value.StringVal).To(Equal("abcdefghijklmnopqrstuvwxyz"))
+					checked++
+				}
+				if params[i].Name == "verify_ec_task_git_pathInRepo" {
+					Expect(params[i].Value.StringVal).To(Equal("catalog/tasks/verify-ec/task.yaml"))
+					checked++
+				}
+			}
+			Expect(checked).To(Equal(3))
 		})
 
 		It("can add an EnterpriseContractPolicy to the PipelineRun", func() {


### PR DESCRIPTION
The EnterpriseContact ConfigMap now contains the information needed for the git resolver of the proper task to use. This commit changes the adapter from passing the task bundle information to passing the task git resolver information.