### PR TITLE
refactor: Remove verify ec git revision

### DIFF
--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -1174,7 +1174,6 @@ func (a *adapter) createManagedPipelineRun(resources *loader.ProcessingResources
 		WithObjectSpecsAsJson(resources.EnterpriseContractPolicy).
 		WithOwner(a.release).
 		WithParamsFromConfigMap(resources.EnterpriseContractConfigMap, []string{"verify_ec_task_bundle"}).
-		WithParamsFromConfigMap(resources.EnterpriseContractConfigMap, []string{"verify_ec_task_git_revision"}).
 		WithPipelineRef(resources.ReleasePlanAdmission.Spec.Pipeline.PipelineRef.ToTektonPipelineRef()).
 		WithServiceAccount(resources.ReleasePlanAdmission.Spec.Pipeline.ServiceAccountName).
 		WithTaskRunSpecs(resources.ReleasePlanAdmission.Spec.Pipeline.TaskRunSpecs...).

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -3699,9 +3699,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			bundle := enterpriseContractConfigMap.Data["verify_ec_task_bundle"]
-			revision := enterpriseContractConfigMap.Data["verify_ec_task_git_revision"]
 			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", Equal(string(bundle)))))
-			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", Equal(string(revision)))))
 		})
 
 		It("passes ociStorage param from ReleasePlanAdmission to PipelineRun", func() {
@@ -6050,8 +6048,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 				Namespace: "default",
 			},
 			Data: map[string]string{
-				"verify_ec_task_bundle":       "test-bundle",
-				"verify_ec_task_git_revision": "main",
+				"verify_ec_task_bundle": "test-bundle",
 			},
 		}
 		Expect(k8sClient.Create(ctx, enterpriseContractConfigMap)).Should(Succeed())


### PR DESCRIPTION
This param is not needed anymore. The release pipelines are using a hardcoded branch - konflux

This depends on https://github.com/konflux-ci/release-service-catalog/pull/2095

Signed-off-by: jstuart@redhat.com