### PR TITLE
feat: add default ReleaseServiceConfig

### DIFF
--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -2,6 +2,7 @@
 # used to generate the 'manifests/' directory in a bundle.
 resources:
 - bases/release-service.clusterserviceversion.yaml
+- release_service_config.yaml
 - ../default
 - ../samples
 - ../scorecard

--- a/config/manifests/release_service_config.yaml
+++ b/config/manifests/release_service_config.yaml
@@ -1,0 +1,6 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseServiceConfig
+metadata:
+  name: config
+spec:
+  debug: false


### PR DESCRIPTION
This commit adds a default ReleaseServiceConfig to the manifests directory so one is created when the operator is deployed.