### PR TITLE
feat(RELEASE-1965): keep previousRelease when retrying a release

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -233,6 +233,14 @@ func (l *loader) GetPreviousRelease(ctx context.Context, cli client.Client, rele
 			possiblePreviousRelease.CreationTimestamp.After(release.CreationTimestamp.Time) {
 			continue
 		}
+		// Ignore a release that failed previously
+		if possiblePreviousRelease.IsFailed() {
+			continue
+		}
+		// Ignore a release that has the same snapshot as the current release
+		if possiblePreviousRelease.Spec.Snapshot == release.Spec.Snapshot {
+			continue
+		}
 		if previousRelease == nil || possiblePreviousRelease.CreationTimestamp.After(previousRelease.CreationTimestamp.Time) {
 			previousRelease = &releases.Items[i]
 		}


### PR DESCRIPTION
* Update GetPreviousRelease in loader to skip releases with the same snapshot
* Ignore failed releases and only consider successful ones as previousRelease
* Add test to ensure failed releases are not used as previousRelease
* Add test to ensure releases sharing the same snapshot are skipped as previousRelease

Ticket: RELEASE-1965
Has been tested on my local kind cluster
