### PR TITLE
feat(RELEASE-1902): support for merge queues

### DIFF
--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -9,6 +9,8 @@ on:  # yamllint disable-line rule:truthy
     paths:
       - '**.go'
   workflow_dispatch:
+  merge_group:
+    types: [checks_requested]
 jobs:
   gosec:
     name: Check GO security

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,8 @@ on:
       - opened
       - synchronize
       - reopened
+  merge_group:
+    types: [checks_requested]
 jobs:
   go:
     name: Check sources

--- a/.tekton/release-service-pull-request.yaml
+++ b/.tekton/release-service-pull-request.yaml
@@ -8,9 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request"
+      (event == "pull_request"
       && target_branch == "main"
-      && (!has(body.pull_request) || !body.pull_request.draft)
+      && (!has(body.pull_request) || !body.pull_request.draft)) || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: release-service


### PR DESCRIPTION
Merge queues require the CI to retrigger correctly in order to pass the branch protection checks. Modify the CI definitions to trigger the CI on merge queues event types
- Github workflows are now triggered on merge_group events
- Tekton pull request pipeline is now triggered on push events

To my knowledge, the integration test itself doesn't need any modifications since it doesn't require the PR number to work correctly. (PR number will be missing in CI triggered by merge queue, which can potentially break the scripts if this value is ever used.)