### PR TITLE
feat(RHTAPREL-783): do not requeue automated errors

### DIFF
--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -503,6 +503,9 @@ func (a *adapter) validateAuthor() *controller.ValidationResult {
 	if a.release.Labels[metadata.AutomatedLabel] == "true" && !a.release.IsAutomated() {
 		err := fmt.Errorf("automated not set in status for automated release")
 		a.release.MarkValidationFailed(err.Error())
+		if a.release.CreationTimestamp.Add(5 * time.Minute).Before(time.Now()) {
+			return &controller.ValidationResult{Valid: false}
+		}
 		return &controller.ValidationResult{Err: err}
 	}
 


### PR DESCRIPTION
Our manager logs were being cluttered with automated validations errors as those were requeued forever. Now, if the error appears after 5 minutes of the release being created (time enough for the Integration service to set the Release as automated) the error is reported and the Release marked as failed.