### PR TITLE
chore: increase commit message line length limit

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -7,7 +7,7 @@ ignore=T5
 line-length=72
 
 [body-max-line-length]
-line-length=72
+line-length=88
 
 [body-first-line-empty]
 


### PR DESCRIPTION
This came up when reviewing this PR from dependabot: https://github.com/redhat-appstudio/release-service/pull/249

Oftentimes it's hard to fit within 72 chars for the commit message body, typically when there is a long url. This should help.

Limit for commit title will stay at 72 chars.