### PR TITLE
Add auto rebase to Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "rebaseWhen": "behind-base-branch",
   "tekton": {
     "schedule": ["* 0 * * *"]
   }


### PR DESCRIPTION
Based on the Renovate docs:

**"rebaseWhen": "auto" (the default):**
Only rebases when required by the repository settings, such as:
 - GitHub's "Require branches to be up to date before merging" is enabled
 - When "automerge": true is configured If none of those conditions apply, it won't rebase out-of-date branches 
 - 
 **"rebaseWhen": "behind-base-branch":**
 - Always rebases branches whenever they're behind the base branch
 - Doesn't depend on repository settings or automerge config
 - More aggressive - keeps all Renovate PRs constantly up-to-date So if your repo doesn't have "Require branches to be up to date" enabled and you're not using automerge, auto won't rebase out-of-date branches. behind-base-branch forces rebasing regardless.