### PR TITLE
feat(RELEASE-2092): fall back to KubeArchive for archived Snapshots

### DIFF
--- a/kubearchive/client.go
+++ b/kubearchive/client.go
@@ -1,0 +1,264 @@
+package kubearchive
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	apiURLConfigMapName = "kubearchive-api-url"
+	apiURLConfigMapKey  = "URL"
+)
+
+const kaNamespace = "product-kubearchive"
+
+// Client provides access to the KubeArchive API for retrieving archived Kubernetes resources.
+// It lazily discovers the KubeArchive API URL on first use and caches it for subsequent calls.
+// Authentication and TLS are derived from the in-cluster REST configuration.
+type Client struct {
+	mu         sync.Mutex
+	apiURL     string
+	resolved   bool
+	httpClient *http.Client
+}
+
+// NewClient creates a new KubeArchive client. The API URL is discovered lazily on the first
+// Get call using the Kubernetes client to locate the KubeArchive service.
+func NewClient() *Client {
+	return &Client{}
+}
+
+// Get retrieves an archived resource from KubeArchive by its GroupVersionResource, namespace,
+// and name. The Kubernetes client is used for one-time API URL discovery and is not needed for
+// subsequent calls. The result is unmarshaled into obj, which should be a pointer to the
+// expected resource type.
+//
+// When multiple archived versions of the same resource exist, the KubeArchive single-resource
+// endpoint returns HTTP 500. In that case, Get falls back to the list endpoint and selects the
+// item with the highest resourceVersion (the most recently persisted version).
+func (c *Client) Get(ctx context.Context, cli client.Client, gvr schema.GroupVersionResource,
+	namespace, name string, obj client.Object) error {
+
+	apiURL, httpClient, err := c.resolve(ctx, cli)
+	if err != nil {
+		return err
+	}
+
+	logger := ctrl.LoggerFrom(ctx)
+	body, statusCode, err := c.doGet(ctx, httpClient, apiURL+buildAPIPath(gvr, namespace, name))
+	if err != nil {
+		return err
+	}
+
+	if statusCode == http.StatusOK {
+		logger.Info("Retrieved resource from KubeArchive",
+			"gvr", gvr.String(), "namespace", namespace, "name", name,
+			"responseBytes", len(body))
+		return json.Unmarshal(body, obj)
+	}
+
+	if statusCode == http.StatusNotFound {
+		logger.Info("Resource not found in KubeArchive",
+			"gvr", gvr.String(), "namespace", namespace, "name", name)
+		return apierrors.NewNotFound(gvr.GroupResource(), name)
+	}
+
+	if statusCode == http.StatusInternalServerError && strings.Contains(string(body), "more than one resource found") {
+		logger.Info("Multiple archived versions found, falling back to list endpoint",
+			"gvr", gvr.String(), "namespace", namespace, "name", name)
+		return c.getFromList(ctx, httpClient, apiURL, gvr, namespace, name, obj)
+	}
+
+	return fmt.Errorf("kubearchive returned HTTP %d for %s/%s: %s",
+		statusCode, namespace, name, truncate(string(body), 200))
+}
+
+// doGet performs an HTTP GET and returns the body, status code, and any transport error.
+func (c *Client) doGet(ctx context.Context, httpClient *http.Client, url string) ([]byte, int, error) {
+	logger := ctrl.LoggerFrom(ctx)
+	logger.Info("Fetching resource from KubeArchive", "url", url)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("building kubearchive request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("kubearchive request to %s failed: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("reading kubearchive response: %w", err)
+	}
+	return body, resp.StatusCode, nil
+}
+
+// getFromList queries the list endpoint with a fieldSelector to retrieve only archived
+// versions matching the given name, then picks the one with the highest resourceVersion.
+func (c *Client) getFromList(ctx context.Context, httpClient *http.Client,
+	apiURL string, gvr schema.GroupVersionResource,
+	namespace, name string, obj client.Object) error {
+
+	listURL := apiURL + buildListAPIPath(gvr, namespace) +
+		"?fieldSelector=" + url.QueryEscape("metadata.name="+name)
+	body, statusCode, err := c.doGet(ctx, httpClient, listURL)
+	if err != nil {
+		return err
+	}
+	if statusCode != http.StatusOK {
+		return fmt.Errorf("kubearchive list returned HTTP %d for %s: %s",
+			statusCode, listURL, truncate(string(body), 200))
+	}
+
+	var raw struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return fmt.Errorf("parsing kubearchive list response: %w", err)
+	}
+
+	logger := ctrl.LoggerFrom(ctx)
+	var bestRaw json.RawMessage
+	bestRV := int64(-1)
+	for _, item := range raw.Items {
+		var meta struct {
+			Metadata struct {
+				Name            string `json:"name"`
+				ResourceVersion string `json:"resourceVersion"`
+			} `json:"metadata"`
+		}
+		if err := json.Unmarshal(item, &meta); err != nil {
+			logger.Info("Skipping unparseable item in KubeArchive list response", "error", err)
+			continue
+		}
+		if meta.Metadata.Name != name {
+			continue
+		}
+		rv, _ := strconv.ParseInt(meta.Metadata.ResourceVersion, 10, 64)
+		if rv > bestRV {
+			bestRV = rv
+			bestRaw = item
+		}
+	}
+
+	if bestRaw == nil {
+		logger.Info("Resource not found in KubeArchive list",
+			"gvr", gvr.String(), "namespace", namespace, "name", name)
+		return apierrors.NewNotFound(gvr.GroupResource(), name)
+	}
+
+	logger.Info("Selected most recent archived version from list",
+		"gvr", gvr.String(), "namespace", namespace, "name", name,
+		"resourceVersion", bestRV)
+	return json.Unmarshal(bestRaw, obj)
+}
+
+// resolve lazily discovers the KubeArchive API URL and builds an authenticated HTTP client
+// on first call, caching both for subsequent use. If discovery has already been attempted
+// and failed, it returns the cached error without retrying.
+func (c *Client) resolve(ctx context.Context, cli client.Client) (string, *http.Client, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.resolved {
+		if c.apiURL == "" {
+			return "", nil, fmt.Errorf("kubearchive is not available on this cluster")
+		}
+		return c.apiURL, c.httpClient, nil
+	}
+
+	logger := ctrl.LoggerFrom(ctx)
+	apiURL, err := discoverAPIURL(ctx, cli)
+	c.resolved = true
+	if err != nil {
+		logger.Info("KubeArchive not available on this cluster", "error", err)
+		return "", nil, fmt.Errorf("kubearchive discovery failed: %w", err)
+	}
+
+	c.apiURL = apiURL
+	if c.httpClient == nil {
+		c.httpClient, err = newHTTPClient()
+		if err != nil {
+			return "", nil, fmt.Errorf("creating kubearchive HTTP client: %w", err)
+		}
+	}
+	logger.Info("Discovered KubeArchive API", "url", apiURL)
+	return c.apiURL, c.httpClient, nil
+}
+
+// discoverAPIURL finds the KubeArchive API server URL by reading the well-known
+// ConfigMap "kubearchive-api-url" from the product-kubearchive namespace. The
+// ConfigMap is deployed by infra-deployments and contains a single key "URL"
+// with the route URL.
+func discoverAPIURL(ctx context.Context, cli client.Client) (string, error) {
+	cm := &corev1.ConfigMap{}
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: kaNamespace, Name: apiURLConfigMapName}, cm); err != nil {
+		return "", fmt.Errorf("ConfigMap %q not found in namespace %q: %w", apiURLConfigMapName, kaNamespace, err)
+	}
+	if u, ok := cm.Data[apiURLConfigMapKey]; ok &&
+		(strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")) {
+		return strings.TrimRight(u, "/"), nil
+	}
+	return "", fmt.Errorf("ConfigMap %q in namespace %q has no valid URL", apiURLConfigMapName, kaNamespace)
+}
+
+// newHTTPClient builds an HTTP client that carries the in-cluster service account
+// bearer token for KubeArchive authentication. The cluster CA is cleared so that
+// Go falls back to the system CA bundle, which can verify the external route TLS
+// certificate (signed by a public CA, not the cluster CA).
+func newHTTPClient() (*http.Client, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("loading in-cluster config: %w", err)
+	}
+	cfg.TLSClientConfig.CAFile = ""
+	cfg.TLSClientConfig.CAData = nil
+	return rest.HTTPClientFor(cfg)
+}
+
+// buildAPIPath constructs the REST API path for a named resource, mirroring the
+// Kubernetes API URL structure that the KubeArchive API server exposes.
+func buildAPIPath(gvr schema.GroupVersionResource, namespace, name string) string {
+	if gvr.Group == "" {
+		return fmt.Sprintf("/api/%s/namespaces/%s/%s/%s",
+			gvr.Version, namespace, gvr.Resource, name)
+	}
+	return fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s/%s",
+		gvr.Group, gvr.Version, namespace, gvr.Resource, name)
+}
+
+// buildListAPIPath constructs the REST API path for listing all resources of a type
+// in a namespace, without a specific resource name.
+func buildListAPIPath(gvr schema.GroupVersionResource, namespace string) string {
+	if gvr.Group == "" {
+		return fmt.Sprintf("/api/%s/namespaces/%s/%s",
+			gvr.Version, namespace, gvr.Resource)
+	}
+	return fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s",
+		gvr.Group, gvr.Version, namespace, gvr.Resource)
+}
+
+// truncate shortens s to maxLen characters, appending "..." if truncation occurs.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/kubearchive/client_test.go
+++ b/kubearchive/client_test.go
@@ -1,0 +1,497 @@
+package kubearchive
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newResolvedClient(server *httptest.Server) *Client {
+	return &Client{
+		resolved:   true,
+		apiURL:     server.URL,
+		httpClient: server.Client(),
+	}
+}
+
+var _ = Describe("KubeArchive Client", func() {
+
+	Describe("buildAPIPath", func() {
+		It("builds a path for a core resource", func() {
+			gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+			Expect(buildAPIPath(gvr, "my-ns", "my-cm")).To(Equal("/api/v1/namespaces/my-ns/configmaps/my-cm"))
+		})
+
+		It("builds a path for a non-core resource", func() {
+			gvr := schema.GroupVersionResource{Group: "appstudio.redhat.com", Version: "v1alpha1", Resource: "snapshots"}
+			Expect(buildAPIPath(gvr, "tenant", "snap-1")).To(
+				Equal("/apis/appstudio.redhat.com/v1alpha1/namespaces/tenant/snapshots/snap-1"))
+		})
+	})
+
+	Describe("buildListAPIPath", func() {
+		It("builds a list path for a core resource", func() {
+			gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+			Expect(buildListAPIPath(gvr, "my-ns")).To(Equal("/api/v1/namespaces/my-ns/configmaps"))
+		})
+
+		It("builds a list path for a non-core resource", func() {
+			gvr := schema.GroupVersionResource{Group: "appstudio.redhat.com", Version: "v1alpha1", Resource: "snapshots"}
+			Expect(buildListAPIPath(gvr, "tenant")).To(
+				Equal("/apis/appstudio.redhat.com/v1alpha1/namespaces/tenant/snapshots"))
+		})
+	})
+
+	Describe("truncate", func() {
+		It("returns the string unchanged when shorter than maxLen", func() {
+			Expect(truncate("short", 10)).To(Equal("short"))
+		})
+
+		It("truncates and appends ellipsis when longer than maxLen", func() {
+			Expect(truncate("a]long string here", 6)).To(Equal("a]long..."))
+		})
+
+		It("returns the string unchanged when exactly maxLen", func() {
+			Expect(truncate("exact", 5)).To(Equal("exact"))
+		})
+	})
+
+	Describe("discoverAPIURL", func() {
+		var (
+			ctx    context.Context
+			scheme *runtime.Scheme
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			scheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		})
+
+		It("returns the URL from the ConfigMap", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiURLConfigMapName,
+					Namespace: kaNamespace,
+				},
+				Data: map[string]string{
+					apiURLConfigMapKey: "https://kubearchive.example.com/",
+				},
+			}
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+			url, err := discoverAPIURL(ctx, cli)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(url).To(Equal("https://kubearchive.example.com"))
+		})
+
+		It("returns an error when no ConfigMap exists", func() {
+			cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			_, err := discoverAPIURL(ctx, cli)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found in namespace"))
+		})
+
+		It("returns an error when the ConfigMap has a non-HTTP URL value", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiURLConfigMapName,
+					Namespace: kaNamespace,
+				},
+				Data: map[string]string{
+					apiURLConfigMapKey: "ftp://bad-url.example.com",
+				},
+			}
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+			_, err := discoverAPIURL(ctx, cli)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no valid URL"))
+		})
+
+		It("trims trailing slash from the URL", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiURLConfigMapName,
+					Namespace: kaNamespace,
+				},
+				Data: map[string]string{
+					apiURLConfigMapKey: "https://example.com///",
+				},
+			}
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+			url, err := discoverAPIURL(ctx, cli)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(url).To(Equal("https://example.com"))
+		})
+	})
+
+	Describe("Get", func() {
+		var (
+			ctx context.Context
+			gvr schema.GroupVersionResource
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			gvr = schema.GroupVersionResource{
+				Group: "appstudio.redhat.com", Version: "v1alpha1", Resource: "snapshots",
+			}
+		})
+
+		It("unmarshals a 200 response into the target object", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				snap := applicationapiv1alpha1.Snapshot{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-snap", Namespace: "ns"},
+					Spec:       applicationapiv1alpha1.SnapshotSpec{Application: "my-app"},
+				}
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(snap)
+			}))
+			defer server.Close()
+
+			c := newResolvedClient(server)
+			obj := &applicationapiv1alpha1.Snapshot{}
+			err := c.Get(ctx, nil, gvr, "ns", "my-snap", obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(obj.Name).To(Equal("my-snap"))
+			Expect(obj.Spec.Application).To(Equal("my-app"))
+		})
+
+		It("returns a NotFound error on 404", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte("not found"))
+			}))
+			defer server.Close()
+
+			c := newResolvedClient(server)
+			obj := &applicationapiv1alpha1.Snapshot{}
+			err := c.Get(ctx, nil, gvr, "ns", "missing", obj)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("falls back to the list endpoint on HTTP 500 with 'more than one resource found'", func() {
+			callCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callCount++
+				if callCount == 1 {
+					w.WriteHeader(http.StatusInternalServerError)
+					w.Write([]byte("more than one resource found"))
+					return
+				}
+				list := map[string]interface{}{
+					"items": []map[string]interface{}{
+						{
+							"apiVersion": "appstudio.redhat.com/v1alpha1",
+							"kind":       "Snapshot",
+							"metadata":   map[string]interface{}{"name": "target", "namespace": "ns", "resourceVersion": "100"},
+							"spec":       map[string]interface{}{"application": "old-app"},
+						},
+						{
+							"apiVersion": "appstudio.redhat.com/v1alpha1",
+							"kind":       "Snapshot",
+							"metadata":   map[string]interface{}{"name": "target", "namespace": "ns", "resourceVersion": "200"},
+							"spec":       map[string]interface{}{"application": "latest-app"},
+						},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(list)
+			}))
+			defer server.Close()
+
+			c := newResolvedClient(server)
+			obj := &applicationapiv1alpha1.Snapshot{}
+			err := c.Get(ctx, nil, gvr, "ns", "target", obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(obj.Name).To(Equal("target"))
+			Expect(obj.ResourceVersion).To(Equal("200"))
+			Expect(obj.Spec.Application).To(Equal("latest-app"))
+			Expect(callCount).To(Equal(2))
+		})
+
+		It("returns an error on unexpected HTTP status codes", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+				w.Write([]byte("forbidden"))
+			}))
+			defer server.Close()
+
+			c := newResolvedClient(server)
+			obj := &applicationapiv1alpha1.Snapshot{}
+			err := c.Get(ctx, nil, gvr, "ns", "snap", obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("HTTP 403"))
+		})
+
+		It("returns an error on HTTP 500 without the duplicate-resource message", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("internal server error"))
+			}))
+			defer server.Close()
+
+			c := newResolvedClient(server)
+			obj := &applicationapiv1alpha1.Snapshot{}
+			err := c.Get(ctx, nil, gvr, "ns", "snap", obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("HTTP 500"))
+		})
+	})
+
+	Describe("getFromList", func() {
+		var (
+			ctx context.Context
+			gvr schema.GroupVersionResource
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			gvr = schema.GroupVersionResource{
+				Group: "appstudio.redhat.com", Version: "v1alpha1", Resource: "snapshots",
+			}
+		})
+
+		It("selects the item with the highest resourceVersion", func() {
+			list := map[string]interface{}{
+				"items": []map[string]interface{}{
+					{"metadata": map[string]interface{}{"name": "snap", "namespace": "ns", "resourceVersion": "50"}},
+					{"metadata": map[string]interface{}{"name": "snap", "namespace": "ns", "resourceVersion": "300"}},
+					{"metadata": map[string]interface{}{"name": "snap", "namespace": "ns", "resourceVersion": "150"}},
+				},
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(list)
+			}))
+			defer server.Close()
+
+			c := newResolvedClient(server)
+			obj := &applicationapiv1alpha1.Snapshot{}
+			err := c.getFromList(ctx, server.Client(), server.URL, gvr, "ns", "snap", obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(obj.ResourceVersion).To(Equal("300"))
+		})
+
+		It("filters items by name", func() {
+			list := map[string]interface{}{
+				"items": []map[string]interface{}{
+					{"metadata": map[string]interface{}{"name": "other", "namespace": "ns", "resourceVersion": "999"}},
+					{"metadata": map[string]interface{}{"name": "target", "namespace": "ns", "resourceVersion": "100"}},
+				},
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(list)
+			}))
+			defer server.Close()
+
+			c := newResolvedClient(server)
+			obj := &applicationapiv1alpha1.Snapshot{}
+			err := c.getFromList(ctx, server.Client(), server.URL, gvr, "ns", "target", obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(obj.Name).To(Equal("target"))
+			Expect(obj.ResourceVersion).To(Equal("100"))
+		})
+
+		It("returns NotFound when the list is empty", func() {
+			list := map[string]interface{}{"items": []interface{}{}}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(list)
+			}))
+			defer server.Close()
+
+			c := newResolvedClient(server)
+			obj := &applicationapiv1alpha1.Snapshot{}
+			err := c.getFromList(ctx, server.Client(), server.URL, gvr, "ns", "snap", obj)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("returns NotFound when no items match the name", func() {
+			list := map[string]interface{}{
+				"items": []map[string]interface{}{
+					{"metadata": map[string]interface{}{"name": "other", "namespace": "ns", "resourceVersion": "1"}},
+				},
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(list)
+			}))
+			defer server.Close()
+
+			c := newResolvedClient(server)
+			obj := &applicationapiv1alpha1.Snapshot{}
+			err := c.getFromList(ctx, server.Client(), server.URL, gvr, "ns", "snap", obj)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("returns an error when the list endpoint returns a non-200 status", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				w.Write([]byte("unavailable"))
+			}))
+			defer server.Close()
+
+			c := newResolvedClient(server)
+			obj := &applicationapiv1alpha1.Snapshot{}
+			err := c.getFromList(ctx, server.Client(), server.URL, gvr, "ns", "snap", obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("HTTP 503"))
+		})
+
+		It("passes the fieldSelector query parameter", func() {
+			var receivedQuery string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedQuery = r.URL.Query().Get("fieldSelector")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{"items": []interface{}{}})
+			}))
+			defer server.Close()
+
+			c := newResolvedClient(server)
+			obj := &applicationapiv1alpha1.Snapshot{}
+			_ = c.getFromList(ctx, server.Client(), server.URL, gvr, "ns", "my-snap", obj)
+			Expect(receivedQuery).To(Equal("metadata.name=my-snap"))
+		})
+	})
+
+	Describe("resolve", func() {
+		var (
+			ctx    context.Context
+			scheme *runtime.Scheme
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			scheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		})
+
+		It("returns cached values on subsequent calls", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+			defer server.Close()
+
+			c := &Client{
+				resolved:   true,
+				apiURL:     server.URL,
+				httpClient: server.Client(),
+			}
+
+			url, httpClient, err := c.resolve(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(url).To(Equal(server.URL))
+			Expect(httpClient).To(Equal(server.Client()))
+		})
+
+		It("returns an error when already resolved but apiURL is empty", func() {
+			c := &Client{resolved: true, apiURL: ""}
+			_, _, err := c.resolve(ctx, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not available"))
+		})
+
+		It("returns an error when no ConfigMap is found during discovery", func() {
+			cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+			c := NewClient()
+
+			_, _, err := c.resolve(ctx, cli)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("kubearchive discovery failed"))
+		})
+	})
+
+	Describe("doGet", func() {
+		var ctx context.Context
+
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		It("returns the body and status code on success", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, "hello")
+			}))
+			defer server.Close()
+
+			c := newResolvedClient(server)
+			body, status, err := c.doGet(ctx, server.Client(), server.URL+"/test")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(http.StatusOK))
+			Expect(string(body)).To(Equal("hello"))
+		})
+
+		It("returns an error when the server is unreachable", func() {
+			c := &Client{}
+			_, _, err := c.doGet(ctx, http.DefaultClient, "http://127.0.0.1:1")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("kubearchive request"))
+		})
+	})
+
+	Describe("Get with resolve", func() {
+		It("discovers the API URL from the ConfigMap and makes the request", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				snap := applicationapiv1alpha1.Snapshot{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-snap", Namespace: "ns"},
+					Spec:       applicationapiv1alpha1.SnapshotSpec{Application: "my-app"},
+				}
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(snap)
+			}))
+			defer server.Close()
+
+			s := runtime.NewScheme()
+			Expect(corev1.AddToScheme(s)).To(Succeed())
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      apiURLConfigMapName,
+					Namespace: kaNamespace,
+				},
+				Data: map[string]string{apiURLConfigMapKey: server.URL},
+			}
+			cli := fake.NewClientBuilder().WithScheme(s).WithObjects(cm).Build()
+
+			c := &Client{httpClient: server.Client()}
+			gvr := schema.GroupVersionResource{
+				Group: "appstudio.redhat.com", Version: "v1alpha1", Resource: "snapshots",
+			}
+			obj := &applicationapiv1alpha1.Snapshot{}
+			err := c.Get(context.Background(), cli, gvr, "ns", "my-snap", obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(obj.Name).To(Equal("my-snap"))
+			Expect(obj.Spec.Application).To(Equal("my-app"))
+		})
+	})
+})
+
+var _ = Describe("NewClient", func() {
+	It("returns a non-nil client", func() {
+		c := NewClient()
+		Expect(c).NotTo(BeNil())
+		Expect(c.resolved).To(BeFalse())
+	})
+})
+
+// compile-time check that *Client satisfies usage with controller-runtime client.Client.
+var _ client.Client = (client.Client)(nil)

