### PR TITLE
fix(RELEASE-1902): fix e2e tests on merge queues

### DIFF
--- a/.tekton/release-service-push.yaml
+++ b/.tekton/release-service-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "main") || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: release-service


### PR DESCRIPTION
The reason e2e tests fail on merge queue is due to missing image. The image is missing because the event is a "push" and thus test-metadata step expects the image tag to not have the "on-pr-" prefix. Images without this prefix are only created with the push pipeline, which means that this pipeline also has to be triggered on merge queue events.