### PR TITLE
feat: add artifact-browser-url to PR comment task

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -39,6 +39,10 @@ spec:
       default: 'none'
       description: 'Container image built from any konflux git repo. Use this param only when you run Konflux e2e tests
         in another Konflux component repo. Will pass the component built image from the snapshot.'
+    - name: artifact-browser-url
+      description: "URL to the artifact browser deployment. If provided, a link will be added to PR comments."
+      default: ""
+      type: string
   tasks:
     - name: check-if-e2e-irrelevant
       taskRef:
@@ -336,3 +340,5 @@ spec:
           value: kind-aws-provision.log
         - name: enable-test-results-analysis
           value: "true"
+        - name: artifact-browser-url
+          value: $(params.artifact-browser-url)


### PR DESCRIPTION
Add the artifact-browser-url pipeline parameter and pass it to the pull-request-comment task. This enables linking to the OCI artifact browser in PR comments when the URL is provided.