--- a/kubearchive/suite_test.go
+++ b/kubearchive/suite_test.go
@@ -1,0 +1,13 @@
+package kubearchive
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "KubeArchive Suite")
+}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/kubearchive"
 	"github.com/konflux-ci/release-service/metadata"
 )
 
@@ -44,10 +45,25 @@ type ObjectLoader interface {
 	GetProcessingResources(ctx context.Context, cli client.Client, release *v1alpha1.Release) (*ProcessingResources, error)
 }
 
-type loader struct{}
+// KubeArchiveClient is the subset of kubearchive.Client used by the loader,
+// extracted as an interface to allow substitution in tests.
+type KubeArchiveClient interface {
+	Get(ctx context.Context, cli client.Client, gvr schema.GroupVersionResource,
+		namespace, name string, obj client.Object) error
+}
+
+type loader struct {
+	kaClient KubeArchiveClient
+}
 
 func NewLoader() ObjectLoader {
-	return &loader{}
+	return &loader{
+		kaClient: kubearchive.NewClient(),
+	}
+}
+
+func newLoader(kaClient KubeArchiveClient) ObjectLoader {
+	return &loader{kaClient: kaClient}
 }
 
 // GetActiveReleasePlanAdmission returns the ReleasePlanAdmission targeted by the given ReleasePlan.
