### PR TITLE
fix(KONFLUX-12127): surface pipeline creation errors to Release status

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -543,6 +543,41 @@ func (r *Release) MarkManagedCollectorsPipelineProcessing() {
 	)
 }
 
+// MarkManagedPipelineProcessing marks the Release Managed Pipeline as processing.
+// This is used when the PipelineRun creation itself fails before any attempt can be registered.
+func (r *Release) MarkManagedPipelineProcessing() {
+	if r.HasManagedPipelineProcessingFinished() {
+		return
+	}
+
+	if !r.IsManagedPipelineProcessing() {
+		// Deprecated: populate ManagedProcessing for backward compatibility
+		r.Status.ManagedProcessing.StartTime = &metav1.Time{Time: time.Now()}
+	}
+
+	conditions.SetCondition(&r.Status.Conditions, managedProcessedConditionType, metav1.ConditionFalse, ProgressingReason)
+}
+
+// MarkManagedPipelineProcessingFailed marks the Release Managed Pipeline processing as failed.
+// This is used when the PipelineRun creation itself fails before any attempt can be registered.
+func (r *Release) MarkManagedPipelineProcessingFailed(message string) {
+	if !r.IsManagedPipelineProcessing() || r.HasManagedPipelineProcessingFinished() {
+		return
+	}
+
+	// Deprecated: populate ManagedProcessing for backward compatibility
+	r.Status.ManagedProcessing.CompletionTime = &metav1.Time{Time: time.Now()}
+	conditions.SetConditionWithMessage(&r.Status.Conditions, managedProcessedConditionType, metav1.ConditionFalse, FailedReason, message)
+
+	go metrics.RegisterCompletedReleasePipelineProcessing(
+		r.Status.ManagedProcessing.StartTime,
+		r.Status.ManagedProcessing.CompletionTime,
+		FailedReason.String(),
+		r.Status.Target,
+		metadata.ManagedPipelineType.String(),
+	)
+}
+
 // MarkCurrentManagedPipelineAttemptProcessing marks the current managed pipeline attempt as processing.
 func (r *Release) MarkCurrentManagedPipelineAttemptProcessing() {
 	// only block after success or skip, failed attempts can be retried
@@ -886,6 +921,26 @@ func (r *Release) getPhaseReason(conditionType conditions.ConditionType) string 
 	}
 
 	return reason
+}
+
+// HasPipelinePhaseFailed returns true if any pipeline processing phase (tenant collectors, managed
+// collectors, tenant, managed, or final) is in the Failed state. Skipped phases are not considered
+// failures. This is used by EnsureReleaseIsCompleted to decide whether to MarkReleased or
+// MarkReleaseFailed when all phases have finished.
+func (r *Release) HasPipelinePhaseFailed() bool {
+	for _, conditionType := range []conditions.ConditionType{
+		tenantCollectorsProcessedConditionType,
+		managedCollectorsProcessedConditionType,
+		tenantProcessedConditionType,
+		managedProcessedConditionType,
+		finalProcessedConditionType,
+	} {
+		condition := meta.FindStatusCondition(r.Status.Conditions, conditionType.String())
+		if condition != nil && condition.Status == metav1.ConditionFalse && condition.Reason == FailedReason.String() {
+			return true
+		}
+	}
+	return false
 }
 
 // hasPhaseFinished checks whether a Release phase (e.g. deployment or processing) has finished.

--- a/api/v1alpha1/release_types_test.go
+++ b/api/v1alpha1/release_types_test.go
@@ -258,6 +258,44 @@ var _ = Describe("Release type", func() {
 		})
 	})
 
