### PR TITLE
feat: onboard to coverport

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,3 +19,6 @@ jobs:
         run: make test
       - name: Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit-tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -96,6 +96,8 @@ jobs:
         run: make test
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
+        with:
+          flags: unit-tests
       - name: Ensure make build succeeds
         run: make build
       - name: Ensure make bundle succeeds

--- a/.tekton/release-service-pull-request.yaml
+++ b/.tekton/release-service-pull-request.yaml
@@ -38,10 +38,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-  - name: hermetic
-    value: "true"
-  - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -231,6 +227,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - ENABLE_COVERAGE=true
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: SOURCE_ARTIFACT

--- a/.tekton/release-service-push.yaml
+++ b/.tekton/release-service-push.yaml
@@ -250,6 +250,50 @@ spec:
         operator: in
         values:
         - "true"
+    - name: build-instrumented-image
+      params:
+      - name: IMAGE
+        value: $(params.output-image).instrumented
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: "false"
+      - name: PREFETCH_INPUT
+        value: ""
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+        - ENABLE_COVERAGE=true
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.5@sha256:fb3b36f1f800960dd3eb6291c9f8802b7305608a61b27310a541f53a716844a3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
     - name: build-image-index
       params:
       - name: IMAGE

--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -63,7 +63,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: tasks/test-metadata/0.3/test-metadata.yaml
+            value: tasks/test-metadata/0.4/test-metadata.yaml
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
@@ -152,9 +152,9 @@ spec:
         - name: credentials-secret-name
           value: $(params.konflux-test-infra-secret)
         - name: component-image-repository
-          value: $(tasks.test-metadata.results.container-repo)
+          value: $(tasks.test-metadata.results.instrumented-container-repo)
         - name: component-image-tag
-          value: $(tasks.test-metadata.results.container-tag)
+          value: $(tasks.test-metadata.results.instrumented-container-tag)
         - name: oci-credentials
           value: konflux-test-infra
         - name: build-credentials
@@ -196,11 +196,36 @@ spec:
         - name: job-spec
           value: "$(tasks.test-metadata.results.job-spec)"
         - name: component-image
-          value: $(tasks.test-metadata.results.container-image)
+          value: "$(tasks.test-metadata.results.instrumented-container-image)"
         - name: cluster-access-secret-name
           value: kfg-$(context.pipelineRun.name)
         - name: test-environment
           value: "upstream"
+    - name: collect-and-upload-coverage
+      runAfter:
+        - konflux-e2e-tests
+      params:
+        - name: instrumented-images
+          value: "$(tasks.test-metadata.results.instrumented-container-repo):$(tasks.test-metadata.results.instrumented-container-tag)"
+        - name: cluster-access-secret-name
+          value: kfg-$(context.pipelineRun.name)
+        - name: test-name
+          value: e2e-tests
+        - name: oci-container
+          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
+        - name: codecov-flags
+          value: e2e-tests
+        - name: credentials-secret-name
+          value: "coverport-secrets"
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/coverport-coverage/0.1/coverport-coverage.yaml
   finally:
     - name: store-pipeline-status
       when:


### PR DESCRIPTION
More information [here](https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1763648933621269)

With this change codecov will report directly in the PR about the e2e test coverage:
<img width="679" height="708" alt="Screenshot 2025-11-25 at 10 16 28" src="https://github.com/user-attachments/assets/d0b57e08-7158-490e-b922-eee62a4121f7" />
