### PR TITLE
feat(RELEASE-2151): add componentGroup support for rp and rpa

### DIFF
--- a/api/v1alpha1/releaseplan_types_test.go
+++ b/api/v1alpha1/releaseplan_types_test.go
@@ -100,6 +100,26 @@ var _ = Describe("ReleasePlan type", func() {
 		})
 	})
 
+	When("GetGroupName method is called", func() {
+		It("should return Application when set", func() {
+			releasePlan := &ReleasePlan{
+				Spec: ReleasePlanSpec{
+					Application: "my-app",
+				},
+			}
+			Expect(releasePlan.GetGroupName()).To(Equal("my-app"))
+		})
+
+		It("should return ComponentGroup when Application is empty", func() {
+			releasePlan := &ReleasePlan{
+				Spec: ReleasePlanSpec{
+					ComponentGroup: "my-group",
+				},
+			}
+			Expect(releasePlan.GetGroupName()).To(Equal("my-group"))
+		})
+	})
+
 	When("setMatchedStatus method is called", func() {
 		var releasePlan *ReleasePlan
 		var releasePlanAdmission *ReleasePlanAdmission

--- a/api/v1alpha1/releaseplanadmission_types_test.go
+++ b/api/v1alpha1/releaseplanadmission_types_test.go
@@ -126,4 +126,90 @@ var _ = Describe("ReleasePlanAdmission type", func() {
 			}))
 		})
 	})
+
+	When("MatchesReleasePlan method is called", func() {
+		It("should return true when RP Application is in RPA Applications", func() {
+			releasePlan := &ReleasePlan{
+				Spec: ReleasePlanSpec{
+					Application: "my-app",
+				},
+			}
+			releasePlanAdmission := &ReleasePlanAdmission{
+				Spec: ReleasePlanAdmissionSpec{
+					Applications: []string{"my-app", "other-app"},
+				},
+			}
+			Expect(releasePlanAdmission.MatchesReleasePlan(releasePlan)).To(BeTrue())
+		})
+
+		It("should return true when RP ComponentGroup is in RPA ComponentGroups", func() {
+			releasePlan := &ReleasePlan{
+				Spec: ReleasePlanSpec{
+					ComponentGroup: "my-group",
+				},
+			}
+			releasePlanAdmission := &ReleasePlanAdmission{
+				Spec: ReleasePlanAdmissionSpec{
+					ComponentGroups: []string{"my-group", "other-group"},
+				},
+			}
+			Expect(releasePlanAdmission.MatchesReleasePlan(releasePlan)).To(BeTrue())
+		})
+
+		It("should return true when RP Application is in RPA ComponentGroups (backward compatible)", func() {
+			releasePlan := &ReleasePlan{
+				Spec: ReleasePlanSpec{
+					Application: "my-app",
+				},
+			}
+			releasePlanAdmission := &ReleasePlanAdmission{
+				Spec: ReleasePlanAdmissionSpec{
+					ComponentGroups: []string{"my-app"},
+				},
+			}
+			Expect(releasePlanAdmission.MatchesReleasePlan(releasePlan)).To(BeTrue())
+		})
+
+		It("should return true when RP ComponentGroup is in RPA Applications (backward compatible)", func() {
+			releasePlan := &ReleasePlan{
+				Spec: ReleasePlanSpec{
+					ComponentGroup: "my-group",
+				},
+			}
+			releasePlanAdmission := &ReleasePlanAdmission{
+				Spec: ReleasePlanAdmissionSpec{
+					Applications: []string{"my-group"},
+				},
+			}
+			Expect(releasePlanAdmission.MatchesReleasePlan(releasePlan)).To(BeTrue())
+		})
+
+		It("should return false when RP Application is not in any RPA list", func() {
+			releasePlan := &ReleasePlan{
+				Spec: ReleasePlanSpec{
+					Application: "my-app",
+				},
+			}
+			releasePlanAdmission := &ReleasePlanAdmission{
+				Spec: ReleasePlanAdmissionSpec{
+					Applications: []string{"other-app"},
+				},
+			}
+			Expect(releasePlanAdmission.MatchesReleasePlan(releasePlan)).To(BeFalse())
+		})
+
+		It("should return false when RP ComponentGroup is not in any RPA list", func() {
+			releasePlan := &ReleasePlan{
+				Spec: ReleasePlanSpec{
+					ComponentGroup: "my-group",
+				},
+			}
+			releasePlanAdmission := &ReleasePlanAdmission{
+				Spec: ReleasePlanAdmissionSpec{
+					ComponentGroups: []string{"other-group"},
+				},
+			}
+			Expect(releasePlanAdmission.MatchesReleasePlan(releasePlan)).To(BeFalse())
+		})
+	})
 })