+	When("HasPipelinePhaseFailed method is called", func() {
+		var release *Release
+
+		BeforeEach(func() {
+			release = &Release{}
+		})
+
+		It("should return false when no conditions are set", func() {
+			Expect(release.HasPipelinePhaseFailed()).To(BeFalse())
+		})
+
+		It("should return false when a phase has succeeded", func() {
+			conditions.SetCondition(&release.Status.Conditions, managedProcessedConditionType, metav1.ConditionTrue, SucceededReason)
+			Expect(release.HasPipelinePhaseFailed()).To(BeFalse())
+		})
+
+		It("should return false when a phase is skipped", func() {
+			conditions.SetCondition(&release.Status.Conditions, managedProcessedConditionType, metav1.ConditionTrue, SkippedReason)
+			Expect(release.HasPipelinePhaseFailed()).To(BeFalse())
+		})
+
+		It("should return false when a phase is still progressing", func() {
+			conditions.SetCondition(&release.Status.Conditions, managedProcessedConditionType, metav1.ConditionFalse, ProgressingReason)
+			Expect(release.HasPipelinePhaseFailed()).To(BeFalse())
+		})
+
+		It("should return true when a phase has failed", func() {
+			conditions.SetCondition(&release.Status.Conditions, managedProcessedConditionType, metav1.ConditionFalse, FailedReason)
+			Expect(release.HasPipelinePhaseFailed()).To(BeTrue())
+		})
+
+		It("should return true when multiple phases have failed", func() {
+			conditions.SetCondition(&release.Status.Conditions, tenantProcessedConditionType, metav1.ConditionFalse, FailedReason)
+			conditions.SetCondition(&release.Status.Conditions, managedProcessedConditionType, metav1.ConditionFalse, FailedReason)
+			Expect(release.HasPipelinePhaseFailed()).To(BeTrue())
+		})
+	})
+
 	When("IsAttributed method is called", func() {
 		var release *Release
 
@@ -1133,6 +1171,93 @@ var _ = Describe("Release type", func() {
 			Expect(*condition).To(MatchFields(IgnoreExtras, Fields{
 				"Reason": Equal(ProgressingReason.String()),
 				"Status": Equal(metav1.ConditionFalse),
+			}))
+		})
+	})
+
+	When("MarkManagedPipelineProcessing method is called", func() {
+		var release *Release
+
+		BeforeEach(func() {
+			release = &Release{}
+		})
+
+		It("should do nothing if the Release managed pipeline processing finished", func() {
+			release.MarkManagedPipelineProcessing()
+			release.Status.ManagedPipelineAttempts = []ManagedPipelineAttempt{{PipelineRun: "default/pr"}}
+			release.MarkCurrentManagedPipelineAttemptProcessed()
+			Expect(release.IsManagedPipelineProcessing()).To(BeFalse())
+			release.MarkManagedPipelineProcessing()
+			Expect(release.IsManagedPipelineProcessing()).To(BeFalse())
+		})
+
+		It("should register the start time if the managed pipeline is not processing", func() {
+			Expect(release.Status.ManagedProcessing.StartTime).To(BeNil())
+			release.MarkManagedPipelineProcessing()
+			Expect(release.Status.ManagedProcessing.StartTime).NotTo(BeNil())
+		})
+
+		It("should not register the start time if the managed pipeline is already processing", func() {
+			release.MarkManagedPipelineProcessing()
+			release.Status.ManagedProcessing.StartTime = &metav1.Time{}
+			Expect(release.Status.ManagedProcessing.StartTime.IsZero()).To(BeTrue())
+			release.MarkManagedPipelineProcessing()
+			Expect(release.Status.ManagedProcessing.StartTime.IsZero()).To(BeTrue())
+		})
+
+		It("should register the condition", func() {
+			Expect(release.Status.Conditions).To(HaveLen(0))
+			release.MarkManagedPipelineProcessing()
+
+			condition := meta.FindStatusCondition(release.Status.Conditions, managedProcessedConditionType.String())
+			Expect(condition).NotTo(BeNil())
+			Expect(*condition).To(MatchFields(IgnoreExtras, Fields{
+				"Reason": Equal(ProgressingReason.String()),
+				"Status": Equal(metav1.ConditionFalse),
+			}))
+		})
+	})
+
+	When("MarkManagedPipelineProcessingFailed method is called", func() {
+		var release *Release
+
+		BeforeEach(func() {
+			release = &Release{}
+		})
+
+		It("should do nothing if the Release managed pipeline processing has not started", func() {
+			release.MarkManagedPipelineProcessingFailed("")
+			Expect(release.Status.ManagedProcessing.CompletionTime).To(BeNil())
+		})
+
+		It("should do nothing if the Release managed pipeline processing finished", func() {
+			release.MarkManagedPipelineProcessing()
+			release.Status.ManagedPipelineAttempts = []ManagedPipelineAttempt{{PipelineRun: "default/pr"}}
+			release.MarkCurrentManagedPipelineAttemptProcessed()
+			Expect(release.Status.ManagedProcessing.CompletionTime.IsZero()).To(BeFalse())
+			release.Status.ManagedProcessing.CompletionTime = &metav1.Time{}
+			release.MarkManagedPipelineProcessingFailed("")
+			Expect(release.Status.ManagedProcessing.CompletionTime.IsZero()).To(BeTrue())
+		})
+
+		It("should register the completion time", func() {
+			release.MarkManagedPipelineProcessing()
+			Expect(release.Status.ManagedProcessing.CompletionTime).To(BeNil())
+			release.MarkManagedPipelineProcessingFailed("")
+			Expect(release.Status.ManagedProcessing.CompletionTime.IsZero()).To(BeFalse())
+		})
+
+		It("should register the condition", func() {
+			Expect(release.Status.Conditions).To(HaveLen(0))
+			release.MarkManagedPipelineProcessing()
+			release.MarkManagedPipelineProcessingFailed("foo")
+
+			condition := meta.FindStatusCondition(release.Status.Conditions, managedProcessedConditionType.String())
+			Expect(condition).NotTo(BeNil())
+			Expect(*condition).To(MatchFields(IgnoreExtras, Fields{
+				"Message": Equal("foo"),
+				"Reason":  Equal(FailedReason.String()),
+				"Status":  Equal(metav1.ConditionFalse),
 			}))
 		})
 	})

