### PR TITLE
feat(KFLUXDP-880): migrate release-service e2e tests in-repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+test: manifests generate fmt vet envtest ## Run unit tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(shell go list ./... | grep -v /e2e-tests/) -coverprofile cover.out
 
 ##@ Build
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 # Documentation: https://docs.codecov.io/docs/codecov-yaml
 ignore:
   - "api/v1alpha1/zz_generated.deepcopy.go" # generated file
+  - "e2e-tests/**"
 
 coverage:
     status:

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,0 +1,83 @@
+# Release Service E2E Tests
+
+End-to-end tests for the [Release Service](https://github.com/konflux-ci/release-service) using Ginkgo/Gomega.
+
+## Quick Start
+
+```bash
+# Set required tokens
+export QUAY_TOKEN='{"auths":{"quay.io":{"auth":"..."}}}'
+export RELEASE_CATALOG_TA_QUAY_TOKEN='{"auths":{"quay.io":{"auth":"..."}}}'
+
+# Run all e2e tests (from project root)
+make test-e2e
+```
+
+## Prerequisites
+
+| Requirement | Version |
+|-------------|---------|
+| Go | 1.23+ |
+| Kubernetes/OpenShift cluster | With Release Service deployed |
+| `kubectl` / `oc` | Configured with cluster access |
+
+## Environment Variables
+
+### Required
+
+| Variable | Format | Description |
+|----------|--------|-------------|
+| `QUAY_TOKEN` | `dockerconfigjson` | Quay.io auth for image push/pull |
+| `RELEASE_CATALOG_TA_QUAY_TOKEN` | `dockerconfigjson` | Quay auth for trusted artifacts |
+
+**Token Format Example:**
+```json
+{
+  "auths": {
+    "quay.io/your-org/your-repo": {
+      "auth": "base64-encoded-credentials"
+    }
+  }
+}
+```
+
+### Optional
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RELEASE_SERVICE_CATALOG_URL` | `https://github.com/konflux-ci/release-service-catalog` | Release pipeline catalog repo |
+| `RELEASE_SERVICE_CATALOG_REVISION` | `development` | Catalog git branch/tag |
+| `E2E_APPLICATIONS_NAMESPACE` | *auto-generated* | Override test namespace |
+
+## Running Tests
+
+Run from the **project root** directory:
+
+```bash
+make test-e2e                          # Run all tests
+make test-e2e LABEL=happy-path         # Run by label
+make test-e2e FOCUS="tenant"           # Run by name pattern
+make test-e2e SKIP="negative"          # Skip tests matching pattern
+make test-e2e E2E_TIMEOUT=120m         # Custom timeout
+make test-e2e-list                     # List all tests
+```
+
+**Combine options:**
+```bash
+make test-e2e LABEL=happy-path E2E_TIMEOUT=90m
+make test-e2e LABEL="release-service && !release-neg"
+```
+
+## Test Labels
+
+| Label | Description |
+|-------|-------------|
+| `release-service` | All release service tests |
+| `happy-path` | Full release flow with managed pipeline |
+| `tenant` | Tenant-only pipeline (no managed namespace) |
+| `release_plan_and_admission` | ReleasePlan ↔ ReleasePlanAdmission matching |
+| `release-neg` | Negative/error scenarios |
+
+## Writing Tests
+
+See [Ginkgo documentation](https://onsi.github.io/ginkgo/) for writing tests. Use existing tests in `tests/release/service/` as examples.

--- a/e2e-tests/cmd/e2e_test.go
+++ b/e2e-tests/cmd/e2e_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	"github.com/onsi/gomega"
+
+	// Import test packages
+	_ "github.com/konflux-ci/release-service/e2e-tests/tests/release/service"
+
+	"flag"
+
+	ecpApi "github.com/conforma/crds/api/v1alpha1"
+	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func init() {
+	klog.SetLogger(ginkgo.GinkgoLogr)
+
+	verbosity := 1
+	if v, err := strconv.ParseUint(os.Getenv("KLOG_VERBOSITY"), 10, 8); err == nil {
+		verbosity = int(v)
+	}
+
+	flags := &flag.FlagSet{}
+	klog.InitFlags(flags)
+	if err := flags.Set("v", fmt.Sprintf("%d", verbosity)); err != nil {
+		panic(err)
+	}
+}
+
+var requiredEnvVars = []string{
+	"QUAY_TOKEN",
+	"RELEASE_CATALOG_TA_QUAY_TOKEN",
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	var missingEnvs []string
+	for _, env := range requiredEnvVars {
+		if os.Getenv(env) == "" {
+			missingEnvs = append(missingEnvs, env)
+		}
+	}
+	gomega.Expect(missingEnvs).To(gomega.BeEmpty(), "Missing required environment variables: %v", missingEnvs)
+
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		kubeconfig = clientcmd.RecommendedHomeFile
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to load kubeconfig")
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	_, err = discoveryClient.ServerVersion()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to connect to cluster")
+
+	scheme := runtime.NewScheme()
+	_ = releaseApi.AddToScheme(scheme)
+	_ = appstudioApi.AddToScheme(scheme)
+	_ = tektonv1.AddToScheme(scheme)
+	_ = ecpApi.AddToScheme(scheme)
+
+	k8sClient, err := client.New(config, client.Options{Scheme: scheme})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Verify all required APIs
+	requiredAPIs := []client.ObjectList{
+		&releaseApi.ReleaseList{},
+		&releaseApi.ReleasePlanList{},
+		&releaseApi.ReleasePlanAdmissionList{},
+		&appstudioApi.SnapshotList{},
+		&appstudioApi.ApplicationList{},
+		&tektonv1.PipelineRunList{},
+		&ecpApi.EnterpriseContractPolicyList{},
+	}
+	for _, api := range requiredAPIs {
+		gomega.Expect(k8sClient.List(context.Background(), api, client.Limit(1))).To(gomega.Succeed(),
+			"API not available: %T", api)
+	}
+})
+
+func TestE2E(t *testing.T) {
+	klog.Info("Starting Release Service e2e tests...")
+	gomega.RegisterFailHandler(ginkgo.Fail)
+
+	config, _ := ginkgo.GinkgoConfiguration()
+	if config.DryRun {
+		reports := ginkgo.PreviewSpecs("Release Service E2E tests")
+		for _, spec := range reports.SpecReports {
+			if spec.State.Is(types.SpecStatePassed) {
+				klog.Info(spec.FullText())
+			}
+		}
+	} else {
+		ginkgo.RunSpecs(t, "Release Service E2E tests")
+	}
+}

--- a/e2e-tests/pkg/constants/constants.go
+++ b/e2e-tests/pkg/constants/constants.go
@@ -1,0 +1,75 @@
+// Package constants defines configuration constants for e2e tests.
+package constants
+
+import "time"
+
+// =============================================================================
+// Environment Variables
+// =============================================================================
+
+const (
+	// E2E_APPLICATIONS_NAMESPACE_ENV overrides the test namespace name.
+	E2E_APPLICATIONS_NAMESPACE_ENV string = "E2E_APPLICATIONS_NAMESPACE"
+)
+
+// =============================================================================
+// Default Values
+// =============================================================================
+
+const (
+	// ApplicationNameDefault is the default application name used in tests.
+	ApplicationNameDefault string = "appstudio"
+
+	// ReleaseStrategyPolicyDefault is the default release strategy policy.
+	ReleaseStrategyPolicyDefault string = "mvp-policy"
+
+	// ReleaseStrategyPolicy is the policy name.
+	ReleaseStrategyPolicy string = "policy"
+)
+
+// =============================================================================
+// Secret Names
+// =============================================================================
+
+const (
+	RedhatAppstudioUserSecret            string = "hacbs-release-tests-token"                     // #nosec G101 -- not a credential, just a k8s Secret name
+	ReleaseCatalogTAQuaySecret           string = "release-catalog-trusted-artifacts-quay-secret" // #nosec G101
+	ReleasePipelineServiceAccountDefault string = "release-service-account"
+	PublicSecretNameAuth                 string = "cosign-public-key" // #nosec G101
+)
+
+// =============================================================================
+// Resource Names
+// =============================================================================
+
+const (
+	SourceReleasePlanName          string = "source-releaseplan"
+	SecondReleasePlanName          string = "the-second-releaseplan"
+	TargetReleasePlanAdmissionName string = "demo"
+	ApplicationName                string = "application"
+	ReleasePvcName                 string = "release-pvc"
+)
+
+// =============================================================================
+// Component & Pipeline Constants
+// =============================================================================
+
+const (
+	ComponentName         string = "dc-metro-map"
+	GitSourceComponentUrl string = "https://github.com/redhat-appstudio-qe/dc-metro-map-release"
+)
+
+// =============================================================================
+// Timeouts & Intervals
+// =============================================================================
+
+const (
+	// Polling intervals
+	PipelineRunPollingInterval = 10 * time.Second
+	DefaultInterval            = 100 * time.Millisecond
+
+	// Timeouts
+	ReleaseCreationTimeout              = 5 * time.Minute
+	ReleasePipelineRunCompletionTimeout = 60 * time.Minute
+	ReleasePlanStatusUpdateTimeout      = 1 * time.Minute
+)

--- a/e2e-tests/pkg/framework/client.go
+++ b/e2e-tests/pkg/framework/client.go
@@ -1,0 +1,193 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ecpApi "github.com/conforma/crds/api/v1alpha1"
+	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+// KubeClient wraps a controller-runtime client with helper methods.
+type KubeClient struct {
+	kubeClient client.Client
+	kubeRest   *rest.Config
+}
+
+// KubeRest returns the Kubernetes client.
+func (c *KubeClient) KubeRest() client.Client {
+	return c.kubeClient
+}
+
+// newKubeClient creates a new KubeClient.
+func newKubeClient() (*KubeClient, error) {
+	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	)
+
+	restConfig, err := kubeconfig.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubeconfig: %v", err)
+	}
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+	_ = releaseApi.AddToScheme(scheme)
+	_ = appstudioApi.AddToScheme(scheme)
+	_ = tektonv1.AddToScheme(scheme)
+	_ = ecpApi.AddToScheme(scheme)
+
+	k8sClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %v", err)
+	}
+
+	return &KubeClient{
+		kubeClient: k8sClient,
+		kubeRest:   restConfig,
+	}, nil
+}
+
+// CreateTestNamespace creates a namespace for testing.
+func (c *KubeClient) CreateTestNamespace(name string) (*corev1.Namespace, error) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	err := c.kubeClient.Create(context.Background(), ns)
+	if err != nil && !k8sErrors.IsAlreadyExists(err) {
+		return nil, err
+	}
+	return ns, nil
+}
+
+// DeleteNamespace deletes a namespace.
+func (c *KubeClient) DeleteNamespace(name string) error {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	return c.kubeClient.Delete(context.Background(), ns)
+}
+
+// GetSecret gets a secret.
+func (c *KubeClient) GetSecret(namespace, name string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	err := c.kubeClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: name}, secret)
+	return secret, err
+}
+
+// CreateRegistryAuthSecret creates a docker registry auth secret.
+// The authJson parameter should be raw dockerconfigjson (already decoded).
+func (c *KubeClient) CreateRegistryAuthSecret(name, namespace, authJson string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Type:       corev1.SecretTypeDockerConfigJson,
+		StringData: map[string]string{corev1.DockerConfigJsonKey: authJson},
+	}
+	err := c.kubeClient.Create(context.Background(), secret)
+	if err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
+// CreateServiceAccount creates a service account.
+func (c *KubeClient) CreateServiceAccount(name, namespace string, secrets []corev1.ObjectReference, imagePullSecrets []corev1.LocalObjectReference) (*corev1.ServiceAccount, error) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Secrets:          secrets,
+		ImagePullSecrets: imagePullSecrets,
+	}
+	err := c.kubeClient.Create(context.Background(), sa)
+	if err != nil {
+		return nil, err
+	}
+	return sa, nil
+}
+
+// LinkSecretToServiceAccount links a secret to a service account.
+func (c *KubeClient) LinkSecretToServiceAccount(namespace, secretName, serviceAccountName string, addImagePullSecret bool) error {
+	sa := &corev1.ServiceAccount{}
+	err := c.kubeClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: serviceAccountName}, sa)
+	if err != nil {
+		return err
+	}
+
+	sa.Secrets = append(sa.Secrets, corev1.ObjectReference{Name: secretName})
+	if addImagePullSecret {
+		sa.ImagePullSecrets = append(sa.ImagePullSecrets, corev1.LocalObjectReference{Name: secretName})
+	}
+
+	return c.kubeClient.Update(context.Background(), sa)
+}
+
+// CreateRole creates a role.
+func (c *KubeClient) CreateRole(name, namespace string, rules map[string][]string) (*rbacv1.Role, error) {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: rules["apiGroupsList"],
+				Resources: rules["roleResources"],
+				Verbs:     rules["roleVerbs"],
+			},
+		},
+	}
+	err := c.kubeClient.Create(context.Background(), role)
+	if err != nil {
+		return nil, err
+	}
+	return role, nil
+}
+
+// CreateRoleBinding creates a role binding.
+func (c *KubeClient) CreateRoleBinding(name, namespace, subjectKind, subjectName, subjectNamespace, roleKind, roleName, roleAPIGroup string) (*rbacv1.RoleBinding, error) {
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      subjectKind,
+				Name:      subjectName,
+				Namespace: subjectNamespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     roleKind,
+			Name:     roleName,
+			APIGroup: roleAPIGroup,
+		},
+	}
+	err := c.kubeClient.Create(context.Background(), rb)
+	if err != nil {
+		return nil, err
+	}
+	return rb, nil
+}

