### PR TITLE
fix(RHTAPBUGS-859): exposes snapshot reference to the UI

### DIFF
--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -867,6 +867,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(pipelineRun.GetLabels()[metadata.PipelinesTypeLabel]).To(Equal("release"))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseNameLabel]).To(Equal(adapter.release.Name))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseNamespaceLabel]).To(Equal(testNamespace))
+			Expect(pipelineRun.GetLabels()[metadata.ReleaseSnapshotLabel]).To(Equal(adapter.release.Spec.Snapshot))
 		})
 
 		It("references the pipeline specified in the ReleasePlanAdmission", func() {

--- a/metadata/labels.go
+++ b/metadata/labels.go
@@ -64,4 +64,7 @@ var (
 
 	// ReleaseNamespaceLabel is the label used to specify the namespace of the Release associated with the PipelineRun
 	ReleaseNamespaceLabel = fmt.Sprintf("%s/%s", releaseLabelPrefix, "namespace")
+
+	// ReleaseSnapshotLabel is the label used to specify the snapshot associated with the PipelineRun
+	ReleaseSnapshotLabel = fmt.Sprintf("%s/%s", rhtapDomain, "snapshot")
 )

--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -147,6 +147,7 @@ func (r *ReleasePipelineRun) WithReleaseAndApplicationMetadata(release *v1alpha1
 		metadata.ReleaseNameLabel:      release.Name,
 		metadata.ReleaseNamespaceLabel: release.Namespace,
 		metadata.ApplicationNameLabel:  applicationName,
+		metadata.ReleaseSnapshotLabel:  release.Spec.Snapshot,
 	}
 	metadata.AddAnnotations(r.AsPipelineRun(), metadata.GetAnnotationsWithPrefix(release, integrationServiceGitopsPkg.PipelinesAsCodePrefix))
 	metadata.AddLabels(r.AsPipelineRun(), metadata.GetLabelsWithPrefix(release, integrationServiceGitopsPkg.PipelinesAsCodePrefix))

--- a/tekton/pipeline_run_test.go
+++ b/tekton/pipeline_run_test.go
@@ -185,6 +185,8 @@ var _ = Describe("PipelineRun", func() {
 				To(Equal(release.Namespace))
 			Expect(releasePipelineRun.Labels["appstudio.openshift.io/application"]).
 				To(Equal(applicationName))
+			Expect(releasePipelineRun.Labels["appstudio.openshift.io/snapshot"]).
+				To(Equal(release.Spec.Snapshot))
 		})
 
 		It("can return a PipelineRun object from a PipelineRun object", func() {


### PR DESCRIPTION
Exposes release pipeline run snapshot information as a label