### PR TITLE
feat(RELEASE-1841): add emptyDir workspaces for tenant pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ atlassian-ide-plugin.xml
 # Operator-sdk
 bin/*
 cover.out
+
+# asdf
+.tool-versions

--- a/config/crd/bases/appstudio.redhat.com_releaseplanadmissions.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplanadmissions.yaml
@@ -165,6 +165,12 @@ spec:
                         description: Resolver is the name of a Tekton resolver to
                           be used (e.g. git)
                         type: string
+                      useEmptyDir:
+                        description: |-
+                          UseEmptyDir specifies whether to use an empty dir volume for the workspace.
+                          When true, the PipelineRun will use an empty dir volume. Otherwise, it will
+                          use a volume claim template by default.
+                        type: boolean
                     required:
                     - params
                     - resolver

--- a/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
@@ -171,6 +171,12 @@ spec:
                         description: Resolver is the name of a Tekton resolver to
                           be used (e.g. git)
                         type: string
+                      useEmptyDir:
+                        description: |-
+                          UseEmptyDir specifies whether to use an empty dir volume for the workspace.
+                          When true, the PipelineRun will use an empty dir volume. Otherwise, it will
+                          use a volume claim template by default.
+                        type: boolean
                     required:
                     - params
                     - resolver
@@ -1053,6 +1059,12 @@ spec:
                         description: Resolver is the name of a Tekton resolver to
                           be used (e.g. git)
                         type: string
+                      useEmptyDir:
+                        description: |-
+                          UseEmptyDir specifies whether to use an empty dir volume for the workspace.
+                          When true, the PipelineRun will use an empty dir volume. Otherwise, it will
+                          use a volume claim template by default.
+                        type: boolean
                     required:
                     - params
                     - resolver

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -3456,6 +3456,26 @@ var _ = Describe("Release adapter", Ordered, func() {
 		It("contains the proper timeout value", func() {
 			Expect(pipelineRun.Spec.Timeouts.Pipeline).To(Equal(newReleasePlan.Spec.TenantPipeline.Timeouts.Pipeline))
 		})
+
+		It("contains a workspace using VolumeClaimTemplate by default", func() {
+			Expect(pipelineRun.Spec.Workspaces).To(HaveLen(1))
+			Expect(pipelineRun.Spec.Workspaces[0].VolumeClaimTemplate).NotTo(BeNil())
+			Expect(pipelineRun.Spec.Workspaces[0].EmptyDir).To(BeNil())
+		})
+
+		It("contains a workspace using EmptyDir when UseEmptyDir is true", func() {
+			newReleasePlan.Spec.TenantPipeline.PipelineRef.UseEmptyDir = true
+
+			var err error
+			emptyDirPipelineRun, err := adapter.createTenantPipelineRun(newReleasePlan, snapshot)
+			Expect(emptyDirPipelineRun).NotTo(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(emptyDirPipelineRun.Spec.Workspaces).To(HaveLen(1))
+			Expect(emptyDirPipelineRun.Spec.Workspaces[0].EmptyDir).NotTo(BeNil())
+			Expect(emptyDirPipelineRun.Spec.Workspaces[0].VolumeClaimTemplate).To(BeNil())
+			Expect(k8sClient.Delete(ctx, emptyDirPipelineRun)).To(Succeed())
+		})
 	})
 
 	When("createManagedPipelineRun is called", func() {
@@ -3925,6 +3945,26 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseNameLabel]).To(Equal(adapter.release.Name))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseNamespaceLabel]).To(Equal(testNamespace))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseSnapshotLabel]).To(Equal(adapter.release.Spec.Snapshot))
+		})
+
+		It("contains a workspace using VolumeClaimTemplate by default", func() {
+			Expect(pipelineRun.Spec.Workspaces).To(HaveLen(1))
+			Expect(pipelineRun.Spec.Workspaces[0].VolumeClaimTemplate).NotTo(BeNil())
+			Expect(pipelineRun.Spec.Workspaces[0].EmptyDir).To(BeNil())
+		})
+
+		It("contains a workspace using EmptyDir when UseEmptyDir is true", func() {
+			newReleasePlan.Spec.FinalPipeline.PipelineRef.UseEmptyDir = true
+
+			var err error
+			emptyDirPipelineRun, err := adapter.createFinalPipelineRun(newReleasePlan, snapshot)
+			Expect(emptyDirPipelineRun).NotTo(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(emptyDirPipelineRun.Spec.Workspaces).To(HaveLen(1))
+			Expect(emptyDirPipelineRun.Spec.Workspaces[0].EmptyDir).NotTo(BeNil())
+			Expect(emptyDirPipelineRun.Spec.Workspaces[0].VolumeClaimTemplate).To(BeNil())
+			Expect(k8sClient.Delete(ctx, emptyDirPipelineRun)).To(Succeed())
 		})
 
 		Context("with git resolver setup", func() {

--- a/tekton/utils/pipeline.go
+++ b/tekton/utils/pipeline.go
@@ -46,6 +46,12 @@ type PipelineRef struct {
 	// This field is intended for use in ReleasePlanAdmissions.
 	// +optional
 	OciStorage string `json:"ociStorage,omitempty"`
+
+	// UseEmptyDir specifies whether to use an empty dir volume for the workspace.
+	// When true, the PipelineRun will use an empty dir volume. Otherwise, it will
+	// use a volume claim template by default.
+	// +optional
+	UseEmptyDir bool `json:"useEmptyDir,omitempty"`
 }
 
 // Pipeline contains a reference to a Pipeline and the name of the service account to use while executing it.


### PR DESCRIPTION
* add useEmptyDir boolean to PipelineRef
* updates adapter logic to create workspaces based on the useEmptyDir.
* add tests to the adapter to verify behaviour
* update .gitignore to include .tool-versions.

Have tested both scenarios locally on kind tenant and the final pipeline.