--- a/e2e-tests/pkg/framework/framework.go
+++ b/e2e-tests/pkg/framework/framework.go
@@ -1,0 +1,80 @@
+package framework
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// ControllerHub aggregates all controller clients.
+type ControllerHub struct {
+	CommonController      *KubeClient
+	ReleaseController     *ReleaseController
+	KonfluxApiController  *KonfluxApiController
+	IntegrationController *IntegrationController
+	TektonController      *TektonController
+}
+
+// Framework is the main entry point for e2e tests.
+type Framework struct {
+	AsKubeAdmin   *ControllerHub
+	UserNamespace string
+	UserName      string
+}
+
+// NewFramework creates a new Framework instance with default timeout.
+func NewFramework(userName string) (*Framework, error) {
+	return NewFrameworkWithTimeout(userName, time.Second*60)
+}
+
+// NewFrameworkWithTimeout creates a new Framework instance with custom timeout.
+func NewFrameworkWithTimeout(userName string, timeout time.Duration) (*Framework, error) {
+	if userName == "" {
+		return nil, fmt.Errorf("userName cannot be empty when initializing a new framework instance")
+	}
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return nil, fmt.Errorf("error creating kubernetes client: %v", err)
+	}
+
+	controllerHub := &ControllerHub{
+		CommonController:      kubeClient,
+		ReleaseController:     NewReleaseController(kubeClient),
+		KonfluxApiController:  &KonfluxApiController{KubeClient: kubeClient},
+		IntegrationController: &IntegrationController{KubeClient: kubeClient},
+		TektonController:      NewTektonController(kubeClient),
+	}
+
+	nsName := os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV)
+	if nsName == "" {
+		nsName = userName
+		_, err := kubeClient.CreateTestNamespace(userName)
+		if err != nil && !k8sErrors.IsAlreadyExists(err) {
+			return nil, fmt.Errorf("failed to create test namespace %s: %+v", nsName, err)
+		}
+	}
+
+	return &Framework{
+		AsKubeAdmin:   controllerHub,
+		UserNamespace: nsName,
+		UserName:      nsName,
+	}, nil
+}
+
+// ReportFailure returns an AfterEach hook function that reports test failures.
+func ReportFailure(fw **Framework) func() {
+	return func() {
+		if ginkgo.CurrentSpecReport().Failed() {
+			ginkgo.GinkgoWriter.Printf("Test failed: %s\n", ginkgo.CurrentSpecReport().FullText())
+			if fw != nil && *fw != nil {
+				ginkgo.GinkgoWriter.Printf("Namespace: %s\n", (*fw).UserNamespace)
+			}
+		}
+	}
+}

--- a/e2e-tests/pkg/framework/integration.go
+++ b/e2e-tests/pkg/framework/integration.go
@@ -1,0 +1,97 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	"github.com/konflux-ci/release-service/metadata"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// IntegrationController handles Snapshot operations (integration-service domain).
+type IntegrationController struct {
+	*KubeClient
+}
+
+// NewIntegrationController creates a new IntegrationController.
+func NewIntegrationController(kubeClient *KubeClient) *IntegrationController {
+	return &IntegrationController{
+		KubeClient: kubeClient,
+	}
+}
+
+// =============================================================================
+// Snapshot Operations
+// =============================================================================
+
+// CreateSnapshotWithImageSource creates a Snapshot with image and git source information.
+// Pass empty strings for componentName2/containerImage2 to create a single-component snapshot.
+func (i *IntegrationController) CreateSnapshotWithImageSource(
+	componentName, applicationName, namespace,
+	containerImage, gitSourceURL, gitSourceRevision,
+	componentName2, containerImage2, gitSourceURL2, gitSourceRevision2 string,
+) (*appstudioApi.Snapshot, error) {
+	snapshotComponents := []appstudioApi.SnapshotComponent{
+		{
+			Name:           componentName,
+			ContainerImage: containerImage,
+			Source: appstudioApi.ComponentSource{
+				ComponentSourceUnion: appstudioApi.ComponentSourceUnion{
+					GitSource: &appstudioApi.GitSource{
+						Revision: gitSourceRevision,
+						URL:      gitSourceURL,
+					},
+				},
+			},
+		},
+	}
+
+	// Add second component if provided
+	if componentName2 != "" && containerImage2 != "" {
+		snapshotComponents = append(snapshotComponents, appstudioApi.SnapshotComponent{
+			Name:           componentName2,
+			ContainerImage: containerImage2,
+			Source: appstudioApi.ComponentSource{
+				ComponentSourceUnion: appstudioApi.ComponentSourceUnion{
+					GitSource: &appstudioApi.GitSource{
+						Revision: gitSourceRevision2,
+						URL:      gitSourceURL2,
+					},
+				},
+			},
+		})
+	}
+
+	snapshotName := "snapshot-sample-" + utils.GenerateRandomString(4)
+
+	snapshot := &appstudioApi.Snapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      snapshotName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"test.appstudio.openshift.io/type":                           "component",
+				fmt.Sprintf("%s/component", metadata.RhtapDomain):            componentName,
+				fmt.Sprintf("%s/event-type", metadata.PipelinesAsCodePrefix): "push",
+				fmt.Sprintf("%s/sender", metadata.PipelinesAsCodePrefix):     "release-service-e2e",
+				metadata.AuthorLabel:                                         "release-service-e2e",
+			},
+			Annotations: map[string]string{
+				fmt.Sprintf("%s/url-repository", metadata.PipelinesAsCodePrefix): gitSourceURL,
+				fmt.Sprintf("%s/sha", metadata.PipelinesAsCodePrefix):            gitSourceRevision,
+			},
+		},
+		Spec: appstudioApi.SnapshotSpec{
+			Application: applicationName,
+			Components:  snapshotComponents,
+		},
+	}
+
+	err := i.kubeClient.Create(context.Background(), snapshot)
+	if err != nil {
+		return nil, err
+	}
+
+	return snapshot, nil
+}

--- a/e2e-tests/pkg/framework/konflux_api.go
+++ b/e2e-tests/pkg/framework/konflux_api.go
@@ -1,0 +1,43 @@
+package framework
+
+import (
+	"context"
+
+	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// KonfluxApiController handles Konflux API resources: Application and Component.
+type KonfluxApiController struct {
+	*KubeClient
+}
+
+// NewKonfluxApiController creates a new KonfluxApiController.
+func NewKonfluxApiController(kubeClient *KubeClient) *KonfluxApiController {
+	return &KonfluxApiController{
+		KubeClient: kubeClient,
+	}
+}
+
+// =============================================================================
+// Application Operations
+// =============================================================================
+
+// CreateApplication creates an Application CR.
+func (k *KonfluxApiController) CreateApplication(name, namespace string) (*appstudioApi.Application, error) {
+	app := &appstudioApi.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appstudioApi.ApplicationSpec{
+			DisplayName: name,
+		},
+	}
+
+	err := k.kubeClient.Create(context.Background(), app)
+	if err != nil {
+		return nil, err
+	}
+	return app, nil
+}

