### PR TITLE
fix(RELEASE-1370): limit the taskRuns race condition with the update

### DIFF
--- a/controllers/release/controller.go
+++ b/controllers/release/controller.go
@@ -114,7 +114,7 @@ func (c *Controller) Register(mgr ctrl.Manager, log *logr.Logger, _ cluster.Clus
 				Kind:  "Release",
 				Group: "appstudio.redhat.com",
 			},
-		}, builder.WithPredicates(tekton.ReleasePipelineRunSucceededPredicate())).
+		}, builder.WithPredicates(tekton.ReleasePipelineRunLifecyclePredicate())).
 		Complete(c)
 }
 

--- a/tekton/utils.go
+++ b/tekton/utils.go
@@ -17,6 +17,8 @@ limitations under the License.
 package tekton
 
 import (
+	"reflect"
+
 	"github.com/konflux-ci/release-service/metadata"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"knative.dev/pkg/apis"
@@ -47,4 +49,17 @@ func hasPipelineSucceeded(object client.Object) bool {
 	}
 
 	return false
+}
+
+// hasFinalizersChanged returns true if the finalizers have changed between old and new objects.
+// This helps detect when other controllers (like Tekton) are modifying finalizers during deletion.
+func hasFinalizersChanged(oldObj, newObj client.Object) bool {
+	if oldObj == nil || newObj == nil {
+		return false
+	}
+
+	oldFinalizers := oldObj.GetFinalizers()
+	newFinalizers := newObj.GetFinalizers()
+
+	return !reflect.DeepEqual(oldFinalizers, newFinalizers)
 }

--- a/tekton/utils_test.go
+++ b/tekton/utils_test.go
@@ -86,4 +86,94 @@ var _ = Describe("Utils", Ordered, func() {
 			Expect(hasPipelineSucceeded(pipelineRun)).To(BeTrue())
 		})
 	})
+
+	When("hasFinalizersChanged is called", func() {
+		It("should return false when both objects are nil", func() {
+			Expect(hasFinalizersChanged(nil, nil)).To(BeFalse())
+		})
+
+		It("should return false when the old object is nil", func() {
+			pipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").Build()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasFinalizersChanged(nil, pipelineRun)).To(BeFalse())
+		})
+
+		It("should return false when the new object is nil", func() {
+			pipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").Build()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasFinalizersChanged(pipelineRun, nil)).To(BeFalse())
+		})
+
+		It("should return false when the finalizers are identical", func() {
+			oldPipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
+				WithFinalizer("finalizer1").
+				WithFinalizer("finalizer2").
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			newPipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
+				WithFinalizer("finalizer1").
+				WithFinalizer("finalizer2").
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(hasFinalizersChanged(oldPipelineRun, newPipelineRun)).To(BeFalse())
+		})
+
+		It("should return true when finalizers are added to the new object", func() {
+			oldPipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
+				WithFinalizer("finalizer1").
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			newPipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
+				WithFinalizer("finalizer1").
+				WithFinalizer("finalizer2").
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(hasFinalizersChanged(oldPipelineRun, newPipelineRun)).To(BeTrue())
+		})
+
+		It("should return true when finalizers are removed from the new object", func() {
+			oldPipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
+				WithFinalizer("finalizer1").
+				WithFinalizer("finalizer2").
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			newPipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
+				WithFinalizer("finalizer1").
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(hasFinalizersChanged(oldPipelineRun, newPipelineRun)).To(BeTrue())
+		})
+
+		It("should return true when finalizers are reordered in the new object", func() {
+			oldPipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
+				WithFinalizer("finalizer1").
+				WithFinalizer("finalizer2").
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			newPipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
+				WithFinalizer("finalizer2").
+				WithFinalizer("finalizer1").
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(hasFinalizersChanged(oldPipelineRun, newPipelineRun)).To(BeTrue())
+		})
+
+		It("should return false when both objects have no finalizers", func() {
+			oldPipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			newPipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(hasFinalizersChanged(oldPipelineRun, newPipelineRun)).To(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
## Describe your changes
The Release controller and Tekton controller were concurrently modifying PipelineRun resources, causing conflicts when removing finalizers. This resulted in stuck finalizers that prevented PipelineRun deletion, leading to resource leaks.

The root cause was the controller's event predicate logic, which had a notification gap - it wasn't being told when other controllers (like Tekton) started deleting or modifying PipelineRuns.
It was led to the controller using stale cached data, resulting in numerous conflict errors during patching and failures for finalizer removals.

This solution enhances the controller's event detection to respond to relevant changes immediately.

- DeleteFunc now triggers when PipelineRun deletion starts
- UpdateFunc now detects finalizer changes (not just success)
- New utility added, hasFinalizersChanged(), to detect modifications

##Relevant Jira
[RELEASE-1370](https://issues.redhat.com/browse/RELEASE-1370)

Signed-off-by: elenagerman [elgerman@redhat.com](mailto:elgerman@redhat.com)

**Full backwards compatibility:**
No breaking changes or API modifications, and 100% of the existing functionality preserved.
The base code logic was internally enhanced to improve reliability in race condition situations.
