### PR TITLE
chore: update tekton schedule to run between 0-4 hours

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "rebaseWhen": "behind-base-branch",
   "tekton": {
-    "schedule": ["* 0 * * *"]
+    "schedule": ["* 0-4 * * *"]
   }
 }


### PR DESCRIPTION
Update schedule to ["* 0-4 * * *"] to match documentation. Previously limited to 1 hour, which could cause MintMaker to run within the 4-hour block but be blocked from creating PRs.