### PR TITLE
fix: modify gosec PR check to log results

### DIFF
--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -23,6 +23,14 @@ jobs:
         id: gosec
         uses: securego/gosec@master
         with:
+          args: -exclude-generated ./...
+        env:
+          GOROOT: ""
+        continue-on-error: true
+      - name: Run Gosec Security Scanner - save SARIF
+        id: gosec-sarif
+        uses: securego/gosec@master
+        with:
           # we let the report trigger a failure using the GitHub Security features.
           args: -exclude-generated -fmt sarif -out results.sarif ./...
         env:
@@ -34,7 +42,7 @@ jobs:
           sarif_file: results.sarif
       - name: Check gosec result
         run: |
-          if [ "${{ steps.gosec.outcome }}" != "success" ]
+          if [ "${{ steps.gosec-sarif.outcome }}" != "success" ]
           then
             echo "Gosec failed. The errors and warnings should be displayed in the PR."
             exit 1


### PR DESCRIPTION
A while ago we modified the workflow to save the results in a SARIF file and then upload to Github to show issues in the UI, but somehow it does not seem to work right now and there is no way to see what's wrong.

This change adds a second run of gosec which will
print the issues in the log directly.

This is related to https://github.com/redhat-appstudio/release-service/pull/363 where we were repeatedly getting failures for gosec, but we couldn't see what the issue was - we just saw that it failed, but there was nothing in the UI. With this change, we can now see the error:

```
Golang errors in file: []:

  > [line 0 : column 0] - error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```

Likely because the error is weird and not related to a specific file, nothing is displayed in Github UI.