### PR TITLE
fix: pin setup-envtest to an older version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,8 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	# That pseudo-version refers to commit b9bccfd41914, which was still compatible with Go 1.24.
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20251010203701-b9bccfd41914
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
Go tests started failing because the latest version requires Go 1.25. So let's try pinning to a previous version.