--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -256,28 +256,73 @@ func (a *adapter) EnsureManagedCollectorsPipelineIsProcessed() (controller.Opera
 				if tenantRoleBinding == nil {
 					tenantRoleBinding, err = a.createRoleBindingForClusterRole("release-pipeline-resource-role", releasePlanAdmission.Spec.Origin, releasePlanAdmission.Spec.Collectors.ServiceAccountName, releasePlanAdmission.Namespace)
 					if err != nil {
-						return controller.RequeueWithError(err)
+						return pipelineCreationResult(handlePipelineCreationError(a.ctx, a.client, a.release, err,
+							a.release.MarkManagedCollectorsPipelineProcessing,
+							a.release.MarkManagedCollectorsPipelineProcessingFailed,
+							"Release processing failed on managed collectors RoleBinding creation"))
 					}
 				}
 
 				if managedRoleBinding == nil {
 					managedRoleBinding, err = a.createRoleBindingForClusterRole("release-pipeline-resource-role", releasePlanAdmission.Namespace, releasePlanAdmission.Spec.Collectors.ServiceAccountName, releasePlanAdmission.Namespace)
 					if err != nil {
-						return controller.RequeueWithError(err)
+						capturedTenant := tenantRoleBinding
+						return pipelineCreationResult(handlePipelineCreationError(a.ctx, a.client, a.release, err,
+							a.release.MarkManagedCollectorsPipelineProcessing,
+							a.release.MarkManagedCollectorsPipelineProcessingFailed,
+							"Release processing failed on managed collectors RoleBinding creation",
+							func() {
+								if capturedTenant != nil {
+									a.release.Status.CollectorsProcessing.ManagedCollectorsProcessing.RoleBindings.TenantRoleBinding =
+										fmt.Sprintf("%s%c%s", capturedTenant.Namespace, types.Separator, capturedTenant.Name)
+								}
+							}))
 					}
 				}
 
 				if secretRoleBinding == nil && releasePlanAdmission.Spec.Collectors.Secrets != nil {
 					secretRoleBinding, err = a.createRoleBindingForCollectorSecrets("managed-collectors", releasePlanAdmission.Namespace, releasePlanAdmission.Spec.Collectors.ServiceAccountName, releasePlanAdmission.Spec.Collectors.Secrets)
 					if err != nil {
-						return controller.RequeueWithError(err)
+						capturedTenant, capturedManaged := tenantRoleBinding, managedRoleBinding
+						return pipelineCreationResult(handlePipelineCreationError(a.ctx, a.client, a.release, err,
+							a.release.MarkManagedCollectorsPipelineProcessing,
+							a.release.MarkManagedCollectorsPipelineProcessingFailed,
+							"Release processing failed on managed collectors RoleBinding creation",
+							func() {
+								if capturedTenant != nil {
+									a.release.Status.CollectorsProcessing.ManagedCollectorsProcessing.RoleBindings.TenantRoleBinding =
+										fmt.Sprintf("%s%c%s", capturedTenant.Namespace, types.Separator, capturedTenant.Name)
+								}
+								if capturedManaged != nil {
+									a.release.Status.CollectorsProcessing.ManagedCollectorsProcessing.RoleBindings.ManagedRoleBinding =
+										fmt.Sprintf("%s%c%s", capturedManaged.Namespace, types.Separator, capturedManaged.Name)
+								}
+							}))
 					}
 				}
 			}
 
 			pipelineRun, err = a.createManagedCollectorsPipelineRun(releasePlanAdmission)
 			if err != nil {
-				return controller.RequeueWithError(err)
+				capturedTenant, capturedManaged, capturedSecret := tenantRoleBinding, managedRoleBinding, secretRoleBinding
+				return pipelineCreationResult(handlePipelineCreationError(a.ctx, a.client, a.release, err,
+					a.release.MarkManagedCollectorsPipelineProcessing,
+					a.release.MarkManagedCollectorsPipelineProcessingFailed,
+					"Release processing failed on managed collectors pipelineRun creation",
+					func() {
+						if capturedTenant != nil {
+							a.release.Status.CollectorsProcessing.ManagedCollectorsProcessing.RoleBindings.TenantRoleBinding =
+								fmt.Sprintf("%s%c%s", capturedTenant.Namespace, types.Separator, capturedTenant.Name)
+						}
+						if capturedManaged != nil {
+							a.release.Status.CollectorsProcessing.ManagedCollectorsProcessing.RoleBindings.ManagedRoleBinding =
+								fmt.Sprintf("%s%c%s", capturedManaged.Namespace, types.Separator, capturedManaged.Name)
+						}
+						if capturedSecret != nil {
+							a.release.Status.CollectorsProcessing.ManagedCollectorsProcessing.RoleBindings.SecretRoleBinding =
+								fmt.Sprintf("%s%c%s", capturedSecret.Namespace, types.Separator, capturedSecret.Name)
+						}
+					}))
 			}
 
 			a.logger.Info(fmt.Sprintf("Created %s Release PipelineRun", metadata.ManagedCollectorsPipelineType),
@@ -357,21 +402,48 @@ func (a *adapter) EnsureTenantCollectorsPipelineIsProcessed() (controller.Operat
 				if tenantRoleBinding == nil {
 					tenantRoleBinding, err = a.createRoleBindingForClusterRole("release-pipeline-resource-role", releasePlan.Namespace, releasePlan.Spec.Collectors.ServiceAccountName, releasePlan.Namespace)
 					if err != nil {
-						return controller.RequeueWithError(err)
+						return pipelineCreationResult(handlePipelineCreationError(a.ctx, a.client, a.release, err,
+							a.release.MarkTenantCollectorsPipelineProcessing,
+							a.release.MarkTenantCollectorsPipelineProcessingFailed,
+							"Release processing failed on tenant collectors RoleBinding creation"))
 					}
 				}
 
 				if secretRoleBinding == nil && releasePlan.Spec.Collectors.Secrets != nil {
 					secretRoleBinding, err = a.createRoleBindingForCollectorSecrets("tenant-collectors", releasePlan.Namespace, releasePlan.Spec.Collectors.ServiceAccountName, releasePlan.Spec.Collectors.Secrets)
 					if err != nil {
-						return controller.RequeueWithError(err)
+						capturedTenant := tenantRoleBinding
+						return pipelineCreationResult(handlePipelineCreationError(a.ctx, a.client, a.release, err,
+							a.release.MarkTenantCollectorsPipelineProcessing,
+							a.release.MarkTenantCollectorsPipelineProcessingFailed,
+							"Release processing failed on tenant collectors RoleBinding creation",
+							func() {
+								if capturedTenant != nil {
+									a.release.Status.CollectorsProcessing.TenantCollectorsProcessing.RoleBindings.TenantRoleBinding =
+										fmt.Sprintf("%s%c%s", capturedTenant.Namespace, types.Separator, capturedTenant.Name)
+								}
+							}))
 					}
 				}
 			}
 
 			pipelineRun, err = a.createTenantCollectorsPipelineRun(releasePlan, releasePlanAdmission)
 			if err != nil {
-				return controller.RequeueWithError(err)
+				capturedTenant, capturedSecret := tenantRoleBinding, secretRoleBinding
+				return pipelineCreationResult(handlePipelineCreationError(a.ctx, a.client, a.release, err,
+					a.release.MarkTenantCollectorsPipelineProcessing,
+					a.release.MarkTenantCollectorsPipelineProcessingFailed,
+					"Release processing failed on tenant collectors pipelineRun creation",
+					func() {
+						if capturedTenant != nil {
+							a.release.Status.CollectorsProcessing.TenantCollectorsProcessing.RoleBindings.TenantRoleBinding =
+								fmt.Sprintf("%s%c%s", capturedTenant.Namespace, types.Separator, capturedTenant.Name)
+						}
+						if capturedSecret != nil {
+							a.release.Status.CollectorsProcessing.TenantCollectorsProcessing.RoleBindings.SecretRoleBinding =
+								fmt.Sprintf("%s%c%s", capturedSecret.Namespace, types.Separator, capturedSecret.Name)
+						}
+					}))
 			}
 
 			a.logger.Info(fmt.Sprintf("Created %s Release PipelineRun", metadata.TenantCollectorsPipelineType),
@@ -445,7 +517,10 @@ func (a *adapter) EnsureTenantPipelineIsProcessed() (controller.OperationResult,
 
 			pipelineRun, err = a.createTenantPipelineRun(releasePlan, snapshot)
 			if err != nil {
-				return controller.RequeueWithError(err)
+				return pipelineCreationResult(handlePipelineCreationError(a.ctx, a.client, a.release, err,
+					a.release.MarkTenantPipelineProcessing,
+					a.release.MarkTenantPipelineProcessingFailed,
+					"Release processing failed on tenant pipelineRun creation"))
 			}
 
 			a.logger.Info(fmt.Sprintf("Created %s Release PipelineRun", metadata.TenantPipelineType),
@@ -508,13 +583,26 @@ func (a *adapter) EnsureManagedPipelineIsProcessed() (controller.OperationResult
 				// This string should probably be a constant somewhere
 				tenantRoleBinding, err = a.createRoleBindingForClusterRole("release-pipeline-resource-role", resources.ReleasePlanAdmission.Spec.Origin, resources.ReleasePlanAdmission.Spec.Pipeline.ServiceAccountName, resources.ReleasePlanAdmission.Namespace)
 				if err != nil {
-					return controller.RequeueWithError(err)
+					return pipelineCreationResult(handlePipelineCreationError(a.ctx, a.client, a.release, err,
+						a.release.MarkManagedPipelineProcessing,
+						a.release.MarkManagedPipelineProcessingFailed,
+						"Release processing failed on managed pipeline RoleBinding creation"))
 				}
 			}
 
 			pipelineRun, err = a.createManagedPipelineRun(resources)
 			if err != nil {
-				return controller.RequeueWithError(err)
+				capturedTenant := tenantRoleBinding
+				return pipelineCreationResult(handlePipelineCreationError(a.ctx, a.client, a.release, err,
+					a.release.MarkManagedPipelineProcessing,
+					a.release.MarkManagedPipelineProcessingFailed,
+					"Release processing failed on managed pipelineRun creation",
+					func() {
+						if capturedTenant != nil {
+							a.release.Status.ManagedProcessing.RoleBindings.TenantRoleBinding =
+								fmt.Sprintf("%s%c%s", capturedTenant.Namespace, types.Separator, capturedTenant.Name)
+						}
+					}))
 			}
 
 			a.logger.Info(fmt.Sprintf("Created %s Release PipelineRun", metadata.ManagedPipelineType),
@@ -560,7 +648,10 @@ func (a *adapter) EnsureFinalPipelineIsProcessed() (controller.OperationResult, 
 
 			pipelineRun, err = a.createFinalPipelineRun(releasePlan, snapshot)
 			if err != nil {
-				return controller.RequeueWithError(err)
+				return pipelineCreationResult(handlePipelineCreationError(a.ctx, a.client, a.release, err,
+					a.release.MarkFinalPipelineProcessing,
+					a.release.MarkFinalPipelineProcessingFailed,
+					"Release processing failed on final pipelineRun creation"))
 			}
 
 			a.logger.Info(fmt.Sprintf("Created %s Release PipelineRun", metadata.FinalPipelineType),
@@ -1954,10 +2045,6 @@ func (a *adapter) validationError(err error) *controller.ValidationResult {
 	a.release.MarkValidationFailed(err.Error())
 	return &controller.ValidationResult{Valid: false}
 }
-
-// maxConditionMessageLength is the maximum length for a Kubernetes condition message.
-// This limit is enforced by the API server validation (MaxLength=32768).
-const maxConditionMessageLength = 31000
 
 // listTaskRunsForPipelineRun returns the TaskRuns associated with the given PipelineRun.
 func (a *adapter) listTaskRunsForPipelineRun(pipelineRun *tektonv1.PipelineRun) ([]tektonv1.TaskRun, error) {

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package release
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -45,13 +46,49 @@ import (
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// createErrorClient wraps a client.Client and returns a configurable error on Create calls.
+// Used in tests to simulate PipelineRun creation failures (e.g. admission webhook denials).
+// createErrorClient wraps a client.Client and returns a configurable error on every Create call.
+// Used to simulate PipelineRun or RoleBinding creation failures (e.g. admission webhook denials).
+type createErrorClient struct {
+	ctrlclient.Client
+	createErr error
+}
+
+func (c *createErrorClient) Create(ctx context.Context, obj ctrlclient.Object, opts ...ctrlclient.CreateOption) error {
+	if c.createErr != nil {
+		return c.createErr
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+// createAfterNErrorClient wraps a client.Client and allows exactly successCount Create calls to
+// succeed before returning createErr on all subsequent calls. Used to simulate failures at
+// specific points in a sequence of creates (e.g. the 2nd or 3rd RoleBinding creation).
+type createAfterNErrorClient struct {
+	ctrlclient.Client
+	successCount int
+	createErr    error
+	creates      int
+}
+
+func (c *createAfterNErrorClient) Create(ctx context.Context, obj ctrlclient.Object, opts ...ctrlclient.CreateOption) error {
+	c.creates++
+	if c.creates > c.successCount {
+		return c.createErr
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
 
 var _ = Describe("Release adapter", Ordered, func() {
 	var (
@@ -513,6 +550,52 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(adapter.client.Delete(adapter.ctx, pipelineRun)).To(Succeed())
 		})
+
+		It("should mark final pipeline and release as failed and stop if PipelineRun creation returns a non-retriable error", func() {
+			parameterizedPipeline := tektonutils.ParameterizedPipeline{}
+			parameterizedPipeline.PipelineRef = tektonutils.PipelineRef{
+				Resolver: "git",
+				Params: []tektonutils.Param{
+					{Name: "url", Value: "https://github.com/octocat/Hello-World.git"},
+					{Name: "revision", Value: "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d"},
+					{Name: "pathInRepo", Value: "pipelines/release.yaml"},
+				},
+			}
+			localReleasePlan := &v1alpha1.ReleasePlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "release-plan",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ReleasePlanSpec{
+					Application:   application.Name,
+					FinalPipeline: &parameterizedPipeline,
+				},
+			}
+			localReleasePlan.Kind = "ReleasePlan"
+
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ReleasePlanContextKey,
+					Resource:   localReleasePlan,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   snapshot,
+				},
+			})
+			adapter.release.MarkReleasing("")
+			adapter.release.MarkManagedPipelineProcessingSkipped()
+			adapter.client = &createErrorClient{
+				Client:    k8sClient,
+				createErr: errors.NewForbidden(schema.GroupResource{}, "pipelinerun", fmt.Errorf("admission webhook denied the request")),
+			}
+
+			result, err := adapter.EnsureFinalPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			Expect(adapter.release.HasFinalPipelineProcessingFinished()).To(BeTrue())
+		})
 	})
 
 	When("EnsureManagedCollectorsPipelineIsProcessed is called", func() {
@@ -847,6 +930,175 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(pipelineRun).NotTo(BeNil())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(adapter.client.Delete(adapter.ctx, pipelineRun)).To(Succeed())
+		})
+
+		It("should mark managed collectors pipeline and release as failed and stop if PipelineRun creation returns a non-retriable error", func() {
+			newReleasePlanAdmission := releasePlanAdmission.DeepCopy()
+			newReleasePlanAdmission.Spec.Collectors = &v1alpha1.Collectors{
+				Items: []v1alpha1.CollectorItem{
+					{
+						Name:   "foo",
+						Type:   "bar",
+						Params: []v1alpha1.Param{},
+					},
+				},
+			}
+
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ReleasePlanAdmissionContextKey,
+					Resource:   newReleasePlanAdmission,
+				},
+			})
+			adapter.client = &createErrorClient{
+				Client:    k8sClient,
+				createErr: errors.NewForbidden(schema.GroupResource{}, "pipelinerun", fmt.Errorf("admission webhook denied the request")),
+			}
+			adapter.release.MarkTenantCollectorsPipelineProcessingSkipped()
+
+			result, err := adapter.EnsureManagedCollectorsPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			Expect(adapter.release.HasManagedCollectorsPipelineProcessingFinished()).To(BeTrue())
+		})
+
+		It("should mark managed collectors pipeline as failed if the first RoleBinding creation returns a non-retriable error", func() {
+			newReleasePlanAdmission := releasePlanAdmission.DeepCopy()
+			newReleasePlanAdmission.Spec.Collectors = &v1alpha1.Collectors{
+				ServiceAccountName: "collector-sa",
+				Items:              []v1alpha1.CollectorItem{{Name: "foo", Type: "bar", Params: []v1alpha1.Param{}}},
+			}
+
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ReleasePlanAdmissionContextKey,
+					Resource:   newReleasePlanAdmission,
+				},
+				{
+					ContextKey: loader.RoleBindingContextKey,
+					Resource:   nil,
+				},
+			})
+			adapter.client = &createErrorClient{
+				Client:    k8sClient,
+				createErr: errors.NewForbidden(schema.GroupResource{}, "rolebinding", fmt.Errorf("insufficient permissions")),
+			}
+			adapter.release.MarkTenantCollectorsPipelineProcessingSkipped()
+
+			result, err := adapter.EnsureManagedCollectorsPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			Expect(adapter.release.HasManagedCollectorsPipelineProcessingFinished()).To(BeTrue())
+		})
+
+		It("should save the first RoleBinding ref in Release status when the second RoleBinding creation fails", func() {
+			newReleasePlanAdmission := releasePlanAdmission.DeepCopy()
+			newReleasePlanAdmission.Spec.Collectors = &v1alpha1.Collectors{
+				ServiceAccountName: "collector-sa",
+				Items:              []v1alpha1.CollectorItem{{Name: "foo", Type: "bar", Params: []v1alpha1.Param{}}},
+			}
+
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ReleasePlanAdmissionContextKey,
+					Resource:   newReleasePlanAdmission,
+				},
+				{
+					ContextKey: loader.RoleBindingContextKey,
+					Resource:   nil,
+				},
+			})
+			// Allow first create (tenantRoleBinding) to succeed; fail the second (managedRoleBinding).
+			adapter.client = &createAfterNErrorClient{
+				Client:       k8sClient,
+				successCount: 1,
+				createErr:    errors.NewForbidden(schema.GroupResource{}, "rolebinding", fmt.Errorf("insufficient permissions")),
+			}
+			adapter.release.MarkTenantCollectorsPipelineProcessingSkipped()
+
+			result, err := adapter.EnsureManagedCollectorsPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			// The first (tenant) RoleBinding ref must be persisted for cleanup.
+			Expect(adapter.release.Status.CollectorsProcessing.ManagedCollectorsProcessing.RoleBindings.TenantRoleBinding).NotTo(BeEmpty())
+		})
+
+		It("should save both RoleBinding refs in Release status when the third RoleBinding creation fails", func() {
+			newReleasePlanAdmission := releasePlanAdmission.DeepCopy()
+			newReleasePlanAdmission.Spec.Collectors = &v1alpha1.Collectors{
+				ServiceAccountName: "collector-sa",
+				Secrets:            []string{"my-secret"},
+				Items:              []v1alpha1.CollectorItem{{Name: "foo", Type: "bar", Params: []v1alpha1.Param{}}},
+			}
+
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ReleasePlanAdmissionContextKey,
+					Resource:   newReleasePlanAdmission,
+				},
+				{
+					ContextKey: loader.RoleBindingContextKey,
+					Resource:   nil,
+				},
+			})
+			// Allow first two creates (tenantRoleBinding, managedRoleBinding via createRoleBindingForClusterRole) to succeed.
+			// createRoleBindingForCollectorSecrets is then called and fails on its first internal create (the Role),
+			// simulating a permanent failure before the secretRoleBinding is created.
+			adapter.client = &createAfterNErrorClient{
+				Client:       k8sClient,
+				successCount: 2,
+				createErr:    errors.NewForbidden(schema.GroupResource{}, "rolebinding", fmt.Errorf("insufficient permissions")),
+			}
+			adapter.release.MarkTenantCollectorsPipelineProcessingSkipped()
+
+			result, err := adapter.EnsureManagedCollectorsPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			// Both preceding RoleBinding refs must be persisted for cleanup.
+			Expect(adapter.release.Status.CollectorsProcessing.ManagedCollectorsProcessing.RoleBindings.TenantRoleBinding).NotTo(BeEmpty())
+			Expect(adapter.release.Status.CollectorsProcessing.ManagedCollectorsProcessing.RoleBindings.ManagedRoleBinding).NotTo(BeEmpty())
+		})
+
+		It("should save all three RoleBinding refs in Release status when PipelineRun creation fails after all are created", func() {
+			newReleasePlanAdmission := releasePlanAdmission.DeepCopy()
+			newReleasePlanAdmission.Spec.Collectors = &v1alpha1.Collectors{
+				ServiceAccountName: "collector-sa",
+				Secrets:            []string{"my-secret"},
+				Items:              []v1alpha1.CollectorItem{{Name: "foo", Type: "bar", Params: []v1alpha1.Param{}}},
+			}
+
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ReleasePlanAdmissionContextKey,
+					Resource:   newReleasePlanAdmission,
+				},
+				{
+					ContextKey: loader.RoleBindingContextKey,
+					Resource:   nil,
+				},
+			})
+			// Allow all four RoleBinding creates to succeed:
+			// 1 (tenantRoleBinding) + 1 (managedRoleBinding) + 2 (Role + RoleBinding for secretRoleBinding).
+			// The fifth create (PipelineRun) then fails.
+			adapter.client = &createAfterNErrorClient{
+				Client:       k8sClient,
+				successCount: 4,
+				createErr:    errors.NewForbidden(schema.GroupResource{}, "pipelinerun", fmt.Errorf("admission webhook denied the request")),
+			}
+			adapter.release.MarkTenantCollectorsPipelineProcessingSkipped()
+
+			result, err := adapter.EnsureManagedCollectorsPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			// All three RoleBinding refs must be persisted for cleanup.
+			Expect(adapter.release.Status.CollectorsProcessing.ManagedCollectorsProcessing.RoleBindings.TenantRoleBinding).NotTo(BeEmpty())
+			Expect(adapter.release.Status.CollectorsProcessing.ManagedCollectorsProcessing.RoleBindings.ManagedRoleBinding).NotTo(BeEmpty())
+			Expect(adapter.release.Status.CollectorsProcessing.ManagedCollectorsProcessing.RoleBindings.SecretRoleBinding).NotTo(BeEmpty())
 		})
 	})
 
