### PR TITLE
fix(RHTAPBUGS-964): override pipelinerun timeout via RPA

### DIFF
--- a/config/crd/bases/appstudio.redhat.com_releaseplanadmissions.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplanadmissions.yaml
@@ -89,6 +89,11 @@ spec:
                     description: Resolver is the name of a Tekton resolver to be used
                       (e.g. git)
                     type: string
+                  timeout:
+                    default: "0"
+                    description: Timeout is value to use to override the tekton default
+                      Pipelinerun timeout
+                    type: string
                 required:
                 - params
                 - resolver

--- a/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
@@ -77,6 +77,11 @@ spec:
                     description: Resolver is the name of a Tekton resolver to be used
                       (e.g. git)
                     type: string
+                  timeout:
+                    default: "0"
+                    description: Timeout is value to use to override the tekton default
+                      Pipelinerun timeout
+                    type: string
                 required:
                 - params
                 - resolver

--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -343,6 +343,7 @@ func (a *adapter) createReleasePipelineRun(resources *loader.ProcessingResources
 		WithReleaseAndApplicationMetadata(a.release, resources.Snapshot.Spec.Application).
 		WithWorkspace(os.Getenv("DEFAULT_RELEASE_WORKSPACE_NAME"), os.Getenv("DEFAULT_RELEASE_PVC")).
 		WithServiceAccount(resources.ReleasePlanAdmission.Spec.ServiceAccount).
+		WithTimeout(resources.ReleasePlanAdmission.Spec.PipelineRef.Timeout).
 		WithPipelineRef(resources.ReleasePlanAdmission.Spec.PipelineRef.ToTektonPipelineRef()).
 		WithEnterpriseContractConfigMap(resources.EnterpriseContractConfigMap).
 		WithEnterpriseContractPolicy(resources.EnterpriseContractPolicy).

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -880,6 +880,11 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(pipelineName).To(Equal(releasePlanAdmission.Spec.PipelineRef.Params[1].Value))
 		})
 
+		It("contains the proper timeout value", func() {
+			timeout := releasePlanAdmission.Spec.PipelineRef.Timeout
+			Expect(pipelineRun.Spec.Timeouts.Pipeline.Duration.String()).To(Equal(string(timeout)))
+		})
+
 		It("contains a parameter with the verify ec task bundle", func() {
 			bundle := enterpriseContractConfigMap.Data["verify_ec_task_bundle"]
 			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", Equal(string(bundle)))))
@@ -1688,6 +1693,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 						{Name: "name", Value: "release-pipeline"},
 						{Name: "kind", Value: "pipeline"},
 					},
+					Timeout: "2h0m0s",
 				},
 				Policy: enterpriseContractPolicy.Name,
 			},

--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 	"unicode"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -157,6 +158,17 @@ func (r *ReleasePipelineRun) WithReleaseAndApplicationMetadata(release *v1alpha1
 // execution of the different Pipeline tasks.
 func (r *ReleasePipelineRun) WithServiceAccount(serviceAccount string) *ReleasePipelineRun {
 	r.Spec.TaskRunTemplate.ServiceAccountName = serviceAccount
+
+	return r
+}
+
+// WithTimeout overwrites the PipelineRun's default timeout value.
+func (r *ReleasePipelineRun) WithTimeout(timeout string) *ReleasePipelineRun {
+	duration, err := time.ParseDuration(timeout)
+	if err == nil {
+		r.Spec.Timeouts = &tektonv1.TimeoutFields{}
+		r.Spec.Timeouts.Pipeline = &v1.Duration{Duration: duration}
+	}
 
 	return r
 }

--- a/tekton/pipeline_run_test.go
+++ b/tekton/pipeline_run_test.go
@@ -51,6 +51,7 @@ var _ = Describe("PipelineRun", func() {
 		workspace             = "test-workspace"
 		persistentVolumeClaim = "test-pvc"
 		serviceAccountName    = "test-service-account"
+		timeout               = "1h0m0s"
 		apiVersion            = "appstudio.redhat.com/v1alpha1"
 		applicationName       = "test-application"
 	)
@@ -207,6 +208,11 @@ var _ = Describe("PipelineRun", func() {
 		It("can add the reference to the service account that should be used", func() {
 			releasePipelineRun.WithServiceAccount(serviceAccountName)
 			Expect(releasePipelineRun.Spec.TaskRunTemplate.ServiceAccountName).To(Equal(serviceAccountName))
+		})
+
+		It("can add the timeout that should be used", func() {
+			releasePipelineRun.WithTimeout(timeout)
+			Expect(releasePipelineRun.Spec.Timeouts.Pipeline.Duration.String()).To(Equal(timeout))
 		})
 
 		It("can add a workspace to the PipelineRun using the given name and PVC", func() {

--- a/tekton/utils/pipeline_ref.go
+++ b/tekton/utils/pipeline_ref.go
@@ -26,6 +26,11 @@ type PipelineRef struct {
 
 	// Params is a slice of parameters for a given resolver
 	Params []Param `json:"params"`
+
+	// Timeout is value to use to override the tekton default Pipelinerun timeout
+	// +kubebuilder:default="0"
+	// +optional
+	Timeout string `json:"timeout,omitempty"`
 }
 
 // Param defines the parameters for a given resolver in PipelineRef


### PR DESCRIPTION
This commit adds a field named timeout to the PipelineRef struct. If it is provided in a ReleasePlanAdmission, it is passed to the release PipelienRun to override the default timeout value.