--- a/e2e-tests/pkg/framework/release.go
+++ b/e2e-tests/pkg/framework/release.go
@@ -1,0 +1,218 @@
+package framework
+
+import (
+	"context"
+	"strconv"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/loader"
+	releaseMetadata "github.com/konflux-ci/release-service/metadata"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ReleaseController handles Release, ReleasePlan, and ReleasePlanAdmission CRD operations.
+type ReleaseController struct {
+	*KubeClient
+	loader loader.ObjectLoader
+}
+
+// NewReleaseController creates a new ReleaseController with the loader.
+func NewReleaseController(kubeClient *KubeClient) *ReleaseController {
+	return &ReleaseController{
+		KubeClient: kubeClient,
+		loader:     loader.NewLoader(),
+	}
+}
+
+// =============================================================================
+// Release Operations
+// =============================================================================
+
+// CreateRelease creates a Release.
+func (r *ReleaseController) CreateRelease(name, namespace, snapshot, releasePlan string) (*releaseApi.Release, error) {
+	release := &releaseApi.Release{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: releaseApi.ReleaseSpec{
+			Snapshot:    snapshot,
+			ReleasePlan: releasePlan,
+		},
+	}
+
+	err := r.kubeClient.Create(context.Background(), release)
+	if err != nil {
+		return nil, err
+	}
+	return release, nil
+}
+
+// GetRelease gets a Release using the loader package (reuses main project code).
+func (r *ReleaseController) GetRelease(name, namespace string) (*releaseApi.Release, error) {
+	return r.loader.GetRelease(context.Background(), r.kubeClient, name, namespace)
+}
+
+// GetFirstReleaseInNamespace gets the first Release in a namespace.
+func (r *ReleaseController) GetFirstReleaseInNamespace(namespace string) (*releaseApi.Release, error) {
+	releaseList := &releaseApi.ReleaseList{}
+	err := r.kubeClient.List(context.Background(), releaseList, client.InNamespace(namespace))
+	if err != nil {
+		return nil, err
+	}
+	if len(releaseList.Items) == 0 {
+		return nil, &NotFoundError{Resource: "Release", Namespace: namespace}
+	}
+	return &releaseList.Items[0], nil
+}
+
+// CreateReleasePipelineRoleBindingForServiceAccount creates a RoleBinding for the release pipeline SA.
+func (r *ReleaseController) CreateReleasePipelineRoleBindingForServiceAccount(namespace string, serviceAccount *corev1.ServiceAccount) (*rbacv1.RoleBinding, error) {
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "release-pipeline-rolebinding",
+			Namespace: namespace,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccount.Name,
+				Namespace: namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     "release-pipeline-resource-role",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+	err := r.kubeClient.Create(context.Background(), rb)
+	if err != nil {
+		return nil, err
+	}
+	return rb, nil
+}
+
+// =============================================================================
+// ReleasePlan Operations
+// =============================================================================
+
+// CreateReleasePlan creates a ReleasePlan.
+func (r *ReleaseController) CreateReleasePlan(name, namespace, application, targetNamespace, autoRelease string, data *runtime.RawExtension, pipeline *tektonutils.ParameterizedPipeline, serviceAccount *string) (*releaseApi.ReleasePlan, error) {
+	// Set auto-release label - default to "true" if empty (matching original behavior)
+	autoReleaseValue := autoRelease
+	if autoReleaseValue == "" {
+		autoReleaseValue = "true"
+	}
+
+	rp := &releaseApi.ReleasePlan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				releaseMetadata.AutoReleaseLabel: autoReleaseValue,
+				releaseMetadata.AttributionLabel: "true",
+			},
+		},
+		Spec: releaseApi.ReleasePlanSpec{
+			Application:    application,
+			Target:         targetNamespace,
+			Data:           data,
+			TenantPipeline: pipeline,
+		},
+	}
+
+	err := r.kubeClient.Create(context.Background(), rp)
+	if err != nil {
+		return nil, err
+	}
+	return rp, nil
+}
+
+// GetReleasePlan gets a ReleasePlan by name and namespace.
+func (r *ReleaseController) GetReleasePlan(name, namespace string) (*releaseApi.ReleasePlan, error) {
+	rp := &releaseApi.ReleasePlan{}
+	err := r.kubeClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: name}, rp)
+	return rp, err
+}
+
+// DeleteReleasePlan deletes a ReleasePlan.
+func (r *ReleaseController) DeleteReleasePlan(name, namespace string, wait bool) error {
+	rp := &releaseApi.ReleasePlan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	return r.kubeClient.Delete(context.Background(), rp)
+}
+
+// =============================================================================
+// ReleasePlanAdmission Operations
+// =============================================================================
+
+// CreateReleasePlanAdmission creates a ReleasePlanAdmission.
+func (r *ReleaseController) CreateReleasePlanAdmission(name, namespace, environment, origin, policy, serviceAccount string, applications []string, blockReleases bool, pipelineRef *tektonutils.PipelineRef, data *runtime.RawExtension) (*releaseApi.ReleasePlanAdmission, error) {
+	rpa := &releaseApi.ReleasePlanAdmission{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				releaseMetadata.BlockReleasesLabel: strconv.FormatBool(blockReleases),
+			},
+		},
+		Spec: releaseApi.ReleasePlanAdmissionSpec{
+			Applications: applications,
+			Origin:       origin,
+			Policy:       policy,
+			Pipeline: &tektonutils.Pipeline{
+				PipelineRef:        *pipelineRef,
+				ServiceAccountName: serviceAccount,
+			},
+			Data: data,
+		},
+	}
+
+	err := r.kubeClient.Create(context.Background(), rpa)
+	if err != nil {
+		return nil, err
+	}
+	return rpa, nil
+}
+
+// GetReleasePlanAdmission gets a ReleasePlanAdmission by name and namespace.
+func (r *ReleaseController) GetReleasePlanAdmission(name, namespace string) (*releaseApi.ReleasePlanAdmission, error) {
+	rpa := &releaseApi.ReleasePlanAdmission{}
+	err := r.kubeClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: name}, rpa)
+	return rpa, err
+}
+
+// DeleteReleasePlanAdmission deletes a ReleasePlanAdmission.
+func (r *ReleaseController) DeleteReleasePlanAdmission(name, namespace string, waitForDeletion bool) error {
+	rpa := &releaseApi.ReleasePlanAdmission{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	return r.kubeClient.Delete(context.Background(), rpa)
+}
+
+// =============================================================================
+// Error Types
+// =============================================================================
+
+// NotFoundError represents a resource not found error.
+type NotFoundError struct {
+	Resource  string
+	Namespace string
+}
+
+func (e *NotFoundError) Error() string {
+	return "no " + e.Resource + " found in namespace " + e.Namespace
+}

--- a/e2e-tests/pkg/framework/tekton.go
+++ b/e2e-tests/pkg/framework/tekton.go
@@ -1,0 +1,204 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	ecp "github.com/conforma/crds/api/v1alpha1"
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/metadata"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TektonController handles Tekton-related operations: PipelineRun, TaskRun, EC Policy, PVC, and signing secrets.
+type TektonController struct {
+	*KubeClient
+}
+
+// NewTektonController creates a new TektonController.
+func NewTektonController(kubeClient *KubeClient) *TektonController {
+	return &TektonController{
+		KubeClient: kubeClient,
+	}
+}
+
+// =============================================================================
+// PVC Operations
+// =============================================================================
+
+// CreatePVCInAccessMode creates a PVC with the specified access mode.
+func (t *TektonController) CreatePVCInAccessMode(name, namespace string, accessMode corev1.PersistentVolumeAccessMode) (*corev1.PersistentVolumeClaim, error) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{accessMode},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	err := t.kubeClient.Create(context.Background(), pvc)
+	if err != nil {
+		return nil, err
+	}
+	return pvc, nil
+}
+
+// =============================================================================
+// Signing Secret Operations
+// =============================================================================
+
+// CreateOrUpdateSigningSecret creates or updates a signing secret.
+func (t *TektonController) CreateOrUpdateSigningSecret(publicKey []byte, name, namespace string) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"cosign.pub": publicKey,
+		},
+	}
+
+	existingSecret := &corev1.Secret{}
+	err := t.kubeClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: name}, existingSecret)
+	if err != nil {
+		// Create if not exists
+		return t.kubeClient.Create(context.Background(), secret)
+	}
+
+	// Update existing
+	existingSecret.Data = secret.Data
+	return t.kubeClient.Update(context.Background(), existingSecret)
+}
+
+// =============================================================================
+// Enterprise Contract Policy Operations
+// =============================================================================
+
+// GetEnterpriseContractPolicy gets an EnterpriseContractPolicy CR.
+func (t *TektonController) GetEnterpriseContractPolicy(name, namespace string) (*ecp.EnterpriseContractPolicy, error) {
+	policy := &ecp.EnterpriseContractPolicy{}
+	err := t.kubeClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: name}, policy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get EnterpriseContractPolicy %s/%s: %w", namespace, name, err)
+	}
+	return policy, nil
+}
+
+// CreateEnterpriseContractPolicy creates an EnterpriseContractPolicy CR.
+func (t *TektonController) CreateEnterpriseContractPolicy(name, namespace string, spec ecp.EnterpriseContractPolicySpec) (*ecp.EnterpriseContractPolicy, error) {
+	policy := &ecp.EnterpriseContractPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: spec,
+	}
+
+	err := t.kubeClient.Create(context.Background(), policy)
+	if err != nil {
+		return nil, err
+	}
+	return policy, nil
+}
+
+// =============================================================================
+// PipelineRun Operations (using metadata from main project)
+// =============================================================================
+
+// GetPipelineRunInNamespace gets a PipelineRun for a release using labels from metadata package.
+func (t *TektonController) GetPipelineRunInNamespace(namespace, releaseName, releaseNamespace string) (*tektonv1.PipelineRun, error) {
+	pipelineRuns := &tektonv1.PipelineRunList{}
+	err := t.kubeClient.List(context.Background(), pipelineRuns, client.InNamespace(namespace))
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range pipelineRuns.Items {
+		pr := &pipelineRuns.Items[i]
+		if pr.Labels != nil {
+			// Use metadata constants for label keys (reusing main project)
+			if pr.Labels[metadata.ReleaseNameLabel] == releaseName &&
+				pr.Labels[metadata.ReleaseNamespaceLabel] == releaseNamespace {
+				return pr, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no pipelinerun found for release %s/%s in namespace %s", releaseNamespace, releaseName, namespace)
+}
+
+// WaitForReleasePipelineToBeFinished waits for a release pipeline to finish.
+// Uses knative apis.ConditionSucceeded for condition checking (same as main project).
+func (t *TektonController) WaitForReleasePipelineToBeFinished(release *releaseApi.Release, managedNamespace string) error {
+	return wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, constants.ReleasePipelineRunCompletionTimeout, true, func(ctx context.Context) (done bool, err error) {
+		pr, err := t.GetPipelineRunInNamespace(managedNamespace, release.GetName(), release.GetNamespace())
+		if err != nil {
+			return false, nil
+		}
+
+		// Use knative apis package for condition checking (same pattern as main project)
+		condition := pr.Status.GetCondition(apis.ConditionSucceeded)
+		if condition == nil {
+			return false, nil
+		}
+
+		if condition.IsTrue() {
+			return true, nil
+		}
+		if condition.IsFalse() {
+			return false, fmt.Errorf("pipelinerun %s/%s failed: %s", pr.Namespace, pr.Name, condition.Message)
+		}
+		return false, nil
+	})
+}
+
+// =============================================================================
+// TaskRun Operations
+// =============================================================================
+
+// GetTaskRunStatus gets the status of a TaskRun in a PipelineRun.
+func (t *TektonController) GetTaskRunStatus(kubeClient client.Client, pr *tektonv1.PipelineRun, taskName string) (*tektonv1.PipelineRunTaskRunStatus, error) {
+	for _, chr := range pr.Status.ChildReferences {
+		if chr.PipelineTaskName == taskName {
+			// Fetch the actual TaskRun to get its status
+			taskRun := &tektonv1.TaskRun{}
+			err := kubeClient.Get(context.Background(), client.ObjectKey{
+				Namespace: pr.Namespace,
+				Name:      chr.Name,
+			}, taskRun)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get TaskRun %s: %w", chr.Name, err)
+			}
+
+			return &tektonv1.PipelineRunTaskRunStatus{
+				PipelineTaskName: chr.PipelineTaskName,
+				Status:           &taskRun.Status,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("taskrun %s not found in pipelinerun %s/%s", taskName, pr.Namespace, pr.Name)
+}
+
+// DidTaskSucceed checks if a TaskRun succeeded using knative apis package.
+func DidTaskSucceed(tr *tektonv1.PipelineRunTaskRunStatus) bool {
+	if tr == nil || tr.Status == nil {
+		return false
+	}
+	condition := tr.Status.GetCondition(apis.ConditionSucceeded)
+	return condition != nil && condition.IsTrue()
+}

--- a/e2e-tests/pkg/utils/utils.go
+++ b/e2e-tests/pkg/utils/utils.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"crypto/rand"
+	"math/big"
+	"os"
+)
+
+// GetEnv retrieves an environment variable with a default fallback.
+func GetEnv(key, defaultVal string) string {
+	if val := os.Getenv(key); val != "" {
+		return val
+	}
+	return defaultVal
+}
+
+// GenerateRandomString generates a random lowercase alphanumeric string of given length.
+func GenerateRandomString(n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, n)
+	for i := range b {
+		num, _ := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		b[i] = letters[num.Int64()]
+	}
+	return string(b)
+}
+
+// GetGeneratedNamespace creates a unique namespace name.
+func GetGeneratedNamespace(name string) string {
+	return name + "-" + GenerateRandomString(4)
+}

--- a/e2e-tests/tests/release/service/block_releases_release_plan_admission.go
+++ b/e2e-tests/tests/release/service/block_releases_release_plan_admission.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"context"
+	"strings"
+
+	"github.com/konflux-ci/application-api/api/v1alpha1"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = ginkgo.Describe("Release CR fails when block-releases true in ReleasePlanAdmission", releasecommon.LabelNegBlockReleases, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+
+	var fw *framework.Framework
+	var err error
+
+	var devNamespace = "block-rp-dev"
+	var managedNamespace = "block-rp-managed"
+
+	var releaseCR *releaseApi.Release
+	var snapshotName = "snapshot"
+	var destinationReleasePlanAdmissionName = "sre-production"
+	var releaseName = "release"
+
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+
+	ginkgo.BeforeAll(func() {
+		fw, err = framework.NewFramework(utils.GetGeneratedNamespace(devNamespace))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework")
+		devNamespace = fw.UserNamespace
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create managed namespace %s", managedNamespace)
+
+		snapshot := &v1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      snapshotName,
+				Namespace: devNamespace,
+			},
+			Spec: v1alpha1.SnapshotSpec{
+				Application: constants.ApplicationName,
+				Components:  []v1alpha1.SnapshotComponent{},
+			},
+		}
+		err = fw.AsKubeAdmin.CommonController.KubeRest().Create(context.Background(), snapshot)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Snapshot %s", snapshotName)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "", nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s", constants.SourceReleasePlanName)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(destinationReleasePlanAdmissionName, managedNamespace, "", devNamespace, constants.ReleaseStrategyPolicy, constants.ReleasePipelineServiceAccountDefault, []string{constants.ApplicationName}, true, &tektonutils.PipelineRef{
+			Resolver: "git",
+			Params: []tektonutils.Param{
+				{Name: "url", Value: releasecommon.RelSvcCatalogURL},
+				{Name: "revision", Value: releasecommon.RelSvcCatalogRevision},
+				{Name: "pathInRepo", Value: "pipelines/managed/e2e/e2e.yaml"},
+			},
+		}, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s with block-releases=true", destinationReleasePlanAdmissionName)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateRelease(releaseName, devNamespace, snapshotName, constants.SourceReleasePlanName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Release %s", releaseName)
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(managedNamespace)).To(gomega.Succeed())
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(fw.UserNamespace)).To(gomega.Succeed())
+		}
+	})
+
+	var _ = ginkgo.Describe("post-release verification.", func() {
+		ginkgo.It("block-releases true in ReleasePlanAdmission makes a Release CR set as failed in both IsReleased and IsValid with a proper message to user.", func() {
+			gomega.Eventually(func() bool {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetRelease(releaseName, devNamespace)
+				if err != nil {
+					return false
+				}
+				if releaseCR.HasReleaseFinished() {
+					return !(releaseCR.IsValid() && releaseCR.IsReleased()) &&
+						strings.Contains(releaseCR.Status.Conditions[0].Message, "Release validation failed")
+				}
+				return false
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.BeTrue(), "expected Release to fail validation due to block-releases=true in RPA")
+		})
+	})
+})

