### PR TITLE
Expose snapshot and releasePlan as labels in Release resource

### DIFF
--- a/api/v1alpha1/webhooks/release/webhook_test.go
+++ b/api/v1alpha1/webhooks/release/webhook_test.go
@@ -21,6 +21,7 @@ import (
 	toolkit "github.com/konflux-ci/operator-toolkit/loader"
 	"github.com/konflux-ci/release-service/api/v1alpha1"
 	"github.com/konflux-ci/release-service/loader"
+	"github.com/konflux-ci/release-service/metadata"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -74,6 +75,35 @@ var _ = Describe("Release validation webhook", func() {
 			Expect(mockedWebhook.Default(mockedCtx, release)).To(BeNil())
 			Expect(release.Spec.GracePeriodDays).To(Equal(0))
 		})
+
+		It("should set snapshot and releasePlan labels from spec fields", func() {
+			mockedCtx := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ReleasePlanContextKey,
+					Resource:   releasePlan,
+				},
+			})
+
+			Expect(mockedWebhook.Default(mockedCtx, release)).To(BeNil())
+			Expect(release.Labels).NotTo(BeNil())
+			Expect(release.Labels[metadata.SnapshotLabel]).To(Equal(release.Spec.Snapshot))
+			Expect(release.Labels[metadata.ReleasePlanLabel]).To(Equal(release.Spec.ReleasePlan))
+		})
+
+		It("should initialize labels map if nil and set labels", func() {
+			release.Labels = nil
+			mockedCtx := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ReleasePlanContextKey,
+					Resource:   releasePlan,
+				},
+			})
+
+			Expect(mockedWebhook.Default(mockedCtx, release)).To(BeNil())
+			Expect(release.Labels).NotTo(BeNil())
+			Expect(release.Labels[metadata.SnapshotLabel]).To(Equal(release.Spec.Snapshot))
+			Expect(release.Labels[metadata.ReleasePlanLabel]).To(Equal(release.Spec.ReleasePlan))
+		})
 	})
 
 	When("When ValidateUpdate is called", func() {
@@ -92,6 +122,42 @@ var _ = Describe("Release validation webhook", func() {
 			updatedRelease := release.DeepCopy()
 			updatedRelease.ObjectMeta.Annotations = map[string]string{
 				"foo": "bar",
+			}
+
+			_, err := webhook.ValidateUpdate(ctx, release, updatedRelease)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should error out when updating the snapshot label", func() {
+			updatedRelease := release.DeepCopy()
+			updatedRelease.Labels = map[string]string{
+				metadata.SnapshotLabel:    "different-snapshot",
+				metadata.ReleasePlanLabel: release.Spec.ReleasePlan,
+			}
+
+			_, err := webhook.ValidateUpdate(ctx, release, updatedRelease)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("release snapshot label cannot be updated"))
+		})
+
+		It("should error out when updating the releasePlan label", func() {
+			updatedRelease := release.DeepCopy()
+			updatedRelease.Labels = map[string]string{
+				metadata.SnapshotLabel:    release.Spec.Snapshot,
+				metadata.ReleasePlanLabel: "different-releaseplan",
+			}
+
+			_, err := webhook.ValidateUpdate(ctx, release, updatedRelease)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("release releasePlan label cannot be updated"))
+		})
+
+		It("should not error out when updating other labels", func() {
+			updatedRelease := release.DeepCopy()
+			updatedRelease.Labels = map[string]string{
+				metadata.SnapshotLabel:    release.Spec.Snapshot,
+				metadata.ReleasePlanLabel: release.Spec.ReleasePlan,
+				"custom-label":            "custom-value",
 			}
 
 			_, err := webhook.ValidateUpdate(ctx, release, updatedRelease)
@@ -141,6 +207,23 @@ var _ = Describe("Release validation webhook", func() {
 			Expect(warnings).To(BeEmpty())
 		})
 
+		It("should return an error when releasePlan name is longer than 63 characters", func() {
+			release := &v1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-release",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ReleaseSpec{
+					Snapshot:    "test-snapshot",
+					ReleasePlan: "this-is-a-very-long-releaseplan-name-that-exceeds-sixty-three-characters",
+				},
+			}
+			warnings, err := webhook.ValidateCreate(context.TODO(), release)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("releasePlan name must be no more than 63 characters"))
+			Expect(warnings).To(BeEmpty())
+		})
+
 		It("should not return an error when both release name and snapshot name are within 63 characters", func() {
 			release := &v1alpha1.Release{
 				ObjectMeta: metav1.ObjectMeta{
@@ -167,6 +250,10 @@ var _ = Describe("Release validation webhook", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-release-",
 				Namespace:    "default",
+				Labels: map[string]string{
+					metadata.SnapshotLabel:    "test-snapshot",
+					metadata.ReleasePlanLabel: "test-releaseplan",
+				},
 			},
 			Spec: v1alpha1.ReleaseSpec{
 				Snapshot:    "test-snapshot",

--- a/metadata/labels.go
+++ b/metadata/labels.go
@@ -93,6 +93,12 @@ var (
 
 	// ReleasePlanAdmissionLabel is the ReleasePlan label for the name of the ReleasePlanAdmission to use
 	ReleasePlanAdmissionLabel = fmt.Sprintf("release.%s/releasePlanAdmission", RhtapDomain)
+
+	// SnapshotLabel is the label used to specify the snapshot associated with the Release
+	SnapshotLabel = fmt.Sprintf("release.%s/snapshot", RhtapDomain)
+
+	// ReleasePlanLabel is the label used to specify the releasePlan associated with the Release
+	ReleasePlanLabel = fmt.Sprintf("release.%s/releasePlan", RhtapDomain)
 )
 
 // Labels to be used within Release PipelineRuns


### PR DESCRIPTION
Expose snapshot and releasePlan as labels in Release resource

Add immutable labels for spec.snapshot and spec.releasePlan to enable label-based querying of Release resources via standard Kubernetes label selectors.

Related to: https://github.com/konflux-ci/release-service/issues/1172