@@ -1193,6 +1445,128 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(adapter.client.Delete(adapter.ctx, pipelineRun)).To(Succeed())
 		})
+
+		It("should mark managed pipeline and release as failed and stop if PipelineRun creation returns a non-retriable error", func() {
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ProcessingResourcesContextKey,
+					Resource: &loader.ProcessingResources{
+						EnterpriseContractConfigMap: enterpriseContractConfigMap,
+						EnterpriseContractPolicy:    enterpriseContractPolicy,
+						ReleasePlan:                 releasePlan,
+						ReleasePlanAdmission:        releasePlanAdmission,
+						Snapshot:                    snapshot,
+					},
+				},
+				{
+					ContextKey: loader.RoleBindingContextKey,
+					Resource:   roleBinding,
+				},
+			})
+			adapter.client = &createErrorClient{
+				Client:    k8sClient,
+				createErr: errors.NewForbidden(schema.GroupResource{}, "pipelinerun", fmt.Errorf("admission webhook denied the request")),
+			}
+			adapter.release.MarkTenantPipelineProcessingSkipped()
+
+			result, err := adapter.EnsureManagedPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			Expect(adapter.release.HasManagedPipelineProcessingFinished()).To(BeTrue())
+		})
+
+		It("should truncate long error messages to maxConditionMessageLength", func() {
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ProcessingResourcesContextKey,
+					Resource: &loader.ProcessingResources{
+						EnterpriseContractConfigMap: enterpriseContractConfigMap,
+						EnterpriseContractPolicy:    enterpriseContractPolicy,
+						ReleasePlan:                 releasePlan,
+						ReleasePlanAdmission:        releasePlanAdmission,
+						Snapshot:                    snapshot,
+					},
+				},
+				{
+					ContextKey: loader.RoleBindingContextKey,
+					Resource:   roleBinding,
+				},
+			})
+			adapter.client = &createErrorClient{
+				Client:    k8sClient,
+				createErr: errors.NewForbidden(schema.GroupResource{}, "pipelinerun", fmt.Errorf("%s", strings.Repeat("x", 32000))),
+			}
+			adapter.release.MarkTenantPipelineProcessingSkipped()
+
+			result, err := adapter.EnsureManagedPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			condition := apimeta.FindStatusCondition(adapter.release.Status.Conditions,
+				"ManagedPipelineProcessed")
+			Expect(condition).NotTo(BeNil())
+			Expect(len(condition.Message)).To(BeNumerically("<=", maxConditionMessageLength))
+		})
+
+		It("should mark managed pipeline as failed if RoleBinding creation returns a non-retriable error", func() {
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ProcessingResourcesContextKey,
+					Resource: &loader.ProcessingResources{
+						EnterpriseContractConfigMap: enterpriseContractConfigMap,
+						EnterpriseContractPolicy:    enterpriseContractPolicy,
+						ReleasePlan:                 releasePlan,
+						ReleasePlanAdmission:        releasePlanAdmission,
+						Snapshot:                    snapshot,
+					},
+				},
+				{
+					ContextKey: loader.RoleBindingContextKey,
+					Resource:   nil,
+				},
+			})
+			adapter.client = &createErrorClient{
+				Client:    k8sClient,
+				createErr: errors.NewForbidden(schema.GroupResource{}, "rolebinding", fmt.Errorf("insufficient permissions")),
+			}
+			adapter.release.MarkTenantPipelineProcessingSkipped()
+
+			result, err := adapter.EnsureManagedPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			Expect(adapter.release.HasManagedPipelineProcessingFinished()).To(BeTrue())
+		})
+
+		It("should requeue if PipelineRun creation returns a retriable error", func() {
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ProcessingResourcesContextKey,
+					Resource: &loader.ProcessingResources{
+						EnterpriseContractConfigMap: enterpriseContractConfigMap,
+						EnterpriseContractPolicy:    enterpriseContractPolicy,
+						ReleasePlan:                 releasePlan,
+						ReleasePlanAdmission:        releasePlanAdmission,
+						Snapshot:                    snapshot,
+					},
+				},
+				{
+					ContextKey: loader.RoleBindingContextKey,
+					Resource:   roleBinding,
+				},
+			})
+			adapter.client = &createErrorClient{
+				Client:    k8sClient,
+				createErr: errors.NewServiceUnavailable("service unavailable"),
+			}
+			adapter.release.MarkTenantPipelineProcessingSkipped()
+
+			result, err := adapter.EnsureManagedPipelineIsProcessed()
+			Expect(result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).To(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeFalse())
+		})
 	})
 
 	When("EnsureTenantCollectorsPipelineIsProcessed is called", func() {
@@ -1488,6 +1862,154 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(adapter.client.Delete(adapter.ctx, pipelineRun)).To(Succeed())
 		})
