### PR TITLE
fix: bump go version

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 jobs:
-  build-and-deploy:
+  report-coverage:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Run tests
         run: make test
       - name: Codecov


### PR DESCRIPTION
We have an error as atomic.Pointer is requested by a dependency and go 1.18 doesn't supply an implementation for it.