### PR TITLE
fix: update filters and panels

### DIFF
--- a/config/grafana/dashboards/release_dashboard.json
+++ b/config/grafana/dashboards/release_dashboard.json
@@ -22,13 +22,17 @@
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 4,
+  "id": 16,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "064f2b18-a714-4631-997b-1fe80bb695b5"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -72,7 +76,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
@@ -81,7 +85,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (namespace, release_reason) (release_total)",
+          "expr": "sum by (namespace) (release_total)",
           "instant": true,
           "interval": "",
           "legendFormat": "__auto",
@@ -93,7 +97,7 @@
       "type": "stat"
     },
     {
-      "datasource": null,
+      "datasource": {},
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -102,6 +106,8 @@
           },
           "decimals": 0,
           "mappings": [],
+          "max": 1,
+          "min": 0,
           "noValue": "0%",
           "thresholds": {
             "mode": "percentage",
@@ -138,7 +144,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
@@ -147,7 +153,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (namespace, release_reason) (release_total{release_reason=\"Succeeded\"}) / sum by (namespace, release_reason) (release_total)",
+          "expr": "sum by (namespace) (release_total{release_reason=\"Succeeded\"}) / sum by (namespace) (release_total)",
           "instant": true,
           "interval": "",
           "legendFormat": "__auto",
@@ -159,7 +165,7 @@
       "type": "stat"
     },
     {
-      "datasource": null,
+      "datasource": {},
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -205,7 +211,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
@@ -225,7 +231,7 @@
       "type": "stat"
     },
     {
-      "datasource": null,
+      "datasource": {},
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -272,7 +278,7 @@
         "showUnfilled": true,
         "text": {}
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
@@ -294,7 +300,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": null,
+      "datasource": {},
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -302,6 +308,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -321,7 +329,14 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": true
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
@@ -414,9 +429,6 @@
         "tooltip": {
           "mode": "single",
           "sort": "none"
-        },
-        "tooltipOptions": {
-          "mode": "single"
         }
       },
       "pluginVersion": "9.1.6",
@@ -473,7 +485,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": {},
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -519,7 +531,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
@@ -528,7 +540,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (namespace, release_reason) (release_total{release_reason=\"Failed\"})",
+          "expr": "sum by (namespace) (release_total{release_reason=\"Failed\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "__auto",
@@ -540,7 +552,7 @@
       "type": "stat"
     },
     {
-      "datasource": null,
+      "datasource": {},
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -585,7 +597,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
@@ -594,7 +606,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (namespace, release_reason) (release_total{deployment_reason=\"Failed\"})",
+          "expr": "sum by (namespace) (release_total{deployment_reason=\"Failed\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "__auto",
@@ -606,7 +618,7 @@
       "type": "stat"
     },
     {
-      "datasource": null,
+      "datasource": {},
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -653,7 +665,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
@@ -662,7 +674,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (namespace, release_reason) (release_total{validation_reason=\"Failed\"})",
+          "expr": "sum by (namespace) (release_total{validation_reason=\"Failed\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "__auto",
@@ -674,115 +686,130 @@
       "type": "stat"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "064f2b18-a714-4631-997b-1fe80bb695b5"
+      },
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Succeeded"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
-      "fill": 10,
-      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 9,
         "x": 0,
         "y": 6
       },
-      "hiddenSeries": false,
-      "id": 23,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null as zero",
+      "id": 25,
       "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.17",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:489",
-          "alias": "Failed",
-          "color": "#F2495C"
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
         },
-        {
-          "$$hashKey": "object:494",
-          "alias": "Succeeded",
-          "color": "#73BF69"
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
         }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      },
       "targets": [
         {
-          "exemplar": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "064f2b18-a714-4631-997b-1fe80bb695b5"
+          },
+          "editorMode": "code",
           "expr": "sum by (namespace, release_reason) (rate(release_total{release_reason=~\"Failed|Succeeded\"}[$__rate_interval]))",
-          "instant": true,
-          "interval": "",
           "legendFormat": "{{release_reason}}",
+          "range": true,
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Releases",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": {},
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -829,7 +856,7 @@
         "showUnfilled": true,
         "text": {}
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
@@ -851,13 +878,15 @@
       "type": "bargauge"
     },
     {
-      "datasource": null,
+      "datasource": {},
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -880,7 +909,14 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": true
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "decimals": 0,
           "mappings": [],
@@ -917,9 +953,6 @@
         "tooltip": {
           "mode": "single",
           "sort": "none"
-        },
-        "tooltipOptions": {
-          "mode": "single"
         }
       },
       "targets": [
@@ -942,7 +975,7 @@
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 27,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -956,5 +989,6 @@
   "timezone": "",
   "title": "Release Service",
   "uid": "b065ed16540677415b31adb8574bb4d9aa9f74e3",
-  "version": 1
+  "version": 1,
+  "weekStart": ""
 }


### PR DESCRIPTION
The Release Grafana dashboard was not working properly. I found out that some filters were not properly defined. I also saw that one of the panels was deprecated, so I updated it.

In any case, there seems to be an unrelated problem. Just editing the panels and clicking on the query was enough for the panel to start showing values (without any changes). Let's see how it behaves after this change.