+
+		It("should mark tenant collectors pipeline and release as failed and stop if PipelineRun creation returns a non-retriable error", func() {
+			newReleasePlan := releasePlan.DeepCopy()
+			newReleasePlan.Spec.Collectors = &v1alpha1.Collectors{
+				Items: []v1alpha1.CollectorItem{
+					{
+						Name:   "foo",
+						Type:   "bar",
+						Params: []v1alpha1.Param{},
+					},
+				},
+			}
+
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ReleasePlanContextKey,
+					Resource:   newReleasePlan,
+				},
+				{
+					ContextKey: loader.ReleasePlanAdmissionContextKey,
+					Resource:   releasePlanAdmission,
+				},
+			})
+			adapter.release.MarkReleasing("")
+			adapter.client = &createErrorClient{
+				Client:    k8sClient,
+				createErr: errors.NewForbidden(schema.GroupResource{}, "pipelinerun", fmt.Errorf("admission webhook denied the request")),
+			}
+
+			result, err := adapter.EnsureTenantCollectorsPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			Expect(adapter.release.HasTenantCollectorsPipelineProcessingFinished()).To(BeTrue())
+		})
+
+		It("should mark tenant collectors pipeline as failed if the first RoleBinding creation returns a non-retriable error", func() {
+			newReleasePlan := releasePlan.DeepCopy()
+			newReleasePlan.Spec.Collectors = &v1alpha1.Collectors{
+				ServiceAccountName: "collector-sa",
+				Items:              []v1alpha1.CollectorItem{{Name: "foo", Type: "bar", Params: []v1alpha1.Param{}}},
+			}
+
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ReleasePlanContextKey,
+					Resource:   newReleasePlan,
+				},
+				{
+					ContextKey: loader.ReleasePlanAdmissionContextKey,
+					Resource:   releasePlanAdmission,
+				},
+				{
+					ContextKey: loader.RoleBindingContextKey,
+					Resource:   nil,
+				},
+			})
+			adapter.release.MarkReleasing("")
+			adapter.client = &createErrorClient{
+				Client:    k8sClient,
+				createErr: errors.NewForbidden(schema.GroupResource{}, "rolebinding", fmt.Errorf("insufficient permissions")),
+			}
+
+			result, err := adapter.EnsureTenantCollectorsPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			Expect(adapter.release.HasTenantCollectorsPipelineProcessingFinished()).To(BeTrue())
+		})
+
+		It("should save the first RoleBinding ref in Release status when the second RoleBinding creation fails", func() {
+			newReleasePlan := releasePlan.DeepCopy()
+			newReleasePlan.Spec.Collectors = &v1alpha1.Collectors{
+				ServiceAccountName: "collector-sa",
+				Secrets:            []string{"my-secret"},
+				Items:              []v1alpha1.CollectorItem{{Name: "foo", Type: "bar", Params: []v1alpha1.Param{}}},
+			}
+
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ReleasePlanContextKey,
+					Resource:   newReleasePlan,
+				},
+				{
+					ContextKey: loader.ReleasePlanAdmissionContextKey,
+					Resource:   releasePlanAdmission,
+				},
+				{
+					ContextKey: loader.RoleBindingContextKey,
+					Resource:   nil,
+				},
+			})
+			adapter.release.MarkReleasing("")
+			// Allow first create (tenantRoleBinding) to succeed; fail the second (secretRoleBinding).
+			adapter.client = &createAfterNErrorClient{
+				Client:       k8sClient,
+				successCount: 1,
+				createErr:    errors.NewForbidden(schema.GroupResource{}, "rolebinding", fmt.Errorf("insufficient permissions")),
+			}
+
+			result, err := adapter.EnsureTenantCollectorsPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			// The first (tenant) RoleBinding ref must be persisted for cleanup.
+			Expect(adapter.release.Status.CollectorsProcessing.TenantCollectorsProcessing.RoleBindings.TenantRoleBinding).NotTo(BeEmpty())
+		})
+
+		It("should save both RoleBinding refs in Release status when PipelineRun creation fails after both are created", func() {
+			newReleasePlan := releasePlan.DeepCopy()
+			newReleasePlan.Spec.Collectors = &v1alpha1.Collectors{
+				ServiceAccountName: "collector-sa",
+				Secrets:            []string{"my-secret"},
+				Items:              []v1alpha1.CollectorItem{{Name: "foo", Type: "bar", Params: []v1alpha1.Param{}}},
+			}
+
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ReleasePlanContextKey,
+					Resource:   newReleasePlan,
+				},
+				{
+					ContextKey: loader.ReleasePlanAdmissionContextKey,
+					Resource:   releasePlanAdmission,
+				},
+				{
+					ContextKey: loader.RoleBindingContextKey,
+					Resource:   nil,
+				},
+			})
+			adapter.release.MarkReleasing("")
+			// Allow first three creates to succeed: tenantRoleBinding (1 create via createRoleBindingForClusterRole)
+			// and the secret binding (2 creates: Role + RoleBinding via createRoleBindingForCollectorSecrets).
+			// The fourth create (PipelineRun) then fails.
+			adapter.client = &createAfterNErrorClient{
+				Client:       k8sClient,
+				successCount: 3,
+				createErr:    errors.NewForbidden(schema.GroupResource{}, "pipelinerun", fmt.Errorf("admission webhook denied the request")),
+			}
+
+			result, err := adapter.EnsureTenantCollectorsPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			// Both RoleBinding refs must be persisted for cleanup.
+			Expect(adapter.release.Status.CollectorsProcessing.TenantCollectorsProcessing.RoleBindings.TenantRoleBinding).NotTo(BeEmpty())
+			Expect(adapter.release.Status.CollectorsProcessing.TenantCollectorsProcessing.RoleBindings.SecretRoleBinding).NotTo(BeEmpty())
+		})
 	})
 
 	When("EnsureTenantPipelineIsProcessed is called", func() {
@@ -1658,6 +2180,51 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(pipelineRun).NotTo(BeNil())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(adapter.client.Delete(adapter.ctx, pipelineRun)).To(Succeed())
+		})
+
+		It("should mark tenant pipeline and release as failed and stop if PipelineRun creation returns a non-retriable error", func() {
+			parameterizedPipeline := tektonutils.ParameterizedPipeline{}
+			parameterizedPipeline.PipelineRef = tektonutils.PipelineRef{
+				Resolver: "git",
+				Params: []tektonutils.Param{
+					{Name: "url", Value: "https://github.com/octocat/Hello-World.git"},
+					{Name: "revision", Value: "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d"},
+					{Name: "pathInRepo", Value: "pipelines/release.yaml"},
+				},
+			}
+			localReleasePlan := &v1alpha1.ReleasePlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "release-plan",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ReleasePlanSpec{
+					Application:    application.Name,
+					TenantPipeline: &parameterizedPipeline,
+				},
+			}
+			localReleasePlan.Kind = "ReleasePlan"
+
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ReleasePlanContextKey,
+					Resource:   localReleasePlan,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   snapshot,
+				},
+			})
+			adapter.client = &createErrorClient{
+				Client:    k8sClient,
+				createErr: errors.NewForbidden(schema.GroupResource{}, "pipelinerun", fmt.Errorf("admission webhook denied the request")),
+			}
+			adapter.release.MarkManagedCollectorsPipelineProcessingSkipped()
+
+			result, err := adapter.EnsureTenantPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			Expect(adapter.release.HasTenantPipelineProcessingFinished()).To(BeTrue())
 		})
 	})
 

