### PR TITLE
fix: remove pattern

### DIFF
--- a/api/v1alpha1/releaseplan_types.go
+++ b/api/v1alpha1/releaseplan_types.go
@@ -66,7 +66,6 @@ type ReleasePlanSpec struct {
 // MatchedReleasePlanAdmission defines the relevant information for a matched ReleasePlanAdmission.
 type MatchedReleasePlanAdmission struct {
 	// Name contains the namespaced name of the releasePlanAdmission
-	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +optional
 	Name string `json:"name,omitempty"`
 

--- a/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
@@ -184,7 +184,6 @@ spec:
                     type: boolean
                   name:
                     description: Name contains the namespaced name of the releasePlanAdmission
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                 type: object
             type: object


### PR DESCRIPTION
The release-service deployment is CrashLooping right now. It is possible that this is caused by multiple RP/RPAs being reconciled because an error that arises whenever the name of a matched RPA is set to empty string. This is a quick fix to remove the pattern check and see if this improves the situation.