### PR TITLE
feat(RHTAPREL-790): pass taskGitRevision param to plr

### DIFF
--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -345,6 +345,7 @@ func (a *adapter) createManagedPipelineRun(resources *loader.ProcessingResources
 		WithServiceAccount(resources.ReleasePlanAdmission.Spec.ServiceAccount).
 		WithTimeout(resources.ReleasePlanAdmission.Spec.PipelineRef.Timeout).
 		WithPipelineRef(resources.ReleasePlanAdmission.Spec.PipelineRef.ToTektonPipelineRef()).
+		WithTaskGitRevisionParameter(resources.ReleasePlanAdmission.Spec.PipelineRef).
 		WithEnterpriseContractConfigMap(resources.EnterpriseContractConfigMap).
 		WithEnterpriseContractPolicy(resources.EnterpriseContractPolicy).
 		AsPipelineRun()

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -872,14 +872,26 @@ var _ = Describe("Release adapter", Ordered, func() {
 		})
 
 		It("references the pipeline specified in the ReleasePlanAdmission", func() {
-			var pipelineName string
+			var pipelineUrl string
 			resolverParams := pipelineRun.Spec.PipelineRef.ResolverRef.Params
 			for i := range resolverParams {
-				if resolverParams[i].Name == "name" {
-					pipelineName = resolverParams[i].Value.StringVal
+				if resolverParams[i].Name == "url" {
+					pipelineUrl = resolverParams[i].Value.StringVal
 				}
 			}
-			Expect(pipelineName).To(Equal(releasePlanAdmission.Spec.PipelineRef.Params[1].Value))
+			Expect(pipelineUrl).To(Equal(releasePlanAdmission.Spec.PipelineRef.Params[0].Value))
+		})
+
+		It("contains a parameter with the taskGitRevision", func() {
+			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Name", "taskGitRevision")))
+			var revision string
+			resolverParams := pipelineRun.Spec.PipelineRef.ResolverRef.Params
+			for i := range resolverParams {
+				if resolverParams[i].Name == "revision" {
+					revision = resolverParams[i].Value.StringVal
+				}
+			}
+			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", revision)))
 		})
 
 		It("contains the proper timeout value", func() {
@@ -1689,11 +1701,11 @@ var _ = Describe("Release adapter", Ordered, func() {
 				Origin:       "default",
 				Environment:  environment.Name,
 				PipelineRef: &tektonutils.PipelineRef{
-					Resolver: "bundles",
+					Resolver: "git",
 					Params: []tektonutils.Param{
-						{Name: "bundle", Value: "quay.io/some/bundle"},
-						{Name: "name", Value: "release-pipeline"},
-						{Name: "kind", Value: "pipeline"},
+						{Name: "url", Value: "my-url"},
+						{Name: "revision", Value: "my-revision"},
+						{Name: "pathInRepo", Value: "my-path"},
 					},
 					Timeout: "2h0m0s",
 				},

--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -30,6 +30,7 @@ import (
 
 	ecapiv1alpha1 "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
 	"github.com/redhat-appstudio/release-service/metadata"
+	"github.com/redhat-appstudio/release-service/tekton/utils"
 
 	libhandler "github.com/operator-framework/operator-lib/handler"
 	integrationServiceGitopsPkg "github.com/redhat-appstudio/integration-service/gitops"
@@ -159,6 +160,23 @@ func (r *ReleasePipelineRun) WithReleaseAndApplicationMetadata(release *v1alpha1
 // execution of the different Pipeline tasks.
 func (r *ReleasePipelineRun) WithServiceAccount(serviceAccount string) *ReleasePipelineRun {
 	r.Spec.TaskRunTemplate.ServiceAccountName = serviceAccount
+
+	return r
+}
+
+// WithTaskGitRevisionParameter adds the taskGitRevision parameter to the managed Release PipelineRun with the value of the revision
+// from the pipelineRef if the pipelineRef is for a git resolver.
+func (r *ReleasePipelineRun) WithTaskGitRevisionParameter(pipelineRef *utils.PipelineRef) *ReleasePipelineRun {
+	if pipelineRef.Resolver == "git" {
+		for _, p := range pipelineRef.Params {
+			if p.Name == "revision" {
+				r.WithExtraParam("taskGitRevision", tektonv1.ParamValue{
+					Type:      tektonv1.ParamTypeString,
+					StringVal: p.Value,
+				})
+			}
+		}
+	}
 
 	return r
 }

--- a/tekton/pipeline_run_test.go
+++ b/tekton/pipeline_run_test.go
@@ -212,6 +212,35 @@ var _ = Describe("PipelineRun", func() {
 			Expect(releasePipelineRun.Spec.TaskRunTemplate.ServiceAccountName).To(Equal(serviceAccountName))
 		})
 
+		It("can add the taskGitRevision parameter to the PipelineRun object when using a git resolver", func() {
+			pipelineRef := &tektonutils.PipelineRef{
+				Resolver: "git",
+				Params: []tektonutils.Param{
+					{
+						Name:  "revision",
+						Value: "my-revision",
+					},
+				},
+			}
+			releasePipelineRun.WithTaskGitRevisionParameter(pipelineRef)
+			Expect(releasePipelineRun.Spec.Params[0].Name).To(Equal("taskGitRevision"))
+			Expect(releasePipelineRun.Spec.Params[0].Value.StringVal).To(Equal("my-revision"))
+		})
+
+		It("does not add the taskGitRevision parameter to the PipelineRun object when using a bundles resolver", func() {
+			pipelineRef := &tektonutils.PipelineRef{
+				Resolver: "bundles",
+				Params: []tektonutils.Param{
+					{
+						Name:  "revision",
+						Value: "my-revision",
+					},
+				},
+			}
+			releasePipelineRun.WithTaskGitRevisionParameter(pipelineRef)
+			Expect(len(releasePipelineRun.Spec.Params)).To(Equal(0))
+		})
+
 		It("can add the timeout that should be used", func() {
 			releasePipelineRun.WithTimeout(timeout)
 			Expect(releasePipelineRun.Spec.Timeouts.Pipeline.Duration.String()).To(Equal(timeout))


### PR DESCRIPTION
If a git resolver is used in the RPA, pass the revision value from it to the release pipelineRun as the taskGitRevision parameter.