### PR TITLE
fix(RHTAPREL-854): add processing cleanup operation to Release adapter

### DIFF
--- a/controllers/release/controller.go
+++ b/controllers/release/controller.go
@@ -83,6 +83,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		adapter.EnsureReleaseExpirationTimeIsAdded,
 		adapter.EnsureReleaseIsProcessed,
 		adapter.EnsureReleaseProcessingIsTracked,
+		adapter.EnsureReleaseProcessingResourcesAreCleanedUp,
 		adapter.EnsureReleaseIsCompleted,
 	})
 }


### PR DESCRIPTION
The Release Processing resources were cleaned up as part of the operation that tracks the Processing status and if an error occurred cleaning them up, it was not retried. This commit breaks the cleanup out into its own operation that will run once the Release is marked as Processed and properly retries if an error occurs during cleanup.