@@ -330,11 +346,25 @@ func (l *loader) GetReleaseServiceConfig(ctx context.Context, cli client.Client,
 	return releaseServiceConfig, toolkit.GetObject(name, namespace, cli, ctx, releaseServiceConfig)
 }
 
-// GetSnapshot returns the Snapshot referenced by the given Release. If the Snapshot is not found or the Get
-// operation fails, an error is returned.
+// GetSnapshot returns the Snapshot referenced by the given Release. If the Snapshot is not found
+// in the cluster, it falls back to KubeArchive to retrieve the archived resource. If both
+// lookups fail, the original cluster error is returned.
 func (l *loader) GetSnapshot(ctx context.Context, cli client.Client, release *v1alpha1.Release) (*applicationapiv1alpha1.Snapshot, error) {
 	snapshot := &applicationapiv1alpha1.Snapshot{}
-	return snapshot, toolkit.GetObject(release.Spec.Snapshot, release.Namespace, cli, ctx, snapshot)
+	err := toolkit.GetObject(release.Spec.Snapshot, release.Namespace, cli, ctx, snapshot)
+	if err != nil && apierrors.IsNotFound(err) {
+		kaErr := l.kaClient.Get(ctx, cli,
+			schema.GroupVersionResource{
+				Group:    "appstudio.redhat.com",
+				Version:  "v1alpha1",
+				Resource: "snapshots",
+			},
+			release.Namespace, release.Spec.Snapshot, snapshot)
+		if kaErr == nil {
+			return snapshot, nil
+		}
+	}
+	return snapshot, err
 }
 
 // ProcessingResources contains the required resources to process the Release.

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"context"
 	stderrors "errors"
 	"fmt"
 	"os"
