### PR TITLE
feat(RELEASE-2011): Make ociStorage configurable through ReleasePlanAdmission

### DIFF
--- a/config/crd/bases/appstudio.redhat.com_releaseplanadmissions.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplanadmissions.yaml
@@ -137,6 +137,13 @@ spec:
                   pipelineRef:
                     description: PipelineRef is the reference to the Pipeline
                     properties:
+                      ociStorage:
+                        description: |-
+                          OciStorage specifies the OCI repository where the Trusted Artifacts are stored.
+                          This value is passed to the Pipeline as the "ociStorage" parameter.
+                          If not set, the default value from the Pipeline definition will be used.
+                          This field is intended for use in ReleasePlanAdmissions.
+                        type: string
                       params:
                         description: Params is a slice of parameters for a given resolver
                         items:

--- a/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
@@ -123,7 +123,8 @@ spec:
                   final Pipeline
                 properties:
                   params:
-                    description: Params is a slice of parameters for a given resolver
+                    description: Params is a slice of parameters to be passed to the
+                      Pipeline
                     items:
                       description: Param defines the parameters for a given resolver
                         in PipelineRef
@@ -142,6 +143,13 @@ spec:
                   pipelineRef:
                     description: PipelineRef is the reference to the Pipeline
                     properties:
+                      ociStorage:
+                        description: |-
+                          OciStorage specifies the OCI repository where the Trusted Artifacts are stored.
+                          This value is passed to the Pipeline as the "ociStorage" parameter.
+                          If not set, the default value from the Pipeline definition will be used.
+                          This field is intended for use in ReleasePlanAdmissions.
+                        type: string
                       params:
                         description: Params is a slice of parameters for a given resolver
                         items:
@@ -997,7 +1005,8 @@ spec:
                   tenant Pipeline
                 properties:
                   params:
-                    description: Params is a slice of parameters for a given resolver
+                    description: Params is a slice of parameters to be passed to the
+                      Pipeline
                     items:
                       description: Param defines the parameters for a given resolver
                         in PipelineRef
@@ -1016,6 +1025,13 @@ spec:
                   pipelineRef:
                     description: PipelineRef is the reference to the Pipeline
                     properties:
+                      ociStorage:
+                        description: |-
+                          OciStorage specifies the OCI repository where the Trusted Artifacts are stored.
+                          This value is passed to the Pipeline as the "ociStorage" parameter.
+                          If not set, the default value from the Pipeline definition will be used.
+                          This field is intended for use in ReleasePlanAdmissions.
+                        type: string
                       params:
                         description: Params is a slice of parameters for a given resolver
                         items:

--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -1156,7 +1156,8 @@ func (a *adapter) createManagedPipelineRun(resources *loader.ProcessingResources
 		WithPipelineRef(resources.ReleasePlanAdmission.Spec.Pipeline.PipelineRef.ToTektonPipelineRef()).
 		WithServiceAccount(resources.ReleasePlanAdmission.Spec.Pipeline.ServiceAccountName).
 		WithTaskRunSpecs(resources.ReleasePlanAdmission.Spec.Pipeline.TaskRunSpecs...).
-		WithTimeouts(&resources.ReleasePlanAdmission.Spec.Pipeline.Timeouts, &a.releaseServiceConfig.Spec.DefaultTimeouts)
+		WithTimeouts(&resources.ReleasePlanAdmission.Spec.Pipeline.Timeouts, &a.releaseServiceConfig.Spec.DefaultTimeouts).
+		WithParams(resources.ReleasePlanAdmission.Spec.Pipeline.GetOciStorageParam()...)
 
 	url, revision, pathInRepo, err := resources.ReleasePlanAdmission.Spec.Pipeline.PipelineRef.GetGitResolverParams()
 	if err == nil && a.releaseServiceConfig.IsPipelineOverridden(url, revision, pathInRepo) {

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -3646,6 +3646,37 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", Equal(string(revision)))))
 		})
 
+		It("passes ociStorage param from ReleasePlanAdmission to PipelineRun", func() {
+			// Add ociStorage to the ReleasePlanAdmission
+			resources.ReleasePlanAdmission.Spec.Pipeline.PipelineRef.OciStorage = "quay.io/my-org/my-storage"
+
+			var err error
+			pipelineRun, err = adapter.createManagedPipelineRun(resources)
+			Expect(pipelineRun).NotTo(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify that the ociStorage param is passed to the PipelineRun
+			Expect(pipelineRun.Spec.Params).Should(ContainElement(And(
+				HaveField("Name", "ociStorage"),
+				HaveField("Value.StringVal", "quay.io/my-org/my-storage"),
+			)))
+		})
+
+		It("does not pass ociStorage param when not set in ReleasePlanAdmission", func() {
+			// Ensure ociStorage is not set
+			resources.ReleasePlanAdmission.Spec.Pipeline.PipelineRef.OciStorage = ""
+
+			var err error
+			pipelineRun, err = adapter.createManagedPipelineRun(resources)
+			Expect(pipelineRun).NotTo(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify that ociStorage param is not added
+			for _, param := range pipelineRun.Spec.Params {
+				Expect(param.Name).NotTo(Equal("ociStorage"))
+			}
+		})
+
 		It("contains a parameter with the json representation of the EnterpriseContractPolicy", func() {
 			var err error
 			pipelineRun, err = adapter.createManagedPipelineRun(resources)
@@ -5131,8 +5162,6 @@ var _ = Describe("Release adapter", Ordered, func() {
 										},
 									},
 								},
-
-								Params: []tektonutils.Param{},
 							},
 						},
 					},
@@ -5208,8 +5237,6 @@ var _ = Describe("Release adapter", Ordered, func() {
 										},
 									},
 								},
-
-								Params: []tektonutils.Param{},
 							},
 						},
 					},


### PR DESCRIPTION
This PR adds the ability to configure `ociStorage` through the `ReleasePlanAdmission` resource. This enables different clusters and managed namespaces to use their own trusted artifact storage instead of the hardcoded default.

## Problem

The `ociStorage` parameter was hardcoded to `quay.io/konflux-ci/release-service-trusted-artifacts` in the release pipelines. This caused failures when:

- Deploying Konflux on **Fedora cluster** (no push access to default registry)
- Running on **local Kind installations** (network/credential restrictions)
- **Enterprise deployments** using internal registries

Related issue: https://github.com/konflux-ci/release-service-catalog/issues/1514

## Solution

Added a new `ociStorage` field inside `pipelineRef` in the RPA spec. This is a dedicated field specifically for configuring trusted artifact storage.

> **Note:** This is intentionally a specific field (not generic params) to prevent users from accidentally overriding other critical pipeline parameters.

### Usage Example

```yaml
apiVersion: appstudio.redhat.com/v1alpha1
kind: ReleasePlanAdmission
spec:
  pipeline:
    pipelineRef:
      resolver: git
      params:
        - name: url
          value: https://github.com/konflux-ci/release-service-catalog.git
        - name: revision
          value: development
        - name: pathInRepo
          value: pipelines/managed/push-to-external-registry/push-to-external-registry.yaml
      # NEW: Dedicated ociStorage field (RELEASE-2011)
      ociStorage: quay.io/my-org/my-trusted-artifacts
```

## Changes

- Add `ociStorage` field to `PipelineRef` struct
- Implement `GetTektonParams()` to pass ociStorage to PipelineRun
- Update `createManagedPipelineRun` to include pipeline params
- Add unit tests for the new functionality
- Regenerate CRDs