--- a/api/v1alpha1/webhooks/releaseplan/webhook.go
+++ b/api/v1alpha1/webhooks/releaseplan/webhook.go
@@ -18,7 +18,6 @@ package releaseplan
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/konflux-ci/release-service/api/v1alpha1"
@@ -66,26 +65,14 @@ func (w *Webhook) Register(mgr ctrl.Manager, log *logr.Logger) error {
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+// Validation is handled by CRD schema (maxLength, pattern) and CEL rules (mutual exclusivity).
 func (w *Webhook) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
-	releasePlan := obj.(*v1alpha1.ReleasePlan)
-
-	// Validate that the Application field doesn't exceed Kubernetes label value limit (63 characters)
-	if len(releasePlan.Spec.Application) > 63 {
-		return nil, fmt.Errorf("application name must be no more than 63 characters, got %d characters", len(releasePlan.Spec.Application))
-	}
-
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+// Validation is handled by CRD schema (maxLength, pattern) and CEL rules (mutual exclusivity).
 func (w *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
-	releasePlan := newObj.(*v1alpha1.ReleasePlan)
-
-	// Validate that the Application field doesn't exceed Kubernetes label value limit (63 characters)
-	if len(releasePlan.Spec.Application) > 63 {
-		return nil, fmt.Errorf("application name must be no more than 63 characters, got %d characters", len(releasePlan.Spec.Application))
-	}
-
 	return nil, nil
 }
 

--- a/api/v1alpha1/webhooks/releaseplanadmission/webhook_test.go
+++ b/api/v1alpha1/webhooks/releaseplanadmission/webhook_test.go
@@ -169,4 +169,45 @@ var _ = Describe("ReleasePlanAdmission webhook", func() {
 			Expect(err.Error()).To(ContainSubstring("must be no more than 63 characters"))
 		})
 	})
