### PR TITLE
fix(KONFLUX-8327): check origin when fetching rpa

### DIFF
--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -1684,7 +1684,8 @@ func (a *adapter) validatePipelineDefined() *controller.ValidationResult {
 		}
 		releasePlanAdmission, err := a.loader.GetActiveReleasePlanAdmissionFromRelease(a.ctx, a.client, a.release)
 		if err != nil {
-			if errors.IsNotFound(err) || strings.Contains(err.Error(), "with auto-release label set to false") {
+			if errors.IsNotFound(err) || strings.Contains(err.Error(), "with auto-release label set to false") ||
+				strings.Contains(err.Error(), "Origin of the releasePlanAdmission") {
 				a.release.MarkValidationFailed(err.Error())
 				return &controller.ValidationResult{Valid: false}
 			}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -124,6 +124,11 @@ func (l *loader) GetMatchingReleasePlanAdmission(ctx context.Context, cli client
 		if err != nil {
 			return nil, err
 		}
+		if releasePlanAdmission.Spec.Origin != releasePlan.Namespace {
+			return nil, fmt.Errorf("releasePlan (%+s) targets releasePlanAdmission (%+s) by label, but the Origin"+
+				" of the releasePlanAdmission (%+s) does not match the namespace of the releasePlan (%+s)",
+				releasePlan.Name, designatedReleasePlanAdmissionName, releasePlanAdmission.Spec.Origin, releasePlan.Namespace)
+		}
 		return releasePlanAdmission, nil
 	}
 


### PR DESCRIPTION
This commit adds a check to the loader function that retrieves matching ReleasePlanAdmissions. When the rpa label on the ReleasePlan is not used, things work normally. However, when you do use the label, as many users do, we simply return the ReleasePlanAdmission without checking that its Origin matches the namespace of the ReleasePlan. This causes issues further down the line. This commit remedies that.