--- a/e2e-tests/tests/release/service/happy_path.go
+++ b/e2e-tests/tests/release/service/happy_path.go
@@ -1,0 +1,189 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+
+	ecp "github.com/conforma/crds/api/v1alpha1"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("Release service happy path", releasecommon.LabelHappyPath, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+
+	var fw *framework.Framework
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+	var err error
+	var compName string
+	var devNamespace = "happy-path"
+	var managedNamespace = "happy-path-managed"
+	var _ *appservice.Snapshot
+	var verifyConformaTaskName = "verify-conforma"
+	var releasedImagePushRepo = "quay.io/redhat-appstudio-qe/dcmetromap"
+	var sampleImage = "quay.io/hacbs-release-tests/dcmetromap@sha256:544259be8bcd9e6a2066224b805d854d863064c9b64fa3a87bfcd03f5b0f28e6"
+	var gitSourceURL = constants.GitSourceComponentUrl
+	var gitSourceRevision = "d49914874789147eb2de9bb6a12cd5d150bfff92"
+	var ecPolicyName = "hpath-policy-" + utils.GenerateRandomString(4)
+
+	var releaseCR *releaseApi.Release
+
+	ginkgo.BeforeAll(func() {
+		fw, err = framework.NewFramework(utils.GetGeneratedNamespace(devNamespace))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework: %v", err)
+		devNamespace = fw.UserNamespace
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create managed namespace %s: %v", managedNamespace, err)
+
+		sourceAuthJson := utils.GetEnv("QUAY_TOKEN", "")
+		gomega.Expect(sourceAuthJson).ToNot(gomega.BeEmpty(), "QUAY_TOKEN env var is required (dockerconfigjson format)")
+
+		releaseCatalogTrustedArtifactsQuayAuthJson := utils.GetEnv("RELEASE_CATALOG_TA_QUAY_TOKEN", "")
+		gomega.Expect(releaseCatalogTrustedArtifactsQuayAuthJson).ToNot(gomega.BeEmpty(), "RELEASE_CATALOG_TA_QUAY_TOKEN env var is required (dockerconfigjson format)")
+
+		managedServiceAccount, err := fw.AsKubeAdmin.CommonController.CreateServiceAccount(constants.ReleasePipelineServiceAccountDefault, managedNamespace, releasecommon.ManagednamespaceSecret, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create service account %s in %s: %v", constants.ReleasePipelineServiceAccountDefault, managedNamespace, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(managedNamespace, managedServiceAccount)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create rolebinding for service account: %v", err)
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateRegistryAuthSecret(constants.RedhatAppstudioUserSecret, managedNamespace, sourceAuthJson)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to create secret %s: %v", constants.RedhatAppstudioUserSecret, err)
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateRegistryAuthSecret(constants.ReleaseCatalogTAQuaySecret, managedNamespace, releaseCatalogTrustedArtifactsQuayAuthJson)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to create secret %s: %v", constants.ReleaseCatalogTAQuaySecret, err)
+
+		err = fw.AsKubeAdmin.CommonController.LinkSecretToServiceAccount(managedNamespace, constants.RedhatAppstudioUserSecret, constants.ReleasePipelineServiceAccountDefault, true)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to link secret to service account: %v", err)
+
+		releasePublicKeyDecoded := []byte("-----BEGIN PUBLIC KEY-----\n" +
+			"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEocSG/SnE0vQ20wRfPltlXrY4Ib9B\n" +
+			"CRnFUCg/fndZsXdz0IX5sfzIyspizaTbu4rapV85KirmSBU6XUaLY347xg==\n" +
+			"-----END PUBLIC KEY-----")
+		err = fw.AsKubeAdmin.TektonController.CreateOrUpdateSigningSecret(releasePublicKeyDecoded, constants.PublicSecretNameAuth, managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create signing secret %s: %v", constants.PublicSecretNameAuth, err)
+
+		defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get default EC policy: %v", err)
+
+		defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
+			Description: "Red Hat's enterprise requirements",
+			PublicKey:   fmt.Sprintf("k8s://%s/%s", managedNamespace, constants.PublicSecretNameAuth),
+			Sources:     defaultEcPolicy.Spec.Sources,
+			Configuration: &ecp.EnterpriseContractPolicyConfiguration{
+				Collections: []string{"@slsa3"},
+				Exclude:     []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
+			},
+		}
+		_, err = fw.AsKubeAdmin.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, managedNamespace, defaultEcPolicySpec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s: %v", ecPolicyName, err)
+
+		_, err = fw.AsKubeAdmin.KonfluxApiController.CreateApplication(constants.ApplicationNameDefault, devNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Application %s: %v", constants.ApplicationNameDefault, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "", nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", constants.SourceReleasePlanName, err)
+
+		data, err := json.Marshal(map[string]interface{}{
+			"mapping": map[string]interface{}{
+				"components": []map[string]interface{}{
+					{
+						"component":  compName,
+						"repository": releasedImagePushRepo,
+					},
+				},
+			},
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to marshal RPA data: %v", err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(constants.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, ecPolicyName, constants.ReleasePipelineServiceAccountDefault, []string{constants.ApplicationNameDefault}, false, &tektonutils.PipelineRef{
+			Resolver: "git",
+			Params: []tektonutils.Param{
+				{Name: "url", Value: releasecommon.RelSvcCatalogURL},
+				{Name: "revision", Value: releasecommon.RelSvcCatalogRevision},
+				{Name: "pathInRepo", Value: "pipelines/managed/e2e/e2e.yaml"},
+			},
+		}, &runtime.RawExtension{
+			Raw: data,
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s: %v", constants.TargetReleasePlanAdmissionName, err)
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateRole("role-release-service-account", managedNamespace, map[string][]string{
+			"apiGroupsList": {""},
+			"roleResources": {"secrets"},
+			"roleVerbs":     {"get", "list", "watch"},
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Role: %v", err)
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateRoleBinding("role-release-service-account-binding", managedNamespace, "ServiceAccount", constants.ReleasePipelineServiceAccountDefault, managedNamespace, "Role", "role-release-service-account", "rbac.authorization.k8s.io")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create RoleBinding: %v", err)
+
+		_, err = fw.AsKubeAdmin.TektonController.CreatePVCInAccessMode(constants.ReleasePvcName, managedNamespace, corev1.ReadWriteOnce)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create PVC %s: %v", constants.ReleasePvcName, err)
+
+		_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithImageSource(constants.ComponentName, constants.ApplicationNameDefault, devNamespace, sampleImage, gitSourceURL, gitSourceRevision, "", "", "", "")
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create Snapshot: %v", err)
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(managedNamespace)).To(gomega.Succeed())
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(fw.UserNamespace)).To(gomega.Succeed())
+		}
+	})
+
+	var _ = ginkgo.Describe("Post-release verification", func() {
+
+		ginkgo.It("verifies that a Release CR should have been created in the dev namespace", func() {
+			gomega.Eventually(func() error {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetFirstReleaseInNamespace(devNamespace)
+				return err
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies that Release PipelineRun is triggered", func() {
+			gomega.Expect(fw.AsKubeAdmin.TektonController.WaitForReleasePipelineToBeFinished(releaseCR, managedNamespace)).To(gomega.Succeed(), "pipelinerun for release %s/%s failed", releaseCR.GetNamespace(), releaseCR.GetName())
+		})
+
+		ginkgo.It("verifies that Enterprise Contract Task has succeeded in the Release PipelineRun", func() {
+			gomega.Eventually(func() error {
+				pr, err := fw.AsKubeAdmin.TektonController.GetPipelineRunInNamespace(managedNamespace, releaseCR.GetName(), releaseCR.GetNamespace())
+				if err != nil {
+					return fmt.Errorf("failed to get PipelineRun: %w", err)
+				}
+				ecTaskRunStatus, err := fw.AsKubeAdmin.TektonController.GetTaskRunStatus(fw.AsKubeAdmin.CommonController.KubeRest(), pr, verifyConformaTaskName)
+				if err != nil {
+					return fmt.Errorf("failed to get TaskRun status for %s: %w", verifyConformaTaskName, err)
+				}
+				if !framework.DidTaskSucceed(ecTaskRunStatus) {
+					return fmt.Errorf("task %s has not succeeded yet", verifyConformaTaskName)
+				}
+				return nil
+			}, constants.ReleasePipelineRunCompletionTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies that a Release is marked as succeeded.", func() {
+			gomega.Eventually(func() error {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetFirstReleaseInNamespace(devNamespace)
+				if err != nil {
+					return fmt.Errorf("failed to get Release: %w", err)
+				}
+				if !releaseCR.IsReleased() {
+					return fmt.Errorf("release %s is not marked as released yet", releaseCR.Name)
+				}
+				return nil
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+	})
+})

--- a/e2e-tests/tests/release/service/missing_release_plan_and_admission.go
+++ b/e2e-tests/tests/release/service/missing_release_plan_and_admission.go
@@ -1,0 +1,115 @@
+package service
+
+import (
+	"context"
+	"strings"
+
+	"github.com/konflux-ci/application-api/api/v1alpha1"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = ginkgo.Describe("Release CR fails when missing ReleasePlan and ReleasePlanAdmission", releasecommon.LabelNegative, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+
+	var fw *framework.Framework
+	var err error
+
+	var devNamespace = "neg-rp-dev"
+	var managedNamespace = "neg-rp-managed"
+
+	var releaseCR *releaseApi.Release
+	var snapshotName = "snapshot"
+	var destinationReleasePlanAdmissionName = "sre-production"
+	var releaseName = "release"
+
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+
+	ginkgo.BeforeAll(func() {
+		fw, err = framework.NewFramework(utils.GetGeneratedNamespace(devNamespace))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework")
+		devNamespace = fw.UserNamespace
+		ginkgo.GinkgoWriter.Printf("Created dev namespace: %s\n", devNamespace)
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create managed namespace %s", managedNamespace)
+
+		snapshot := &v1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      snapshotName,
+				Namespace: devNamespace,
+			},
+			Spec: v1alpha1.SnapshotSpec{
+				Application: constants.ApplicationName,
+				Components:  []v1alpha1.SnapshotComponent{},
+			},
+		}
+		err = fw.AsKubeAdmin.CommonController.KubeRest().Create(context.Background(), snapshot)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Snapshot %s", snapshotName)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(destinationReleasePlanAdmissionName, managedNamespace, "", devNamespace, constants.ReleaseStrategyPolicy, constants.ReleasePipelineServiceAccountDefault, []string{constants.ApplicationName}, false, &tektonutils.PipelineRef{
+			Resolver: "git",
+			Params: []tektonutils.Param{
+				{Name: "url", Value: releasecommon.RelSvcCatalogURL},
+				{Name: "revision", Value: releasecommon.RelSvcCatalogRevision},
+				{Name: "pathInRepo", Value: "pipelines/managed/e2e/e2e.yaml"},
+			},
+		}, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s", destinationReleasePlanAdmissionName)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateRelease(releaseName, devNamespace, snapshotName, constants.SourceReleasePlanName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Release %s", releaseName)
+		ginkgo.GinkgoWriter.Printf("Created Release %s (without matching ReleasePlan)\n", releaseName)
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(managedNamespace)).To(gomega.Succeed())
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(fw.UserNamespace)).To(gomega.Succeed())
+		}
+	})
+
+	var _ = ginkgo.Describe("post-release verification.", func() {
+		ginkgo.It("missing ReleasePlan makes a Release CR set as failed in both IsReleased and IsValid with a proper message to user.", func() {
+			gomega.Eventually(func() bool {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetRelease(releaseName, devNamespace)
+				if err != nil {
+					ginkgo.GinkgoWriter.Printf("Failed to get Release: %v\n", err)
+					return false
+				}
+				if releaseCR.HasReleaseFinished() {
+					return !(releaseCR.IsValid() && releaseCR.IsReleased()) &&
+						strings.Contains(releaseCR.Status.Conditions[0].Message, "Release validation failed")
+				}
+				return false
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.BeTrue(), "expected Release to fail validation due to missing ReleasePlan")
+			ginkgo.GinkgoWriter.Printf("Release %s correctly failed: %s\n", releaseName, releaseCR.Status.Conditions[0].Message)
+		})
+		ginkgo.It("missing ReleasePlanAdmission makes a Release CR set as failed in both IsReleased and IsValid with a proper message to user.", func() {
+			gomega.Expect(fw.AsKubeAdmin.ReleaseController.DeleteReleasePlanAdmission(destinationReleasePlanAdmissionName, managedNamespace, false)).NotTo(gomega.HaveOccurred(), "failed to delete ReleasePlanAdmission %s", destinationReleasePlanAdmissionName)
+			ginkgo.GinkgoWriter.Printf("Deleted ReleasePlanAdmission %s\n", destinationReleasePlanAdmissionName)
+
+			gomega.Eventually(func() bool {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetRelease(releaseName, devNamespace)
+				if err != nil {
+					ginkgo.GinkgoWriter.Printf("Failed to get Release: %v\n", err)
+					return false
+				}
+				if releaseCR.HasReleaseFinished() {
+					return !(releaseCR.IsValid() && releaseCR.IsReleased()) &&
+						strings.Contains(releaseCR.Status.Conditions[0].Message, "Release validation failed")
+				}
+				return false
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.BeTrue(), "expected Release to fail validation due to missing ReleasePlanAdmission")
+			ginkgo.GinkgoWriter.Printf("Release %s correctly failed: %s\n", releaseName, releaseCR.Status.Conditions[0].Message)
+		})
+	})
+})

--- a/e2e-tests/tests/release/service/release_plan_and_admission_matched.go
+++ b/e2e-tests/tests/release/service/release_plan_and_admission_matched.go
@@ -1,0 +1,220 @@
+package service
+
+import (
+	"fmt"
+
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = ginkgo.Describe("ReleasePlan and ReleasePlanAdmission match", releasecommon.LabelReleasePlanAdm, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+
+	var fw *framework.Framework
+	var err error
+	var devNamespace = "rel-plan-admis"
+	var managedNamespace = "plan-and-admission-managed"
+
+	var releasePlanCR, secondReleasePlanCR *releaseApi.ReleasePlan
+	var releasePlanAdmissionCR *releaseApi.ReleasePlanAdmission
+
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+
+	ginkgo.BeforeAll(func() {
+		fw, err = framework.NewFramework(utils.GetGeneratedNamespace(devNamespace))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework")
+		devNamespace = fw.UserNamespace
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create managed namespace %s", managedNamespace)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "true", nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s", constants.SourceReleasePlanName)
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(managedNamespace)).NotTo(gomega.HaveOccurred())
+		}
+	})
+
+	var _ = ginkgo.Describe("RP and PRA status change verification", func() {
+		ginkgo.It("verifies that the ReleasePlan CR is unmatched in the beginning", func() {
+			var condition *metav1.Condition
+			gomega.Eventually(func() error {
+				releasePlanCR, err = fw.AsKubeAdmin.ReleaseController.GetReleasePlan(constants.SourceReleasePlanName, devNamespace)
+				if err != nil {
+					return fmt.Errorf("failed to get ReleasePlan: %w", err)
+				}
+				condition = meta.FindStatusCondition(releasePlanCR.Status.Conditions, releaseApi.MatchedConditionType.String())
+				if condition == nil {
+					return fmt.Errorf("matched condition not set yet on %s", releasePlanCR.Name)
+				}
+				return nil
+			}, constants.ReleasePlanStatusUpdateTimeout, constants.DefaultInterval).Should(gomega.Succeed(), "timed out waiting for ReleasePlan %s to have Matched condition", constants.SourceReleasePlanName)
+			condition = meta.FindStatusCondition(releasePlanCR.Status.Conditions, releaseApi.MatchedConditionType.String())
+			gomega.Expect(condition.Status).To(gomega.Equal(metav1.ConditionFalse), "expected ReleasePlan to be unmatched initially")
+		})
+
+		ginkgo.It("Creates ReleasePlanAdmission CR in corresponding managed namespace", func() {
+			_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(constants.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, constants.ReleaseStrategyPolicyDefault, constants.ReleasePipelineServiceAccountDefault, []string{constants.ApplicationNameDefault}, false, &tektonutils.PipelineRef{
+				Resolver: "git",
+				Params: []tektonutils.Param{
+					{Name: "url", Value: releasecommon.RelSvcCatalogURL},
+					{Name: "revision", Value: releasecommon.RelSvcCatalogRevision},
+					{Name: "pathInRepo", Value: "pipelines/managed/e2e/e2e.yaml"},
+				},
+			}, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s in %s", constants.TargetReleasePlanAdmissionName, managedNamespace)
+		})
+
+		ginkgo.When("ReleasePlanAdmission CR is created in managed namespace", func() {
+			ginkgo.It("verifies that the ReleasePlan CR is set to matched", func() {
+				var condition *metav1.Condition
+				gomega.Eventually(func() error {
+					releasePlanCR, err = fw.AsKubeAdmin.ReleaseController.GetReleasePlan(constants.SourceReleasePlanName, devNamespace)
+					if err != nil {
+						return fmt.Errorf("failed to get ReleasePlan: %w", err)
+					}
+					condition = meta.FindStatusCondition(releasePlanCR.Status.Conditions, releaseApi.MatchedConditionType.String())
+					if condition == nil {
+						return fmt.Errorf("matched condition not set yet on %s", releasePlanCR.Name)
+					}
+					if condition.Status == metav1.ConditionFalse {
+						return fmt.Errorf("release plan %s not matched yet", releasePlanCR.Name)
+					}
+					return nil
+				}, constants.ReleasePlanStatusUpdateTimeout, constants.DefaultInterval).Should(gomega.Succeed(), "timed out waiting for ReleasePlan %s to be matched", constants.SourceReleasePlanName)
+				gomega.Expect(condition.Status).To(gomega.Equal(metav1.ConditionTrue), "expected ReleasePlan to be matched")
+				gomega.Expect(releasePlanCR.Status.ReleasePlanAdmission.Name).To(gomega.Equal(managedNamespace+"/"+constants.TargetReleasePlanAdmissionName), "expected ReleasePlan to reference the correct RPA")
+				gomega.Expect(releasePlanCR.Status.ReleasePlanAdmission.Active).To(gomega.BeTrue(), "expected ReleasePlanAdmission reference to be active")
+			})
+
+			ginkgo.It("verifies that the ReleasePlanAdmission CR is set to matched", func() {
+				var condition *metav1.Condition
+				gomega.Eventually(func() error {
+					releasePlanAdmissionCR, err = fw.AsKubeAdmin.ReleaseController.GetReleasePlanAdmission(constants.TargetReleasePlanAdmissionName, managedNamespace)
+					if err != nil {
+						return fmt.Errorf("failed to get ReleasePlanAdmission: %w", err)
+					}
+					condition = meta.FindStatusCondition(releasePlanAdmissionCR.Status.Conditions, releaseApi.MatchedConditionType.String())
+					if condition == nil || condition.Status == metav1.ConditionFalse {
+						return fmt.Errorf("release plan admission %s not matched yet", releasePlanAdmissionCR.Name)
+					}
+					return nil
+				}, constants.ReleasePlanStatusUpdateTimeout, constants.DefaultInterval).Should(gomega.Succeed(), "timed out waiting for ReleasePlanAdmission %s to be matched", constants.TargetReleasePlanAdmissionName)
+				gomega.Expect(condition).NotTo(gomega.BeNil(), "expected Matched condition to exist")
+				gomega.Expect(condition.Status).To(gomega.Equal(metav1.ConditionTrue), "expected ReleasePlanAdmission to be matched")
+				gomega.Expect(releasePlanAdmissionCR.Status.ReleasePlans).To(gomega.HaveLen(1), "expected exactly 1 matched ReleasePlan")
+				gomega.Expect(releasePlanAdmissionCR.Status.ReleasePlans).To(gomega.Equal([]releaseApi.MatchedReleasePlan{{Name: devNamespace + "/" + constants.SourceReleasePlanName, Active: true}}))
+			})
+		})
+
+		ginkgo.It("Creates a manual release ReleasePlan CR in devNamespace", func() {
+			_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SecondReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "false", nil, nil, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create second ReleasePlan %s", constants.SecondReleasePlanName)
+		})
+
+		ginkgo.When("the second ReleasePlan CR is created", func() {
+			ginkgo.It("verifies that the second ReleasePlan CR is set to matched", func() {
+				var condition *metav1.Condition
+				gomega.Eventually(func() error {
+					secondReleasePlanCR, err = fw.AsKubeAdmin.ReleaseController.GetReleasePlan(constants.SecondReleasePlanName, devNamespace)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					condition = meta.FindStatusCondition(secondReleasePlanCR.Status.Conditions, releaseApi.MatchedConditionType.String())
+
+					if condition == nil {
+						return fmt.Errorf("the matched condition of %s is still not set", secondReleasePlanCR.Name)
+					}
+					if condition.Status == metav1.ConditionFalse {
+						return fmt.Errorf("the matched condition of %s has not reconciled yet", secondReleasePlanCR.Name)
+					}
+					return nil
+				}, constants.ReleasePlanStatusUpdateTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+				gomega.Expect(condition.Status).To(gomega.Equal(metav1.ConditionTrue))
+				gomega.Expect(secondReleasePlanCR.Status.ReleasePlanAdmission.Name).To(gomega.Equal(managedNamespace + "/" + constants.TargetReleasePlanAdmissionName))
+				gomega.Expect(secondReleasePlanCR.Status.ReleasePlanAdmission.Active).To(gomega.BeTrue())
+			})
+
+			ginkgo.It("verifies that the ReleasePlanAdmission CR has two matched ReleasePlan CRs", func() {
+				gomega.Eventually(func() error {
+					releasePlanAdmissionCR, err = fw.AsKubeAdmin.ReleaseController.GetReleasePlanAdmission(constants.TargetReleasePlanAdmissionName, managedNamespace)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					condition := meta.FindStatusCondition(releasePlanAdmissionCR.Status.Conditions, releaseApi.MatchedConditionType.String())
+					if condition == nil {
+						return fmt.Errorf("failed to get the matched condition of RPA %s", releasePlanAdmissionCR.Name)
+					}
+
+					if len(releasePlanAdmissionCR.Status.ReleasePlans) < 2 {
+						return fmt.Errorf("the second ReleasePlan CR has not been added to %s", releasePlanAdmissionCR.Name)
+					}
+					gomega.Expect(condition).NotTo(gomega.BeNil())
+					gomega.Expect(condition.Status).To(gomega.Equal(metav1.ConditionTrue))
+					return nil
+				}, constants.ReleasePlanStatusUpdateTimeout, constants.DefaultInterval).Should(gomega.Succeed(), fmt.Sprintf("timed out waiting for ReleasePlanAdmission %s to be reconciled to matched", releasePlanAdmissionCR.Name))
+				gomega.Expect(releasePlanAdmissionCR.Status.ReleasePlans).To(gomega.HaveLen(2))
+				gomega.Expect(releasePlanAdmissionCR.Status.ReleasePlans).To(gomega.Equal([]releaseApi.MatchedReleasePlan{{Name: devNamespace + "/" + constants.SourceReleasePlanName, Active: true}, {Name: devNamespace + "/" + constants.SecondReleasePlanName, Active: false}}))
+			})
+		})
+
+		ginkgo.It("deletes one ReleasePlan CR", func() {
+			err = fw.AsKubeAdmin.ReleaseController.DeleteReleasePlan(constants.SourceReleasePlanName, devNamespace, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to delete ReleasePlan %s", constants.SourceReleasePlanName)
+		})
+
+		ginkgo.When("One ReleasePlan CR is deleted in managed namespace", func() {
+			ginkgo.It("verifies that the ReleasePlanAdmission CR has only one matching ReleasePlan", func() {
+				gomega.Eventually(func() error {
+					releasePlanAdmissionCR, err = fw.AsKubeAdmin.ReleaseController.GetReleasePlanAdmission(constants.TargetReleasePlanAdmissionName, managedNamespace)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					condition := meta.FindStatusCondition(releasePlanAdmissionCR.Status.Conditions, releaseApi.MatchedConditionType.String())
+					if condition == nil {
+						return fmt.Errorf("failed to find the matched condition of %s", releasePlanAdmissionCR.Name)
+					}
+
+					if len(releasePlanAdmissionCR.Status.ReleasePlans) > 1 {
+						return fmt.Errorf("release plan CR is deleted, but ReleasePlanAdmission CR %s has not been reconciled", releasePlanAdmissionCR.Name)
+					}
+					gomega.Expect(condition).NotTo(gomega.BeNil())
+					gomega.Expect(condition.Status).To(gomega.Equal(metav1.ConditionTrue))
+					return nil
+				}, constants.ReleasePlanStatusUpdateTimeout, constants.DefaultInterval).Should(gomega.Succeed(), fmt.Sprintf("timed out waiting for ReleasePlanAdmission %s to be reconciled after one ReleasePlan is deleted", releasePlanAdmissionCR.Name))
+				gomega.Expect(releasePlanAdmissionCR.Status.ReleasePlans).To(gomega.HaveLen(1))
+				gomega.Expect(releasePlanAdmissionCR.Status.ReleasePlans).To(gomega.Equal([]releaseApi.MatchedReleasePlan{{Name: devNamespace + "/" + constants.SecondReleasePlanName, Active: false}}))
+			})
+		})
+
+		ginkgo.It("deletes the ReleasePlanAdmission CR", func() {
+			err = fw.AsKubeAdmin.ReleaseController.DeleteReleasePlanAdmission(constants.TargetReleasePlanAdmissionName, managedNamespace, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to delete ReleasePlanAdmission %s", constants.TargetReleasePlanAdmissionName)
+		})
+
+		ginkgo.When("ReleasePlanAdmission CR is deleted in managed namespace", func() {
+			ginkgo.It("verifies that the ReleasePlan CR has no matched ReleasePlanAdmission", func() {
+				gomega.Eventually(func() error {
+					secondReleasePlanCR, err = fw.AsKubeAdmin.ReleaseController.GetReleasePlan(constants.SecondReleasePlanName, devNamespace)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					condition := meta.FindStatusCondition(secondReleasePlanCR.Status.Conditions, releaseApi.MatchedConditionType.String())
+					if condition == nil {
+						return fmt.Errorf("failed to get the matched condition of %s", secondReleasePlanCR.Name)
+					}
+
+					if condition.Status == metav1.ConditionTrue {
+						return fmt.Errorf("the matched condition of %s has not reconciled yet", secondReleasePlanCR.Name)
+					}
+					return nil
+				}, constants.ReleasePlanStatusUpdateTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+				gomega.Expect(secondReleasePlanCR.Status.ReleasePlanAdmission).To(gomega.Equal(releaseApi.MatchedReleasePlanAdmission{}))
+			})
+		})
+	})
+})

--- a/e2e-tests/tests/release/service/tenant_pipelines.go
+++ b/e2e-tests/tests/release/service/tenant_pipelines.go
@@ -1,0 +1,132 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = ginkgo.Describe("Release service tenant pipeline", releasecommon.LabelTenant, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+
+	var fw *framework.Framework
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+	var err error
+	var devNamespace = "tenant-dev"
+	var releasedImagePushRepo = "quay.io/redhat-appstudio-qe/dcmetromap"
+	var sampleImage = "quay.io/redhat-appstudio-qe/dcmetromap@sha256:544259be8bcd9e6a2066224b805d854d863064c9b64fa3a87bfcd03f5b0f28e6"
+	var gitSourceURL = "https://github.com/redhat-appstudio-qe/dc-metro-map-release"
+	var gitSourceRevision = "d49914874789147eb2de9bb6a12cd5d150bfff92"
+	var tenantServiceAccountName = "tenant-service-account" // #nosec G101 -- not a credential, just a k8s resource name
+	var tenantPullSecretName = "tenant-pull-secret"         // #nosec G101
+
+	var releaseCR *releaseApi.Release
+
+	ginkgo.BeforeAll(func() {
+		fw, err = framework.NewFramework(utils.GetGeneratedNamespace(devNamespace))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework: %v", err)
+		devNamespace = fw.UserNamespace
+
+		sourceAuthJson := utils.GetEnv("QUAY_TOKEN", "")
+		gomega.Expect(sourceAuthJson).ToNot(gomega.BeEmpty(), "QUAY_TOKEN env var is required (dockerconfigjson format)")
+
+		_, err := fw.AsKubeAdmin.CommonController.GetSecret(devNamespace, tenantPullSecretName)
+		if errors.IsNotFound(err) {
+			_, err = fw.AsKubeAdmin.CommonController.CreateRegistryAuthSecret(tenantPullSecretName, devNamespace, sourceAuthJson)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to create pull secret %s: %v", tenantPullSecretName, err)
+		} else {
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get pull secret %s: %v", tenantPullSecretName, err)
+		}
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateServiceAccount(tenantServiceAccountName, devNamespace, []corev1.ObjectReference{{Name: tenantPullSecretName}}, nil)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to create service account %s: %v", tenantServiceAccountName, err)
+
+		_, err = fw.AsKubeAdmin.KonfluxApiController.CreateApplication(constants.ApplicationNameDefault, devNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Application %s: %v", constants.ApplicationNameDefault, err)
+
+		data, err := json.Marshal(map[string]interface{}{
+			"mapping": map[string]interface{}{
+				"components": []map[string]interface{}{
+					{
+						"component":  constants.ComponentName,
+						"repository": releasedImagePushRepo,
+					},
+				},
+			},
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to marshal ReleasePlan data: %v", err)
+
+		tenantPipeline := &tektonutils.ParameterizedPipeline{}
+		tenantPipeline.ServiceAccountName = tenantServiceAccountName
+		tenantPipeline.Timeouts = tektonv1.TimeoutFields{
+			Pipeline: &metav1.Duration{Duration: 1 * time.Hour},
+		}
+		tenantPipeline.PipelineRef = tektonutils.PipelineRef{
+			Resolver: "git",
+			Params: []tektonutils.Param{
+				{Name: "url", Value: "https://github.com/redhat-appstudio-qe/pipeline_examples"},
+				{Name: "revision", Value: "main"},
+				{Name: "pathInRepo", Value: "pipelines/simple_pipeline.yaml"},
+			},
+		}
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, "", "", &runtime.RawExtension{
+			Raw: data,
+		}, tenantPipeline, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", constants.SourceReleasePlanName, err)
+
+		_, err = fw.AsKubeAdmin.TektonController.CreatePVCInAccessMode(constants.ReleasePvcName, devNamespace, corev1.ReadWriteOnce)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create PVC %s: %v", constants.ReleasePvcName, err)
+
+		_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithImageSource(constants.ComponentName, constants.ApplicationNameDefault, devNamespace, sampleImage, gitSourceURL, gitSourceRevision, "", "", "", "")
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create Snapshot: %v", err)
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(fw.UserNamespace)).To(gomega.Succeed())
+		}
+	})
+
+	var _ = ginkgo.Describe("Post-release verification", func() {
+
+		ginkgo.It("verifies that a Release CR should have been created in the dev namespace", func() {
+			gomega.Eventually(func() error {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetFirstReleaseInNamespace(devNamespace)
+				return err
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies that Tenant PipelineRun is triggered", func() {
+			gomega.Expect(fw.AsKubeAdmin.TektonController.WaitForReleasePipelineToBeFinished(releaseCR, devNamespace)).To(gomega.Succeed(), "tenant pipelinerun for %s/%s failed", releaseCR.GetNamespace(), releaseCR.GetName())
+		})
+
+		ginkgo.It("verifies that a Release is marked as succeeded.", func() {
+			gomega.Eventually(func() error {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetFirstReleaseInNamespace(devNamespace)
+				if err != nil {
+					return fmt.Errorf("failed to get Release: %w", err)
+				}
+				if !releaseCR.IsReleased() {
+					return fmt.Errorf("release %s is not marked as released yet", releaseCR.Name)
+				}
+				return nil
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+	})
+})

--- a/e2e-tests/tests/release/testdata.go
+++ b/e2e-tests/tests/release/testdata.go
@@ -1,0 +1,31 @@
+// Package common provides test data and helper functions for release e2e tests.
+package common
+
+import (
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Test suite labels for release-service e2e tests.
+var (
+	LabelReleaseService   = ginkgo.Label("release-service")
+	LabelHappyPath        = ginkgo.Label("release-service", "happy-path")
+	LabelTenant           = ginkgo.Label("release-service", "tenant")
+	LabelReleasePlanAdm   = ginkgo.Label("release-service", "release_plan_and_admission")
+	LabelNegative         = ginkgo.Label("release-service", "release-neg", "negMissingReleasePlan")
+	LabelNegBlockReleases = ginkgo.Label("release-service", "release-neg", "negBlockReleases")
+)
+
+// ManagednamespaceSecret contains the secrets required for the managed namespace.
+var ManagednamespaceSecret = []corev1.ObjectReference{
+	{Name: constants.RedhatAppstudioUserSecret},
+	{Name: constants.ReleaseCatalogTAQuaySecret},
+}
+
+// Pipeline configuration variables (loaded from environment at runtime).
+var (
+	RelSvcCatalogURL      string = utils.GetEnv("RELEASE_SERVICE_CATALOG_URL", "https://github.com/konflux-ci/release-service-catalog")
+	RelSvcCatalogRevision string = utils.GetEnv("RELEASE_SERVICE_CATALOG_REVISION", "development")
+)

--- a/go.mod
+++ b/go.mod
@@ -148,7 +148,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.3 // indirect
 	k8s.io/component-base v0.35.3 // indirect
-	k8s.io/klog/v2 v2.140.0 // indirect
+	k8s.io/klog/v2 v2.140.0
 	k8s.io/kube-openapi v0.0.0-20260330154417-16be699c7b31 // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -5,10 +5,9 @@ metadata:
   name: konflux-e2e-tests-pipeline
 spec:
   description: |-
-    This pipeline automates the process of running end-to-end tests for Konflux
-    using a Kind cluster running on AWS cluster. The pipeline provisions
-    the Kind cluster, installs Konflux using the konflux-ci repository scripts, runs the tests, collects artifacts,
-    and finally deprovisions the Kind cluster.
+    This pipeline runs release-service e2e tests on an ephemeral Kind cluster.
+    It provisions the cluster on AWS, deploys Konflux, runs the Ginkgo test suite
+    from the e2e-tests/ directory, collects artifacts, and deprovisions the cluster.
   params:
     - name: SNAPSHOT
       description: 'The JSON string representing the snapshot of the application under test.'
@@ -37,13 +36,16 @@ spec:
       description: The ORAS container used to store all test artifacts.
     - name: component-image
       default: 'none'
-      description: 'Container image built from any konflux git repo. Use this param only when you run Konflux e2e tests
-        in another Konflux component repo. Will pass the component built image from the snapshot.'
+      description: 'Container image built from any konflux git repo.'
     - name: artifact-browser-url
       description: "URL to the artifact browser deployment. If provided, a link will be added to PR comments."
       default: ""
       type: string
+
   tasks:
+    # ──────────────────────────────────────────────────────────────────────────
+    # Pre-flight: decide whether to run e2e
+    # ──────────────────────────────────────────────────────────────────────────
     - name: check-if-e2e-irrelevant
       taskRef:
         resolver: git
@@ -54,6 +56,7 @@ spec:
             value: main
           - name: pathInRepo
             value: tasks/check-if-e2e-irrelevant/0.1/check-if-e2e-irrelevant.yaml
+
     - name: test-metadata
       when:
         - input: "$(tasks.check-if-e2e-irrelevant.results.result)"
@@ -73,6 +76,10 @@ spec:
           value: $(params.SNAPSHOT)
         - name: test-name
           value: $(context.pipelineRun.name)
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Infrastructure: provision cluster and deploy Konflux
+    # ──────────────────────────────────────────────────────────────────────────
     - name: provision-kind-cluster
       runAfter:
         - test-metadata
@@ -118,7 +125,10 @@ spec:
           value: $(params.konflux-test-infra-secret)
         - name: spot-increase-rate
           value: 80
+
     - name: deploy-konflux
+      runAfter:
+        - provision-kind-cluster
       when:
         - input: "$(tasks.check-if-e2e-irrelevant.results.result)"
           operator: in
@@ -129,8 +139,6 @@ spec:
         - input: "$(tasks.test-metadata.results.component-name)"
           operator: in
           values: ["release-service"]
-      runAfter:
-        - provision-kind-cluster
       taskRef:
         resolver: git
         params:
@@ -163,8 +171,14 @@ spec:
           value: konflux-test-infra
         - name: build-credentials
           value: konflux-e2e-secrets
-    - name: konflux-e2e-tests
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # E2E tests: clone release-service repo and run Ginkgo suite
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: release-service-e2e-tests
       timeout: 3h
+      runAfter:
+        - deploy-konflux
       when:
         - input: "$(tasks.check-if-e2e-irrelevant.results.result)"
           operator: in
@@ -175,38 +189,149 @@ spec:
         - input: "$(tasks.test-metadata.results.component-name)"
           operator: in
           values: ["release-service"]
-      runAfter:
-        - deploy-konflux
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/e2e-tests.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: integration-tests/tasks/konflux-e2e-tests/0.2/konflux-e2e-tests.yaml
       params:
-        - name: test-name
-          value: "$(context.pipelineRun.name)"
-        - name: git-repo
-          value: "$(tasks.test-metadata.results.git-repo)"
         - name: git-url
           value: "$(tasks.test-metadata.results.git-url)"
         - name: git-revision
           value: "$(tasks.test-metadata.results.git-revision)"
         - name: oras-container
           value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
-        - name: job-spec
-          value: "$(tasks.test-metadata.results.job-spec)"
-        - name: component-image
-          value: "$(tasks.test-metadata.results.instrumented-container-image)"
         - name: cluster-access-secret-name
           value: kfg-$(context.pipelineRun.name)
-        - name: test-environment
-          value: "upstream"
+      taskSpec:
+        params:
+          - name: git-url
+            type: string
+          - name: git-revision
+            type: string
+          - name: oras-container
+            type: string
+          - name: cluster-access-secret-name
+            type: string
+        volumes:
+          - name: konflux-ci-secrets-volume
+            secret:
+              secretName: konflux-e2e-secrets
+          - name: konflux-infra-secrets-volume
+            secret:
+              secretName: konflux-test-infra
+          - name: cluster-secret-volume
+            secret:
+              optional: true
+              secretName: $(params.cluster-access-secret-name)
+        steps:
+          - name: e2e-test
+            image: registry.access.redhat.com/ubi9/go-toolset:9.7-1768393489
+            securityContext:
+              runAsUser: 0
+            volumeMounts:
+              - name: konflux-ci-secrets-volume
+                mountPath: /usr/local/konflux-ci-secrets
+              - name: konflux-infra-secrets-volume
+                mountPath: /usr/local/konflux-test-infra
+              - name: cluster-secret-volume
+                mountPath: /tmp/kubeconfig
+                subPath: kubeconfig
+            env:
+              - name: KUBECONFIG
+                value: /tmp/kubeconfig
+              - name: GOTOOLCHAIN
+                value: auto
+              - name: GOMAXPROCS
+                value: "4"
+              - name: ARTIFACT_DIR
+                value: /tmp/artifact-dir
+              - name: GIT_URL
+                value: $(params.git-url)
+              - name: GIT_REVISION
+                value: $(params.git-revision)
+              - name: E2E_TIMEOUT
+                value: "45m"
+            onError: continue
+            script: |
+              #!/bin/bash
+              set -euo pipefail
+
+              # Load and decode secrets (stored as base64 in konflux-e2e-secrets)
+              SECRETS="/usr/local/konflux-ci-secrets"
+              export QUAY_TOKEN="$(base64 -d < "${SECRETS}/quay-token")"
+              export RELEASE_CATALOG_TA_QUAY_TOKEN="$(base64 -d < "${SECRETS}/release-catalog-ta-quay-token")"
+
+              # Set up a clean working directory
+              WORK_DIR="$(mktemp -d)"
+              export GOPATH="${WORK_DIR}/go"
+              export GOCACHE="${WORK_DIR}/cache"
+              mkdir -p "${ARTIFACT_DIR}" "${GOPATH}" "${GOCACHE}"
+
+              # Clone and checkout the release-service repo at the PR revision
+              git clone "${GIT_URL}" "${WORK_DIR}/release-service"
+              cd "${WORK_DIR}/release-service"
+              git checkout "${GIT_REVISION}"
+
+              # Prepare Go toolchain and Ginkgo
+              go mod download
+              go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+              export PATH="${GOPATH}/bin:${PATH}"
+
+              # Run the release-service e2e test suite
+              cd e2e-tests
+              ginkgo -v \
+                --no-color \
+                --output-interceptor-mode=none \
+                --fail-on-empty \
+                --timeout="${E2E_TIMEOUT}" \
+                --output-dir="${ARTIFACT_DIR}" \
+                --junit-report=e2e-report.xml \
+                --label-filter="release-service" \
+                ./cmd
+          - name: secure-push-oci
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/tekton-integration-catalog.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+            params:
+              - name: workdir-path
+                value: /tmp/artifact-dir
+              - name: oci-ref
+                value: $(params.oras-container)
+              - name: credentials-volume-name
+                value: konflux-infra-secrets-volume
+          - name: fail-if-any-step-failed
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/tekton-integration-catalog.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Finally: coverage, status, deprovision, PR comment
+  # ────────────────────────────────────────────────────────────────────────────
   finally:
     - name: collect-and-upload-coverage
+      when:
+        - input: $(tasks.release-service-e2e-tests.status)
+          operator: in
+          values:
+            - Succeeded
+            - Failed
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/coverport-coverage/0.1/coverport-coverage.yaml
       params:
         - name: instrumented-images
           value: "$(tasks.test-metadata.results.instrumented-container-repo):$(tasks.test-metadata.results.instrumented-container-tag)"
@@ -220,21 +345,7 @@ spec:
           value: e2e-tests
         - name: credentials-secret-name
           value: "release-service-coverport-secrets"
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: tasks/coverport-coverage/0.1/coverport-coverage.yaml
-      when:
-        - input: $(tasks.konflux-e2e-tests.status)
-          operator: in
-          values:
-            - Succeeded
-            - Failed
+
     - name: store-pipeline-status
       when:
         - input: "$(tasks.check-if-e2e-irrelevant.results.result)"
@@ -264,6 +375,7 @@ spec:
           value: $(context.pipelineRun.name)
         - name: pipeline-aggregate-status
           value: $(tasks.status)
+
     - name: deprovision-kind-cluster
       when:
         - input: "$(tasks.check-if-e2e-irrelevant.results.result)"
@@ -295,6 +407,7 @@ spec:
           value: $(params.oci-container-repo):$(context.pipelineRun.name)
         - name: oci-credentials
           value: konflux-test-infra
+
     - name: pull-request-status-message
       when:
         - input: "$(tasks.check-if-e2e-irrelevant.results.result)"


### PR DESCRIPTION
## Summary

This PR migrates the release-service end-to-end (e2e) test suite from the external [`konflux-ci/e2e-tests`](https://github.com/konflux-ci/e2e-tests) repository into this repo under `e2e-tests/`.

Having the e2e tests co-located with the service code enables faster iteration, tighter review cycles, and removes the cross-repo dependency that slowed down test development.

**Jira:** [KFLUXDP-880](https://redhat.atlassian.net/browse/KFLUXDP-880)

## What changed

### New e2e test framework (`e2e-tests/pkg/`)
- **`framework/`** — Kubernetes/Konflux client setup, helper functions to create and manage Release, ReleasePlan, ReleasePlanAdmission, Snapshot, Application, and Component resources.
- **`constants/`** — Shared test constants (timeouts, namespaces, labels).
- **`utils/`** — General-purpose utilities for test execution.

### Migrated test specs (`e2e-tests/tests/release/service/`)
| Test | Description |
|------|-------------|
| `happy_path` | Validates the full release lifecycle from Snapshot to successful Release |
| `tenant_pipelines` | Tests release processing with tenant-scoped pipelines |
| `release_plan_and_admission_matched` | Ensures a ReleasePlan is correctly matched to a ReleasePlanAdmission |
| `missing_release_plan_and_admission` | Verifies graceful handling when ReleasePlan or Admission resources are missing |
| `block_releases_release_plan_admission` *(new)* | Confirms the `block-releases` label on a ReleasePlanAdmission prevents release processing |

### Build & CI updates
- **Makefile** — Added `test-e2e` and `test-e2e-list` targets; excluded `e2e-tests/` from the unit test target so `make test` stays fast.
- **Tekton pipeline** (`integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml`) — Replaced the external e2e task reference with an inline `taskSpec` that clones this repo and runs Ginkgo directly.
- **.gitignore** — Added test report patterns (`*-report.xml`, `*.junit.xml`).

## How to run

```bash
# Run all e2e tests
make test-e2e

# Run a specific test by label
make test-e2e LABEL="happy-path"

# List all available tests (dry run)
make test-e2e-list
```

> See [`e2e-tests/README.md`](e2e-tests/README.md) for full setup instructions and environment variable requirements.

## Test plan
- [ ] Unit tests pass (`make test`)
- [ ] E2E tests pass in a Konflux cluster (`make test-e2e`)
- [ ] CI pipeline completes successfully with the new inline task
- [ ] Verify the `block-releases` test correctly blocks release processing

[KFLUXDP-880]: https://redhat.atlassian.net/browse/KFLUXDP-880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