### PR TITLE
feat(RELEASE-1344): add logs of a failing task to Release CR

### DIFF
--- a/config/rbac/tekton_role.yaml
+++ b/config/rbac/tekton_role.yaml
@@ -4,6 +4,12 @@ kind: ClusterRole
 metadata:
   name: tekton-role
 rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
   - verbs:
       - create
       - delete
@@ -17,6 +23,7 @@ rules:
       - tekton.dev
     resources:
       - pipelineruns
+      - taskruns
   - apiGroups:
       - triggers.tekton.dev
     resources:

--- a/tekton/utils/pipeline_test.go
+++ b/tekton/utils/pipeline_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package utils
 
 import (
+	"reflect"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-
-	"reflect"
 )
 
 var _ = Describe("Pipeline", func() {
@@ -240,5 +240,4 @@ var _ = Describe("Pipeline", func() {
 			Expect(bundleRef.IsClusterScoped()).To(BeFalse())
 		})
 	})
-
 })


### PR DESCRIPTION
If any Release pipeline fails, the failing logs get added to the Release
CR. They get added to the condition's message, for example
"ManagedPipelineProcessed". Due to 32 KB size limit, the logs get
truncated if they're too long.

The logs are extracted from the failing pod, so access control is
updated to have the right permissions.