### PR TITLE
chore(RHTAP-54): set build-source-image to true

### DIFF
--- a/.tekton/release-service-pull-request.yaml
+++ b/.tekton/release-service-pull-request.yaml
@@ -30,6 +30,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: build-source-image
+    value: 'true'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/release-service-push.yaml
+++ b/.tekton/release-service-push.yaml
@@ -27,6 +27,8 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: build-source-image
+    value: 'true'
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
Set the build-source-image parameter to true in the .tekton directory pipelines to comply with Enterprise Contract.