### PR TITLE
feat(RHTAPREL-711): add shortnames to CRDs

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -159,6 +159,7 @@ type ValidationInfo struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=rel
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Snapshot",type=string,JSONPath=`.spec.snapshot`
 // +kubebuilder:printcolumn:name="ReleasePlan",type=string,JSONPath=`.spec.releasePlan`

--- a/api/v1alpha1/releaseplan_types.go
+++ b/api/v1alpha1/releaseplan_types.go
@@ -65,6 +65,7 @@ type ReleasePlanStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=rp
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Application",type=string,JSONPath=`.spec.application`
 // +kubebuilder:printcolumn:name="Target",type=string,JSONPath=`.spec.target`

--- a/api/v1alpha1/releaseplanadmission_types.go
+++ b/api/v1alpha1/releaseplanadmission_types.go
@@ -71,6 +71,7 @@ type ReleasePlanAdmissionStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=rpa
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Environment",type=string,JSONPath=`.spec.environment`
 // +kubebuilder:printcolumn:name="Origin",type=string,JSONPath=`.spec.origin`

--- a/api/v1alpha1/releaseserviceconfig_types.go
+++ b/api/v1alpha1/releaseserviceconfig_types.go
@@ -35,6 +35,7 @@ type ReleaseServiceConfigStatus struct {
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:shortName=rsc
 //+kubebuilder:subresource:status
 
 // ReleaseServiceConfig is the Schema for the releaseserviceconfigs API

--- a/config/crd/bases/appstudio.redhat.com_releaseplanadmissions.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplanadmissions.yaml
@@ -12,6 +12,8 @@ spec:
     kind: ReleasePlanAdmission
     listKind: ReleasePlanAdmissionList
     plural: releaseplanadmissions
+    shortNames:
+    - rpa
     singular: releaseplanadmission
   scope: Namespaced
   versions:

--- a/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
@@ -12,6 +12,8 @@ spec:
     kind: ReleasePlan
     listKind: ReleasePlanList
     plural: releaseplans
+    shortNames:
+    - rp
     singular: releaseplan
   scope: Namespaced
   versions:

--- a/config/crd/bases/appstudio.redhat.com_releases.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releases.yaml
@@ -12,6 +12,8 @@ spec:
     kind: Release
     listKind: ReleaseList
     plural: releases
+    shortNames:
+    - rel
     singular: release
   scope: Namespaced
   versions:

--- a/config/crd/bases/appstudio.redhat.com_releaseserviceconfigs.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseserviceconfigs.yaml
@@ -12,6 +12,8 @@ spec:
     kind: ReleaseServiceConfig
     listKind: ReleaseServiceConfigList
     plural: releaseserviceconfigs
+    shortNames:
+    - rsc
     singular: releaseserviceconfig
   scope: Namespaced
   versions:


### PR DESCRIPTION
Add the rp shortname for ReleasePlan and rpa shortname for ReleasePlanAdmission.

```
$ oc get rp
NAME   APPLICATION   TARGET
rp     foo           rpas

$ oc get rpa
NAME   ENVIRONMENT   ORIGIN
rpa    production    rpas
```