### PR TITLE
feat(RHTAPREL-371): create roleBinding for managed pipelineRun

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -144,6 +144,12 @@ type ProcessingInfo struct {
 	// +optional
 	PipelineRun string `json:"pipelineRun,omitempty"`
 
+	// RoleBinding contains the namespaced name of the roleBinding created for the managed Release PipelineRun
+	// executed as part of this release
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	// +optional
+	RoleBinding string `json:"roleBinding,omitempty"`
+
 	// StartTime is the time when the Release processing started
 	// +optional
 	StartTime *metav1.Time `json:"startTime,omitempty"`

--- a/config/crd/bases/appstudio.redhat.com_releases.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releases.yaml
@@ -213,6 +213,12 @@ spec:
                       Release PipelineRun executed as part of this release
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
+                  roleBinding:
+                    description: RoleBinding contains the namespaced name of the roleBinding
+                      created for the managed Release PipelineRun executed as part
+                      of this release
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
                   startTime:
                     description: StartTime is the time when the Release processing
                       started

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,6 +28,16 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
+  - internalrequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
   - releaseplanadmissions
   verbs:
   - get
@@ -120,4 +130,16 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch

--- a/controllers/release/controller.go
+++ b/controllers/release/controller.go
@@ -54,6 +54,10 @@ type Controller struct {
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=enterprisecontractpolicies/status,verbs=get
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releaseserviceconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=internalrequests,verbs=create;delete;get;list;watch
+//InternalRequests RBAC is required to prevent `forbidden: user system:serviceaccount:release-service:release-service-controller-manager
+//is attempting to grant RBAC permissions not currently held`
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -28,6 +29,7 @@ const (
 	ReleasePlanAdmissionContextKey
 	ReleasePlanContextKey
 	ReleaseServiceConfigContextKey
+	RoleBindingContextKey
 	SnapshotContextKey
 	SnapshotEnvironmentBindingContextKey
 )
@@ -128,6 +130,14 @@ func (l *mockLoader) GetRelease(ctx context.Context, cli client.Client, name, na
 		return l.loader.GetRelease(ctx, cli, name, namespace)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, ReleaseContextKey, &v1alpha1.Release{})
+}
+
+// GetRoleBindingFromReleaseStatus returns the resource and error passed as values of the context.
+func (l *mockLoader) GetRoleBindingFromReleaseStatus(ctx context.Context, cli client.Client, release *v1alpha1.Release) (*rbac.RoleBinding, error) {
+	if ctx.Value(RoleBindingContextKey) == nil {
+		return l.loader.GetRoleBindingFromReleaseStatus(ctx, cli, release)
+	}
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, RoleBindingContextKey, &rbac.RoleBinding{})
 }
 
 // GetManagedReleasePipelineRun returns the resource and error passed as values of the context.

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -9,6 +9,7 @@ import (
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	rbac "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("Release Adapter", Ordered, func() {
@@ -166,6 +167,21 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			})
 			resource, err := loader.GetRelease(mockContext, nil, "", "")
 			Expect(resource).To(Equal(release))
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("calling GetRoleBindingFromReleaseStatus", func() {
+		It("returns the resource and error from the context", func() {
+			roleBinding := &rbac.RoleBinding{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: RoleBindingContextKey,
+					Resource:   roleBinding,
+				},
+			})
+			resource, err := loader.GetRoleBindingFromReleaseStatus(mockContext, nil, nil)
+			Expect(resource).To(Equal(roleBinding))
 			Expect(err).To(BeNil())
 		})
 	})


### PR DESCRIPTION
Create a RoleBinding that grants the serviceAccount that is used to execute the managed PipelineRun permissions in the origin workspace so that it can read the required CRs.