--- a/controllers/release/utils.go
+++ b/controllers/release/utils.go
@@ -1,0 +1,60 @@
+package release
+
+import (
+	"context"
+
+	"github.com/konflux-ci/operator-toolkit/controller"
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/loader"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// maxConditionMessageLength is the maximum length for a Kubernetes condition message.
+// This limit is enforced by the API server validation (MaxLength=32768).
+const maxConditionMessageLength = 31000
+
+// handlePipelineCreationError handles errors returned when creating a PipelineRun or RoleBinding.
+// For retriable (transient) errors such as network timeouts or conflicts, it returns the original
+// error so the caller can requeue. For permanent errors (e.g., admission webhook denials), it
+// marks the pipeline and release as failed and continues reconciliation so that downstream
+// Ensure* operations can mark their own phases as skipped via their IsFailed() guards. Without
+// continuing, no future reconcile is triggered (no PipelineRun was created, and
+// GenerationChangedPredicate ignores status-only patches), leaving downstream pipeline conditions
+// permanently unset.
+//
+// The optional extraStatusUpdates callbacks run after the patch baseline is taken, so their
+// changes are included in the same atomic status patch as the failure marks. This is used to
+// persist RoleBinding refs that were created before the failure, so that
+// EnsureCollectorsProcessingResourcesAreCleanedUp can find and delete them on the next reconcile.
+
+// pipelineCreationResult converts the (retryable, err) pair returned by handlePipelineCreationError
+// into the appropriate OperationResult: RequeueWithError for retryable errors, RequeueOnErrorOrContinue
+// for permanent errors (where err is the patch error, which may be nil on success).
+func pipelineCreationResult(retryable bool, err error) (controller.OperationResult, error) {
+	if retryable {
+		return controller.RequeueWithError(err)
+	}
+	return controller.RequeueOnErrorOrContinue(err)
+}
+
+// handlePipelineCreationError returns (true, originalErr) for retryable errors so the caller
+// can requeue via RequeueWithError. For permanent errors it marks the pipeline and release as
+// failed, patches the status, and returns (false, patchErr) so the caller can continue via
+// RequeueOnErrorOrContinue.
+func handlePipelineCreationError(ctx context.Context, c client.Client, release *v1alpha1.Release, err error, markProcessing func(), markPipelineFailed func(string), releaseFailedMsg string, extraStatusUpdates ...func()) (bool, error) {
+	if loader.IsRetryableCreationError(err) {
+		return true, err
+	}
+	patch := client.MergeFrom(release.DeepCopy())
+	for _, update := range extraStatusUpdates {
+		update()
+	}
+	markProcessing()
+	errMsg := err.Error()
+	if len(errMsg) > maxConditionMessageLength {
+		errMsg = errMsg[:maxConditionMessageLength]
+	}
+	markPipelineFailed(errMsg)
+	release.MarkReleaseFailed(releaseFailedMsg)
+	return false, c.Status().Patch(ctx, release, patch)
+}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -410,6 +410,21 @@ func (l *loader) GetProcessingResources(ctx context.Context, cli client.Client, 
 	return resources, nil
 }
 
+// IsRetryableCreationError returns true if the error is transient and the creation should be
+// retried. Returns false for known permanent failures (e.g. admission webhook denial, invalid
+// resource spec, insufficient RBAC) that will not resolve on retry.
+func IsRetryableCreationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return !apierrors.IsBadRequest(err) &&
+		!apierrors.IsInvalid(err) &&
+		!apierrors.IsForbidden(err) &&
+		!apierrors.IsUnauthorized(err) &&
+		!apierrors.IsMethodNotSupported(err) &&
+		!apierrors.IsRequestEntityTooLargeError(err)
+}
+
 // IsRetriable returns true if the error is transient, such as a
 // network hiccup, concurrency conflict, or server-side throttling,
 // indicating that the operation should be retried.

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1044,3 +1044,38 @@ func (f *fakeKAClient) Get(ctx context.Context, cli client.Client, gvr schema.Gr
 	namespace, name string, obj client.Object) error {
 	return f.getFunc(ctx, cli, gvr, namespace, name, obj)
 }
