### PR TITLE
feat(RHTAPREL-764): allow RPs to specify RPAs

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -140,6 +140,12 @@ func (l *loader) GetManagedApplicationComponents(ctx context.Context, cli client
 // If a matching ReleasePlanAdmission is not found or the List operation fails, an error will be returned.
 // If more than one matching ReleasePlanAdmission objects are found, an error will be returned.
 func (l *loader) GetMatchingReleasePlanAdmission(ctx context.Context, cli client.Client, releasePlan *v1alpha1.ReleasePlan) (*v1alpha1.ReleasePlanAdmission, error) {
+	designatedReleasePlanAdmissionName := releasePlan.GetLabels()[metadata.ReleasePlanAdmissionLabel]
+	if designatedReleasePlanAdmissionName != "" {
+		releasePlanAdmission := &v1alpha1.ReleasePlanAdmission{}
+		return releasePlanAdmission, toolkit.GetObject(designatedReleasePlanAdmissionName, releasePlan.Spec.Target, cli, ctx, releasePlanAdmission)
+	}
+
 	releasePlanAdmissions := &v1alpha1.ReleasePlanAdmissionList{}
 	err := cli.List(ctx, releasePlanAdmissions,
 		client.InNamespace(releasePlan.Spec.Target),

--- a/metadata/labels.go
+++ b/metadata/labels.go
@@ -40,6 +40,9 @@ var (
 
 	// AutomatedLabel is the label name for marking a Release as automated
 	AutomatedLabel = fmt.Sprintf("release.%s/automated", rhtapDomain)
+
+	// ReleasePlanAdmissionLabel is the ReleasePlan label for the name of the ReleasePlanAdmission to use
+	ReleasePlanAdmissionLabel = fmt.Sprintf("release.%s/releasePlanAdmission", rhtapDomain)
 )
 
 // Prefixes to be used by Release Pipeline Labels


### PR DESCRIPTION
This commit changes the logic for fetching a ReleasePlanAdmission for a given ReleasePlan. If the ReleasePlan contains a label for the ReleasePlanAdmission to use, that ReleasePlanAdmission is searched for directly. This allows operations to continue even if multiple ReleasePlanAdmissions exist in a single managed namespace.