### PR TITLE
fix: add required conforma labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,11 @@ LABEL io.k8s.display-name="release-service"
 LABEL summary="Konflux Release Service"
 LABEL com.redhat.component="release-service"
 LABEL io.openshift.tags="konflux"
+LABEL vendor="Red Hat, Inc."
+LABEL distribution-scope="public"
+LABEL release="1"
+LABEL url="github.com/konflux-ci/release-service"
+LABEL version="1"
 
 USER 65532:65532
 


### PR DESCRIPTION
Conforma policy checks require explicit
container labels rather than inheriting
them from base images. Added all required
labels including name, description, component,
vendor, version, and CPE to fix CI failures
and ensure Red Hat container certification compliance.

This addresses the buildah-oci-ta 0.6→0.7
migration impact where INHERIT_BASE_IMAGE_LABELS
behavior changed, even though 0.7.1 reverted
the default.

https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/0.7/MIGRATION.md