### PR TITLE
revert(RHTAPREL-654): revert to using bundle resolver for ec

### DIFF
--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	tektonutils "github.com/redhat-appstudio/release-service/tekton/utils"
 	"os"
 	"reflect"
 	"strings"
+
+	tektonutils "github.com/redhat-appstudio/release-service/tekton/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -879,28 +880,9 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(pipelineName).To(Equal(releasePlanAdmission.Spec.PipelineRef.Params[1].Value))
 		})
 
-		It("contains parameters with the verify ec task git resolver information", func() {
-			url := enterpriseContractConfigMap.Data["verify_ec_task_git_url"]
-			revision := enterpriseContractConfigMap.Data["verify_ec_task_git_revision"]
-			pathInRepo := enterpriseContractConfigMap.Data["verify_ec_task_git_pathInRepo"]
-			params := pipelineRun.Spec.Params
-			checked := 0
-
-			for i := range params {
-				if params[i].Name == "verify_ec_task_git_url" {
-					Expect(params[i].Value.StringVal).To(Equal(string(url)))
-					checked++
-				}
-				if params[i].Name == "verify_ec_task_git_revision" {
-					Expect(params[i].Value.StringVal).To(Equal(string(revision)))
-					checked++
-				}
-				if params[i].Name == "verify_ec_task_git_pathInRepo" {
-					Expect(params[i].Value.StringVal).To(Equal(string(pathInRepo)))
-					checked++
-				}
-			}
-			Expect(checked).To(Equal(3))
+		It("contains a parameter with the verify ec task bundle", func() {
+			bundle := enterpriseContractConfigMap.Data["verify_ec_task_bundle"]
+			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", Equal(string(bundle)))))
 		})
 
 		It("contains a parameter with the json representation of the EnterpriseContractPolicy", func() {
@@ -1630,9 +1612,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 				Namespace: "default",
 			},
 			Data: map[string]string{
-				"verify_ec_task_git_url":        "https://github.com/org/repo.git",
-				"verify_ec_task_git_revision":   "abcdefghijklmnopqrstuvwxyz",
-				"verify_ec_task_git_pathInRepo": "catalog/tasks/verify-ec/task.yaml",
+				"verify_ec_task_bundle": "test-bundle",
 			},
 		}
 		Expect(k8sClient.Create(ctx, enterpriseContractConfigMap)).Should(Succeed())

--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -70,16 +70,16 @@ func (r *ReleasePipelineRun) AsPipelineRun() *tektonv1.PipelineRun {
 	return &r.PipelineRun
 }
 
-// WithEnterpriseContractConfigMap adds a param providing the verify ec task git resolver information to the release PipelineRun.
+// WithEnterpriseContractConfigMap adds a param providing the verify ec task bundle to the release PipelineRun.
 func (r *ReleasePipelineRun) WithEnterpriseContractConfigMap(ecConfig *corev1.ConfigMap) *ReleasePipelineRun {
-	gitResolverFields := []string{"verify_ec_task_git_url", "verify_ec_task_git_revision", "verify_ec_task_git_pathInRepo"}
+	enterpriseContractConfigMapBundleField := "verify_ec_task_bundle"
 
-	for _, field := range gitResolverFields {
-		r.WithExtraParam(field, tektonv1.ParamValue{
-			Type:      tektonv1.ParamTypeString,
-			StringVal: ecConfig.Data[string(field)],
-		})
-	}
+	ecTaskBundle := ecConfig.Data[enterpriseContractConfigMapBundleField]
+
+	r.WithExtraParam(enterpriseContractConfigMapBundleField, tektonv1.ParamValue{
+		Type:      tektonv1.ParamTypeString,
+		StringVal: string(ecTaskBundle),
+	})
 
 	return r
 }

--- a/tekton/pipeline_run_test.go
+++ b/tekton/pipeline_run_test.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	tektonutils "github.com/redhat-appstudio/release-service/tekton/utils"
 	"reflect"
 	"strings"
+
+	tektonutils "github.com/redhat-appstudio/release-service/tekton/utils"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -91,9 +92,7 @@ var _ = Describe("PipelineRun", func() {
 				Kind: "ConfigMap",
 			},
 			Data: map[string]string{
-				"verify_ec_task_git_url":        "https://github.com/org/repo.git",
-				"verify_ec_task_git_revision":   "abcdefghijklmnopqrstuvwxyz",
-				"verify_ec_task_git_pathInRepo": "catalog/tasks/verify-ec/task.yaml",
+				"verify_ec_task_bundle": "test-bundle",
 			},
 		}
 		enterpriseContractPolicy = &ecapiv1alpha1.EnterpriseContractPolicy{
@@ -216,26 +215,9 @@ var _ = Describe("PipelineRun", func() {
 			Expect(releasePipelineRun.Spec.Workspaces).Should(ContainElement(HaveField("PersistentVolumeClaim.ClaimName", Equal(persistentVolumeClaim))))
 		})
 
-		It("can add the EC task git resolver parameters to the PipelineRun", func() {
+		It("can add the EC task bundle parameter to the PipelineRun", func() {
 			releasePipelineRun.WithEnterpriseContractConfigMap(enterpriseContractConfigMap)
-			params := releasePipelineRun.Spec.Params
-			checked := 0
-
-			for i := range params {
-				if params[i].Name == "verify_ec_task_git_url" {
-					Expect(params[i].Value.StringVal).To(Equal("https://github.com/org/repo.git"))
-					checked++
-				}
-				if params[i].Name == "verify_ec_task_git_revision" {
-					Expect(params[i].Value.StringVal).To(Equal("abcdefghijklmnopqrstuvwxyz"))
-					checked++
-				}
-				if params[i].Name == "verify_ec_task_git_pathInRepo" {
-					Expect(params[i].Value.StringVal).To(Equal("catalog/tasks/verify-ec/task.yaml"))
-					checked++
-				}
-			}
-			Expect(checked).To(Equal(3))
+			Expect(releasePipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", Equal(string("test-bundle")))))
 		})
 
 		It("can add an EnterpriseContractPolicy to the PipelineRun", func() {


### PR DESCRIPTION
This commit reverts
https://github.com/redhat-appstudio/release-service/pull/248 and has the operator pass a bundle ref for the verify-enterprise-contract task in the release pipelines once again.