### PR TITLE
feat(RHTAPREL-792): pass taskGitUrl param to plr

### DIFF
--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -345,7 +345,7 @@ func (a *adapter) createManagedPipelineRun(resources *loader.ProcessingResources
 		WithServiceAccount(resources.ReleasePlanAdmission.Spec.ServiceAccount).
 		WithTimeout(resources.ReleasePlanAdmission.Spec.PipelineRef.Timeout).
 		WithPipelineRef(resources.ReleasePlanAdmission.Spec.PipelineRef.ToTektonPipelineRef()).
-		WithTaskGitRevisionParameter(resources.ReleasePlanAdmission.Spec.PipelineRef).
+		WithTaskGitPipelineParameters(resources.ReleasePlanAdmission.Spec.PipelineRef).
 		WithEnterpriseContractConfigMap(resources.EnterpriseContractConfigMap).
 		WithEnterpriseContractPolicy(resources.EnterpriseContractPolicy).
 		AsPipelineRun()

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -882,6 +882,18 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(pipelineUrl).To(Equal(releasePlanAdmission.Spec.PipelineRef.Params[0].Value))
 		})
 
+		It("contains a parameter with the taskGitUrl", func() {
+			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Name", "taskGitUrl")))
+			var url string
+			resolverParams := pipelineRun.Spec.PipelineRef.ResolverRef.Params
+			for i := range resolverParams {
+				if resolverParams[i].Name == "url" {
+					url = resolverParams[i].Value.StringVal
+				}
+			}
+			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", url)))
+		})
+
 		It("contains a parameter with the taskGitRevision", func() {
 			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Name", "taskGitRevision")))
 			var revision string

--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -164,11 +164,17 @@ func (r *ReleasePipelineRun) WithServiceAccount(serviceAccount string) *ReleaseP
 	return r
 }
 
-// WithTaskGitRevisionParameter adds the taskGitRevision parameter to the managed Release PipelineRun with the value of the revision
-// from the pipelineRef if the pipelineRef is for a git resolver.
-func (r *ReleasePipelineRun) WithTaskGitRevisionParameter(pipelineRef *utils.PipelineRef) *ReleasePipelineRun {
+// WithTaskGitPipelineParameters adds the taskGitUrl and taskGitRevision parameters to the managed Release PipelineRun with
+// the value of the url and revision from the pipelineRef if the pipelineRef is for a git resolver.
+func (r *ReleasePipelineRun) WithTaskGitPipelineParameters(pipelineRef *utils.PipelineRef) *ReleasePipelineRun {
 	if pipelineRef.Resolver == "git" {
 		for _, p := range pipelineRef.Params {
+			if p.Name == "url" {
+				r.WithExtraParam("taskGitUrl", tektonv1.ParamValue{
+					Type:      tektonv1.ParamTypeString,
+					StringVal: p.Value,
+				})
+			}
 			if p.Name == "revision" {
 				r.WithExtraParam("taskGitRevision", tektonv1.ParamValue{
 					Type:      tektonv1.ParamTypeString,

--- a/tekton/pipeline_run_test.go
+++ b/tekton/pipeline_run_test.go
@@ -212,32 +212,42 @@ var _ = Describe("PipelineRun", func() {
 			Expect(releasePipelineRun.Spec.TaskRunTemplate.ServiceAccountName).To(Equal(serviceAccountName))
 		})
 
-		It("can add the taskGitRevision parameter to the PipelineRun object when using a git resolver", func() {
+		It("can add the taskGit pipeline parameters to the PipelineRun object when using a git resolver", func() {
 			pipelineRef := &tektonutils.PipelineRef{
 				Resolver: "git",
 				Params: []tektonutils.Param{
 					{
-						Name:  "revision",
-						Value: "my-revision",
+						Name:  "url",
+						Value: "my-url",
 					},
-				},
-			}
-			releasePipelineRun.WithTaskGitRevisionParameter(pipelineRef)
-			Expect(releasePipelineRun.Spec.Params[0].Name).To(Equal("taskGitRevision"))
-			Expect(releasePipelineRun.Spec.Params[0].Value.StringVal).To(Equal("my-revision"))
-		})
-
-		It("does not add the taskGitRevision parameter to the PipelineRun object when using a bundles resolver", func() {
-			pipelineRef := &tektonutils.PipelineRef{
-				Resolver: "bundles",
-				Params: []tektonutils.Param{
 					{
 						Name:  "revision",
 						Value: "my-revision",
 					},
 				},
 			}
-			releasePipelineRun.WithTaskGitRevisionParameter(pipelineRef)
+			releasePipelineRun.WithTaskGitPipelineParameters(pipelineRef)
+			Expect(releasePipelineRun.Spec.Params[0].Name).To(Equal("taskGitUrl"))
+			Expect(releasePipelineRun.Spec.Params[0].Value.StringVal).To(Equal("my-url"))
+			Expect(releasePipelineRun.Spec.Params[1].Name).To(Equal("taskGitRevision"))
+			Expect(releasePipelineRun.Spec.Params[1].Value.StringVal).To(Equal("my-revision"))
+		})
+
+		It("does not add the taskGit pipeline parameters to the PipelineRun object when using a bundles resolver", func() {
+			pipelineRef := &tektonutils.PipelineRef{
+				Resolver: "bundles",
+				Params: []tektonutils.Param{
+					{
+						Name:  "url",
+						Value: "my-url",
+					},
+					{
+						Name:  "revision",
+						Value: "my-revision",
+					},
+				},
+			}
+			releasePipelineRun.WithTaskGitPipelineParameters(pipelineRef)
 			Expect(len(releasePipelineRun.Spec.Params)).To(Equal(0))
 		})
 


### PR DESCRIPTION
If a git resolver is used in the RPA, pass the url value from it to the release pipelineRun as the taskGitUrl parameter.