### PR TITLE
fix(KONFLUX-10973): remove owner refs from release and releaseplan

### DIFF
--- a/controllers/releaseplan/controller.go
+++ b/controllers/releaseplan/controller.go
@@ -64,7 +64,6 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureMatchingInformationIsSet,
-		adapter.EnsureOwnerReferenceIsSet,
 	})
 }
 


### PR DESCRIPTION
Remove owner references from Release and ReleasePlan to fix ArgoCD pruning. Owner references prevent ArgoCD from correctly pruning resources when using Helm.

Related issues:
- https://github.com/argoproj/argo-cd/issues/4764
- https://github.com/argoproj/argo-cd/issues/11972

Relevant Jira:
- https://issues.redhat.com/browse/KONFLUX-10973
