### PR TITLE
fix(RELEASE-21): only requeue cleanup errors that are retriable

### DIFF
--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -764,7 +764,13 @@ func (a *adapter) EnsureCollectorsProcessingResourcesAreCleanedUp() (controller.
 	}
 
 	if len(cleanupErrors) > 0 {
-		return controller.RequeueWithError(fmt.Errorf("cleanup failed: %v", cleanupErrors))
+		for _, cleanupErr := range cleanupErrors {
+			if loader.IsRetriable(cleanupErr) {
+				return controller.RequeueWithError(fmt.Errorf("cleanup failed: %v", cleanupErrors))
+			}
+		}
+		a.logger.Error(fmt.Errorf("cleanup errors: %v", cleanupErrors),
+			"Non-retriable collector cleanup errors occurred, continuing")
 	}
 
 	return controller.ContinueProcessing()
@@ -801,7 +807,13 @@ func (a *adapter) EnsureReleaseProcessingResourcesAreCleanedUp() (controller.Ope
 	}
 
 	if len(cleanupErrors) > 0 {
-		return controller.RequeueWithError(fmt.Errorf("cleanup failed: %v", cleanupErrors))
+		for _, cleanupErr := range cleanupErrors {
+			if loader.IsRetriable(cleanupErr) {
+				return controller.RequeueWithError(fmt.Errorf("cleanup failed: %v", cleanupErrors))
+			}
+		}
+		a.logger.Error(fmt.Errorf("cleanup errors: %v", cleanupErrors),
+			"Non-retriable pipeline cleanup errors occurred, continuing")
 	}
 
 	return controller.ContinueProcessing()


### PR DESCRIPTION
Cleanup functions now use IsRetriable to distinguish transient errors from permanent ones. Permanent errors are logged and skipped to avoid infinite requeue loops.