### PR TITLE
fix(RHTAPREL-810): reorder operations in ReleasePlan controller

### DIFF
--- a/controllers/releaseplan/controller.go
+++ b/controllers/releaseplan/controller.go
@@ -63,8 +63,8 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	adapter := newAdapter(ctx, c.client, releasePlan, loader.NewLoader(), &logger)
 
 	return controller.ReconcileHandler([]controller.Operation{
-		adapter.EnsureOwnerReferenceIsSet,
 		adapter.EnsureMatchingInformationIsSet,
+		adapter.EnsureOwnerReferenceIsSet,
 	})
 }
 


### PR DESCRIPTION
This commit reorders the operations in the ReleasePlan controller so that the application owner reference is set last. If the application is not found, the reconcile loop errors. This means that if the application is not yet created, the other operations will not run, and (at this time) no matching information will be set. With this commit, the matching information is set before, as this does not rely on the application CR existing.