### PR TITLE
fix(RELEASE-21): handle transient errors during validation

### DIFF
--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -4986,6 +4986,23 @@ var _ = Describe("Release adapter", Ordered, func() {
 
 			result := adapter.validateProcessingResources()
 			Expect(result.Valid).To(BeFalse())
+			Expect(adapter.release.IsValid()).To(BeFalse())
+		})
+
+		It("should return valid with error if a retriable error occurs", func() {
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ProcessingResourcesContextKey,
+					Err:        errors.NewTimeoutError("API timeout", 5),
+					Resource: &loader.ProcessingResources{
+						ReleasePlanAdmission: releasePlanAdmission,
+						ReleasePlan:          releasePlan,
+					},
+				},
+			})
+
+			result := adapter.validateProcessingResources()
+			Expect(result.Valid).To(BeFalse())
 			Expect(result.Err).To(HaveOccurred())
 			Expect(adapter.release.IsValid()).To(BeFalse())
 		})
@@ -5036,7 +5053,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ReleasePlanContextKey,
-					Err:        fmt.Errorf("internal error"),
+					Err:        errors.NewInternalError(fmt.Errorf("internal error")),
 					Resource:   releasePlan,
 				},
 			})
@@ -5051,7 +5068,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ReleasePlanAdmissionContextKey,
-					Err:        fmt.Errorf("internal error"),
+					Err:        errors.NewInternalError(fmt.Errorf("internal error")),
 					Resource:   releasePlanAdmission,
 				},
 			})

--- a/controllers/release/controller.go
+++ b/controllers/release/controller.go
@@ -79,6 +79,8 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureFinalizersAreCalled,
 		adapter.EnsureConfigIsLoaded, // This operation sets the config in the adapter to be used in other operations.
+		adapter.EnsureCollectorsProcessingResourcesAreCleanedUp,
+		adapter.EnsureReleaseProcessingResourcesAreCleanedUp,
 		adapter.EnsureReleaseIsRunning,
 		adapter.EnsureReleaseIsValid,
 		adapter.EnsureApplicationMetadataIsSet,
@@ -88,14 +90,12 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		adapter.EnsureTenantCollectorsPipelineIsTracked,
 		adapter.EnsureManagedCollectorsPipelineIsProcessed,
 		adapter.EnsureManagedCollectorsPipelineIsTracked,
-		adapter.EnsureCollectorsProcessingResourcesAreCleanedUp,
 		adapter.EnsureTenantPipelineIsProcessed,
 		adapter.EnsureTenantPipelineProcessingIsTracked,
 		adapter.EnsureManagedPipelineIsProcessed,
 		adapter.EnsureManagedPipelineProcessingIsTracked,
 		adapter.EnsureFinalPipelineIsProcessed,
 		adapter.EnsureFinalPipelineProcessingIsTracked,
-		adapter.EnsureReleaseProcessingResourcesAreCleanedUp,
 		adapter.EnsureReleaseIsCompleted,
 	})
 }


### PR DESCRIPTION
- Transient validation errors now requeue instead of stopping reconciliation
- Reorder cleanup operations to run before completed Releases stop processing,
  ensuring PipelineRun finalizers are always removed
- Cleanup failures now requeue for retry instead of being silently ignored