+
+	When("a ReleasePlanAdmission is created with a componentGroup name longer than 63 characters", func() {
+		It("should be rejected", func() {
+			releasePlanAdmission.Spec.Applications = nil
+			releasePlanAdmission.Spec.ComponentGroups = []string{
+				"this-is-a-very-long-component-group-name-that-exceeds-sixty-three-chars",
+			}
+			err := k8sClient.Create(ctx, releasePlanAdmission)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("componentGroup name"))
+			Expect(err.Error()).To(ContainSubstring("must be no more than 63 characters"))
+		})
+	})
+
+	When("a ReleasePlanAdmission is created with both applications and componentGroups", func() {
+		It("should be rejected", func() {
+			releasePlanAdmission.Spec.Applications = []string{"app"}
+			releasePlanAdmission.Spec.ComponentGroups = []string{"group"}
+			err := k8sClient.Create(ctx, releasePlanAdmission)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("exactly one of applications or componentGroups must be specified"))
+		})
+	})
+
+	When("a ReleasePlanAdmission is created with neither applications nor componentGroups", func() {
+		It("should be rejected", func() {
+			releasePlanAdmission.Spec.Applications = nil
+			releasePlanAdmission.Spec.ComponentGroups = nil
+			err := k8sClient.Create(ctx, releasePlanAdmission)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("exactly one of applications or componentGroups must be specified"))
+		})
+	})
+
+	When("a ReleasePlanAdmission is created with only componentGroups", func() {
+		It("should succeed", func() {
+			releasePlanAdmission.Spec.Applications = nil
+			releasePlanAdmission.Spec.ComponentGroups = []string{"my-component-group"}
+			Expect(k8sClient.Create(ctx, releasePlanAdmission)).Should(Succeed())
+		})
+	})
 })

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -342,6 +342,11 @@ func (in *ReleasePlanAdmissionSpec) DeepCopyInto(out *ReleasePlanAdmissionSpec) 
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ComponentGroups != nil {
+		in, out := &in.ComponentGroups, &out.ComponentGroups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Collectors != nil {
 		in, out := &in.Collectors, &out.Collectors
 		*out = new(Collectors)

--- a/config/crd/bases/appstudio.redhat.com_releaseplanadmissions.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplanadmissions.yaml
@@ -50,10 +50,12 @@ spec:
             description: ReleasePlanAdmissionSpec defines the desired state of ReleasePlanAdmission.
             properties:
               applications:
-                description: Applications is a list of references to applications
-                  to be released in the managed namespace
+                description: |-
+                  Applications is a list of references to applications to be released in the managed namespace.
+                  Either applications or componentGroups must be specified, but not both.
                 items:
                   type: string
+                minItems: 1
                 type: array
               collectors:
                 description: Collectors contains all the information of the collectors
@@ -115,6 +117,14 @@ spec:
                 required:
                 - items
                 type: object
+              componentGroups:
+                description: |-
+                  ComponentGroups is a list of references to component groups to be released in the managed namespace.
+                  Either applications or componentGroups must be specified, but not both.
+                items:
+                  type: string
+                minItems: 1
+                type: array
               data:
                 description: Data is an unstructured key used for providing data for
                   the managed Release Pipeline
@@ -996,10 +1006,12 @@ spec:
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
             required:
-            - applications
             - origin
             - policy
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of applications or componentGroups must be specified
+              rule: has(self.applications) != has(self.componentGroups)
           status:
             description: ReleasePlanAdmissionStatus defines the observed state of
               ReleasePlanAdmission.

--- a/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .spec.application
       name: Application
       type: string
+    - jsonPath: .spec.componentGroup
+      name: ComponentGroup
+      type: string
     - jsonPath: .spec.target
       name: Target
       type: string
@@ -49,8 +52,10 @@ spec:
             description: ReleasePlanSpec defines the desired state of ReleasePlan.
             properties:
               application:
-                description: Application is a reference to the application to be released
-                  in the managed namespace
+                description: |-
+                  Application is a reference to the application to be released in the managed namespace.
+                  Either application or componentGroup must be specified, but not both.
+                maxLength: 63
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
               collectors:
@@ -113,6 +118,13 @@ spec:
                 required:
                 - items
                 type: object
+              componentGroup:
+                description: |-
+                  ComponentGroup is a reference to the component group to be released in the managed namespace.
+                  Either application or componentGroup must be specified, but not both.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
               data:
                 description: Data is an unstructured key used for providing data for
                   the managed Release Pipeline
@@ -1886,9 +1898,10 @@ spec:
                 required:
                 - pipelineRef
                 type: object
-            required:
-            - application
             type: object
+            x-kubernetes-validations:
+            - message: exactly one of application or componentGroup must be specified
+              rule: has(self.application) != has(self.componentGroup)
           status:
             description: ReleasePlanStatus defines the observed state of ReleasePlan.
             properties:

--- a/controllers/utils/predicates/predicates.go
+++ b/controllers/utils/predicates/predicates.go
@@ -74,20 +74,19 @@ func hasBehaviorLabelChanged(objectOld, objectNew client.Object) bool {
 }
 
 // haveApplicationsChanged returns true if passed objects are of the same kind and the
-// Spec.Application(s) values between them is different.
+// Spec.Application/ComponentGroup or Spec.Applications/ComponentGroups values between them is different.
 func haveApplicationsChanged(objectOld, objectNew client.Object) bool {
 	if releasePlanOld, ok := objectOld.(*v1alpha1.ReleasePlan); ok {
 		if releasePlanNew, ok := objectNew.(*v1alpha1.ReleasePlan); ok {
-			return releasePlanOld.Spec.Application != releasePlanNew.Spec.Application
+			return releasePlanOld.Spec.Application != releasePlanNew.Spec.Application ||
+				releasePlanOld.Spec.ComponentGroup != releasePlanNew.Spec.ComponentGroup
 		}
 	}
 
 	if releasePlanAdmissionOld, ok := objectOld.(*v1alpha1.ReleasePlanAdmission); ok {
 		if releasePlanAdmissionNew, ok := objectNew.(*v1alpha1.ReleasePlanAdmission); ok {
-			return !reflect.DeepEqual(
-				releasePlanAdmissionOld.Spec.Applications,
-				releasePlanAdmissionNew.Spec.Applications,
-			)
+			return !reflect.DeepEqual(releasePlanAdmissionOld.Spec.Applications, releasePlanAdmissionNew.Spec.Applications) ||
+				!reflect.DeepEqual(releasePlanAdmissionOld.Spec.ComponentGroups, releasePlanAdmissionNew.Spec.ComponentGroups)
 		}
 	}
 


### PR DESCRIPTION
This change adds spec.componentGroup to ReleasePlan and spec.componentGroups to ReleasePlanAdmission as alternatives to the existing application fields.

The matching logic is backward compatible, allowing a ReleasePlan to match a ReleasePlanAdmission regardless of whether they use applications or componentGroups. All existing resources with application fields continue to work unchanged.

Assisted-by: Claude Code