+
+var _ = Describe("Loader helpers", func() {
+	Describe("IsRetryableCreationError", func() {
+		It("should return false for nil error", func() {
+			Expect(IsRetryableCreationError(nil)).To(BeFalse())
+		})
+
+		DescribeTable("should return false for permanent creation errors",
+			func(err error) {
+				Expect(IsRetryableCreationError(err)).To(BeFalse())
+			},
+			Entry("bad request", errors.NewBadRequest("malformed object")),
+			Entry("invalid", errors.NewInvalid(schema.GroupKind{}, "pipelinerun", nil)),
+			Entry("forbidden (admission webhook denial)", errors.NewForbidden(schema.GroupResource{}, "pipelinerun", fmt.Errorf("admission webhook denied the request"))),
+			Entry("unauthorized", errors.NewUnauthorized("not authorized")),
+			Entry("method not supported", errors.NewMethodNotSupported(schema.GroupResource{}, "patch")),
+			Entry("request entity too large", errors.NewRequestEntityTooLargeError("payload too large")),
+		)
+
+		DescribeTable("should return true for transient / retriable errors",
+			func(err error) {
+				Expect(IsRetryableCreationError(err)).To(BeTrue())
+			},
+			Entry("conflict", errors.NewConflict(schema.GroupResource{}, "pipelinerun", fmt.Errorf("conflict"))),
+			Entry("server timeout", errors.NewServerTimeout(schema.GroupResource{}, "create", 1)),
+			Entry("service unavailable", errors.NewServiceUnavailable("service unavailable")),
+			Entry("too many requests", errors.NewTooManyRequests("throttled", 1)),
+			Entry("internal server error", errors.NewInternalError(fmt.Errorf("internal"))),
+		)
+
+		It("should return true for an unknown non-API error", func() {
+			Expect(IsRetryableCreationError(fmt.Errorf("some unexpected error"))).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
## Describe your changes
When a PipelineRun was denied by an admission webhook (or any other permanent creation failure), the release controller logged the error but never updated the Release CR status, leaving users with no
signal indicating why the pipeline was not triggered and causing an infinite retry hot loop.

The **fix** introduces handlePipelineCreationError, a centralized helper that classifies errors as permanent (forbidden, invalid, bad request, etc.) or transient. Permanent errors now surface the full error message in the pipeline condition and mark the Release as Failed; transient errors continue to requeue as before.


## Relevant Jira
[KONFLUX-12127](https://issues.redhat.com/browse/KONFLUX-12127)

Assisted-by: Cursor


[KONFLUX-12127]: https://redhat.atlassian.net/browse/KONFLUX-12127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