### PR TITLE
feat(KONFLUX-12768): add MaxConcurrentReconciles support to all controllers

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -79,6 +79,8 @@ spec:
               key: DEFAULT_RELEASE_WORKSPACE_SIZE
               name: manager-properties
               optional: true
+        - name: MAX_CONCURRENT_RECONCILES
+          value: "10"
         - name: SERVICE_NAMESPACE
           valueFrom:
             fieldRef:

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -23,9 +23,11 @@ import (
 	"github.com/konflux-ci/release-service/controllers/releaseplanadmission"
 )
 
-// EnabledControllers is a slice containing references to all the controllers that have to be registered
-var EnabledControllers = []controller.Controller{
-	&release.Controller{},
-	&releaseplan.Controller{},
-	&releaseplanadmission.Controller{},
+// EnabledControllers returns a slice containing references to all the controllers that have to be registered
+func EnabledControllers(maxConcurrentReconciles int) []controller.Controller {
+	return []controller.Controller{
+		&release.Controller{MaxConcurrentReconciles: maxConcurrentReconciles},
+		&releaseplan.Controller{MaxConcurrentReconciles: maxConcurrentReconciles},
+		&releaseplanadmission.Controller{MaxConcurrentReconciles: maxConcurrentReconciles},
+	}
 }

--- a/controllers/release/controller.go
+++ b/controllers/release/controller.go
@@ -35,13 +35,15 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	sigsctrl "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // Controller reconciles a Release object
 type Controller struct {
-	client client.Client
-	log    logr.Logger
+	client                  client.Client
+	log                     logr.Logger
+	MaxConcurrentReconciles int
 }
 
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releases,verbs=get;list;watch;create;update;patch;delete
@@ -109,6 +111,7 @@ func (c *Controller) Register(mgr ctrl.Manager, log *logr.Logger, _ cluster.Clus
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Release{}, builder.WithPredicates(predicate.GenerationChangedPredicate{}, predicates.IgnoreBackups{})).
+		WithOptions(sigsctrl.Options{MaxConcurrentReconciles: c.MaxConcurrentReconciles}).
 		Watches(&tektonv1.PipelineRun{}, &libhandler.EnqueueRequestForAnnotation[client.Object]{
 			Type: schema.GroupKind{
 				Kind:  "Release",

--- a/controllers/release/controller_test.go
+++ b/controllers/release/controller_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 var _ = Describe("Release Controller", Ordered, func() {
-
 	// For the Reconcile function test we don't want to make a successful call as it will call every single operation
 	// defined there. We don't have any control over the operations being executed, and we want to keep a clean env for
 	// the adapter tests.
@@ -73,11 +72,11 @@ var _ = Describe("Release Controller", Ordered, func() {
 	})
 
 	When("Register is called", func() {
-
 		It("should setup the controller successfully", func() {
 			controller := &Controller{
-				client: k8sClient,
-				log:    ctrl.Log,
+				client:                  k8sClient,
+				log:                     ctrl.Log,
+				MaxConcurrentReconciles: 10,
 			}
 
 			mgr, _ := ctrl.NewManager(cfg, ctrl.Options{
@@ -90,5 +89,4 @@ var _ = Describe("Release Controller", Ordered, func() {
 			Expect(controller.Register(mgr, &ctrl.Log, nil)).To(Succeed())
 		})
 	})
-
 })

--- a/controllers/releaseplan/controller.go
+++ b/controllers/releaseplan/controller.go
@@ -31,13 +31,15 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	sigsctrl "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // Controller reconciles a ReleasePlan object
 type Controller struct {
-	client client.Client
-	log    logr.Logger
+	client                  client.Client
+	log                     logr.Logger
+	MaxConcurrentReconciles int
 }
 
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releaseplanadmissions,verbs=get;list;watch
@@ -72,6 +74,7 @@ func (c *Controller) Register(mgr ctrl.Manager, log *logr.Logger, _ cluster.Clus
 	c.client = mgr.GetClient()
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(sigsctrl.Options{MaxConcurrentReconciles: c.MaxConcurrentReconciles}).
 		For(&v1alpha1.ReleasePlan{}, builder.WithPredicates(predicate.GenerationChangedPredicate{}, predicates.MatchPredicate())).
 		Watches(&v1alpha1.ReleasePlanAdmission{}, &handlers.EnqueueRequestForMatchedResource[client.Object]{},
 			builder.WithPredicates(predicates.MatchPredicate())).

--- a/controllers/releaseplan/controller_test.go
+++ b/controllers/releaseplan/controller_test.go
@@ -18,6 +18,7 @@ package releaseplan
 
 import (
 	"reflect"
+
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -30,7 +31,6 @@ import (
 )
 
 var _ = Describe("ReleasePlan Controller", Ordered, func() {
-
 	// For the Reconcile function test we don't want to make a successful call as it will call every single operation
 	// defined there. We don't have any control over the operations being executed, and we want to keep a clean env for
 	// the adapter tests.
@@ -56,8 +56,9 @@ var _ = Describe("ReleasePlan Controller", Ordered, func() {
 	When("Register is called", func() {
 		It("should setup the controller successfully", func() {
 			controller := &Controller{
-				client: k8sClient,
-				log:    ctrl.Log,
+				client:                  k8sClient,
+				log:                     ctrl.Log,
+				MaxConcurrentReconciles: 10,
 			}
 
 			mgr, _ := ctrl.NewManager(cfg, ctrl.Options{
@@ -70,5 +71,4 @@ var _ = Describe("ReleasePlan Controller", Ordered, func() {
 			Expect(controller.Register(mgr, &ctrl.Log, nil)).To(Succeed())
 		})
 	})
-
 })

--- a/controllers/releaseplanadmission/controller.go
+++ b/controllers/releaseplanadmission/controller.go
@@ -32,12 +32,14 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	sigsctrl "sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 // Controller reconciles a ReleasePlanAdmission object
 type Controller struct {
-	client client.Client
-	log    logr.Logger
+	client                  client.Client
+	log                     logr.Logger
+	MaxConcurrentReconciles int
 }
 
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releaseplans,verbs=get;list;watch
@@ -71,6 +73,7 @@ func (c *Controller) Register(mgr ctrl.Manager, log *logr.Logger, _ cluster.Clus
 	c.client = mgr.GetClient()
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(sigsctrl.Options{MaxConcurrentReconciles: c.MaxConcurrentReconciles}).
 		For(&v1alpha1.ReleasePlanAdmission{}, builder.WithPredicates(predicates.MatchPredicate())).
 		Watches(&v1alpha1.ReleasePlan{}, &handlers.EnqueueRequestForMatchedResource[client.Object]{},
 			builder.WithPredicates(predicates.MatchPredicate())).

--- a/controllers/releaseplanadmission/controller_test.go
+++ b/controllers/releaseplanadmission/controller_test.go
@@ -55,8 +55,9 @@ var _ = Describe("ReleasePlanAdmission Controller", Ordered, func() {
 	When("Register is called", func() {
 		It("should setup the controller successfully", func() {
 			controller := &Controller{
-				client: k8sClient,
-				log:    ctrl.Log,
+				client:                  k8sClient,
+				log:                     ctrl.Log,
+				MaxConcurrentReconciles: 10,
 			}
 
 			mgr, _ := ctrl.NewManager(cfg, ctrl.Options{

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"os"
+	"strconv"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -155,7 +156,7 @@ func main() {
 		Cache: cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
 				// we want to cache PipelineRuns only created by this operator.
-				&tektonv1.PipelineRun{}: cache.ByObject{
+				&tektonv1.PipelineRun{}: {
 					Label: labels.SelectorFromSet(labels.Set{metadata.ServiceNameLabel: metadata.ServiceName}),
 				},
 				// also cache other watched objects, but no filter is required.
@@ -210,7 +211,19 @@ func main() {
 		}
 	}
 
-	setUpControllers(mgr)
+	// Set max concurrent reconciles for the controllers
+	// default is 1 if MAX_CONCURRENT_RECONCILES is undefined
+	maxConcurrentReconciles := 1
+	if val := os.Getenv("MAX_CONCURRENT_RECONCILES"); val != "" {
+		n, err := strconv.Atoi(val)
+		if err != nil || n < 1 {
+			setupLog.Error(err, "invalid MAX_CONCURRENT_RECONCILES value, using default", "value", val, "default", maxConcurrentReconciles)
+		} else {
+			maxConcurrentReconciles = n
+		}
+	}
+
+	setUpControllers(mgr, maxConcurrentReconciles)
 	setUpWebhooks(mgr)
 
 	err = os.Setenv("ENTERPRISE_CONTRACT_CONFIG_MAP", "enterprise-contract-service/ec-defaults")
@@ -238,8 +251,8 @@ func main() {
 }
 
 // setUpControllers sets up controllers.
-func setUpControllers(mgr ctrl.Manager) {
-	err := controller.SetupControllers(mgr, nil, controllers.EnabledControllers...)
+func setUpControllers(mgr ctrl.Manager, maxConcurrentReconciles int) {
+	err := controller.SetupControllers(mgr, nil, controllers.EnabledControllers(maxConcurrentReconciles)...)
 	if err != nil {
 		setupLog.Error(err, "unable to setup controllers")
 		os.Exit(1)


### PR DESCRIPTION
Add configurable MaxConcurrentReconciles to all controllers via the MAX_CONCURRENT_RECONCILES environment variable, defaulting to 1 if unset. The env var is set to 10 in the manager deployment manifest.

Assisted-by: Claude Code