@@ -21,6 +22,7 @@ import (
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -749,6 +751,54 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			Expect(returnedObject).NotTo(Equal(&applicationapiv1alpha1.Snapshot{}))
 			Expect(returnedObject.Name).To(Equal(snapshot.Name))
 		})
+
+		It("does not call KubeArchive when the snapshot exists in the cluster", func() {
+			called := false
+			kaLoader := newLoader(&fakeKAClient{
+				getFunc: func(_ context.Context, _ client.Client, _ schema.GroupVersionResource, _, _ string, _ client.Object) error {
+					called = true
+					return fmt.Errorf("should not be called")
+				},
+			})
+			returnedObject, err := kaLoader.GetSnapshot(ctx, k8sClient, release)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(returnedObject.Name).To(Equal(snapshot.Name))
+			Expect(called).To(BeFalse())
+		})
+
+		It("falls back to KubeArchive when the snapshot is not found in the cluster", func() {
+			missingRelease := release.DeepCopy()
+			missingRelease.Spec.Snapshot = "archived-snapshot"
+
+			kaLoader := newLoader(&fakeKAClient{
+				getFunc: func(_ context.Context, _ client.Client, _ schema.GroupVersionResource, _, _ string, obj client.Object) error {
+					snap := obj.(*applicationapiv1alpha1.Snapshot)
+					snap.Name = "archived-snapshot"
+					snap.Namespace = "default"
+					snap.Spec.Application = "recovered-app"
+					return nil
+				},
+			})
+			returnedObject, err := kaLoader.GetSnapshot(ctx, k8sClient, missingRelease)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(returnedObject.Name).To(Equal("archived-snapshot"))
+			Expect(returnedObject.Spec.Application).To(Equal("recovered-app"))
+		})
+
+		It("returns the cluster error when KubeArchive also fails", func() {
+			missingRelease := release.DeepCopy()
+			missingRelease.Spec.Snapshot = "gone-snapshot"
+
+			kaLoader := newLoader(&fakeKAClient{
+				getFunc: func(_ context.Context, _ client.Client, _ schema.GroupVersionResource, _, _ string, _ client.Object) error {
+					return fmt.Errorf("kubearchive unavailable")
+				},
+			})
+			_, err := kaLoader.GetSnapshot(ctx, k8sClient, missingRelease)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+			Expect(err.Error()).NotTo(ContainSubstring("kubearchive unavailable"))
+		})
 	})
 
 	// Composite functions
@@ -984,3 +1034,13 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	}
 
 })
+
+type fakeKAClient struct {
+	getFunc func(ctx context.Context, cli client.Client, gvr schema.GroupVersionResource,
+		namespace, name string, obj client.Object) error
+}
+
+func (f *fakeKAClient) Get(ctx context.Context, cli client.Client, gvr schema.GroupVersionResource,
+	namespace, name string, obj client.Object) error {
+	return f.getFunc(ctx, cli, gvr, namespace, name, obj)
+}


### PR DESCRIPTION
Add a new kubearchive package that provides a client for the KubeArchive API. The client lazily discovers the API URL from a ConfigMap defined in infra-deployments [1], authenticates using the in-cluster service account token, and handles the edge case where multiple archived versions of a resource exist by falling back to the list endpoint and selecting the entry with the highest resourceVersion.

GetSnapshot in the loader now attempts to retrieve the Snapshot from KubeArchive when the cluster returns a NotFound error, enabling release processing for Snapshots that have been garbage-collected from the cluster but are still available in the archive.

[1] https://github.com/redhat-appstudio/infra-deployments/blob/main/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml#L11-L16

Assisted-by: Cursor