### PR TITLE
fix: remove RP and RPA controllers

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -19,13 +19,11 @@ package controllers
 import (
 	"github.com/redhat-appstudio/operator-toolkit/controller"
 	"github.com/redhat-appstudio/release-service/controllers/release"
-	"github.com/redhat-appstudio/release-service/controllers/releaseplan"
-	"github.com/redhat-appstudio/release-service/controllers/releaseplanadmission"
 )
 
 // EnabledControllers is a slice containing references to all the controllers that have to be registered
 var EnabledControllers = []controller.Controller{
 	&release.Controller{},
-	&releaseplan.Controller{},
-	&releaseplanadmission.Controller{},
+	//&releaseplan.Controller{},
+	//&releaseplanadmission.Controller{},
 }


### PR DESCRIPTION
The release-service pod is CrashLooping right now. This could be caused by reconciliation problems on the RP and RPA controllers or by a high resource consumption. This change disable the controllers as a quick fix to see if the situation improves.