### PR TITLE
feat(RHTAPREL-119): make target optional in ReleasePlans

### DIFF
--- a/api/v1alpha1/releaseplan_types.go
+++ b/api/v1alpha1/releaseplan_types.go
@@ -47,7 +47,7 @@ type ReleasePlanSpec struct {
 
 	// Target references where to send the release requests
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-	// +required
+	// +optional
 	Target string `json:"target"`
 }
 

--- a/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
@@ -92,7 +92,6 @@ spec:
                 type: string
             required:
             - application
-            - target
             type: object
           status:
             description: ReleasePlanStatus defines the observed state of ReleasePlan.


### PR DESCRIPTION
If a user wants to run a dev release pipeline with no managed release pipeline, it really doesn't make sense to have a target workspace. This commit makes the target workspace optional instead of required in the ReleasePlan Spec.