### PR TITLE
test(KONFLUX-12126): add final pipeline finalizer test

### DIFF
--- a/e2e-tests/pkg/framework/release.go
+++ b/e2e-tests/pkg/framework/release.go
@@ -58,10 +58,19 @@ func (r *ReleaseController) GetRelease(name, namespace string) (*releaseApi.Rele
 	return r.loader.GetRelease(context.Background(), r.kubeClient, name, namespace)
 }
 
-// GetFirstReleaseInNamespace gets the first Release in a namespace.
-func (r *ReleaseController) GetFirstReleaseInNamespace(namespace string) (*releaseApi.Release, error) {
+// GetReleasesInNamespace gets the list of Releases in a namespace.
+func (r *ReleaseController) GetReleasesInNamespace(namespace string) (*releaseApi.ReleaseList, error) {
 	releaseList := &releaseApi.ReleaseList{}
 	err := r.kubeClient.List(context.Background(), releaseList, client.InNamespace(namespace))
+	if err != nil {
+		return nil, err
+	}
+	return releaseList, nil
+}
+
+// GetFirstReleaseInNamespace gets the first Release in a namespace.
+func (r *ReleaseController) GetFirstReleaseInNamespace(namespace string) (*releaseApi.Release, error) {
+	releaseList, err := r.GetReleasesInNamespace(namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +112,7 @@ func (r *ReleaseController) CreateReleasePipelineRoleBindingForServiceAccount(na
 // =============================================================================
 
 // CreateReleasePlan creates a ReleasePlan.
-func (r *ReleaseController) CreateReleasePlan(name, namespace, application, targetNamespace, autoRelease string, data *runtime.RawExtension, pipeline *tektonutils.ParameterizedPipeline, serviceAccount *string) (*releaseApi.ReleasePlan, error) {
+func (r *ReleaseController) CreateReleasePlan(name, namespace, application, targetNamespace, autoRelease string, data *runtime.RawExtension, tenantPipeline, finalpipeline *tektonutils.ParameterizedPipeline, serviceAccount *string) (*releaseApi.ReleasePlan, error) {
 	// Set auto-release label - default to "true" if empty (matching original behavior)
 	autoReleaseValue := autoRelease
 	if autoReleaseValue == "" {
@@ -123,7 +132,8 @@ func (r *ReleaseController) CreateReleasePlan(name, namespace, application, targ
 			Application:    application,
 			Target:         targetNamespace,
 			Data:           data,
-			TenantPipeline: pipeline,
+			TenantPipeline: tenantPipeline,
+			FinalPipeline:  finalpipeline,
 		},
 	}
 

--- a/e2e-tests/pkg/framework/tekton.go
+++ b/e2e-tests/pkg/framework/tekton.go
@@ -120,10 +120,19 @@ func (t *TektonController) CreateEnterpriseContractPolicy(name, namespace string
 // PipelineRun Operations (using metadata from main project)
 // =============================================================================
 
-// GetPipelineRunInNamespace gets a PipelineRun for a release using labels from metadata package.
-func (t *TektonController) GetPipelineRunInNamespace(namespace, releaseName, releaseNamespace string) (*tektonv1.PipelineRun, error) {
+// GetAllPipelineRunsInNamespace gets a PipelineRun for a release using labels from metadata package.
+func (t *TektonController) GetAllPipelineRunsInNamespace(namespace string) (*tektonv1.PipelineRunList, error) {
 	pipelineRuns := &tektonv1.PipelineRunList{}
 	err := t.kubeClient.List(context.Background(), pipelineRuns, client.InNamespace(namespace))
+	if err != nil {
+		return nil, err
+	}
+	return pipelineRuns, err
+}
+
+// GetPipelineRunInNamespace gets a PipelineRun for a release using labels from metadata package.
+func (t *TektonController) GetPipelineRunInNamespace(namespace, releaseName, releaseNamespace string) (*tektonv1.PipelineRun, error) {
+	pipelineRuns, err := t.GetAllPipelineRunsInNamespace(namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -165,6 +174,16 @@ func (t *TektonController) WaitForReleasePipelineToBeFinished(release *releaseAp
 		}
 		return false, nil
 	})
+}
+
+// HasPipelineRunSucceeded checks the plr conditions to see if the pipelineRun succeeded
+func HasPipelineRunSucceeded(pr *tektonv1.PipelineRun) bool {
+	return pr.GetStatusCondition().GetCondition(apis.ConditionSucceeded).IsTrue()
+}
+
+// HasPipelineRunFailed checks the plr conditions to see if the pipelineRun failed
+func HasPipelineRunFailed(pr *tektonv1.PipelineRun) bool {
+	return pr.IsDone() && pr.GetStatusCondition().GetCondition(apis.ConditionSucceeded).IsFalse()
 }
 
 // =============================================================================

--- a/e2e-tests/tests/release/service/block_releases_release_plan_admission.go
+++ b/e2e-tests/tests/release/service/block_releases_release_plan_admission.go
@@ -54,7 +54,7 @@ var _ = ginkgo.Describe("Release CR fails when block-releases true in ReleasePla
 		err = fw.AsKubeAdmin.CommonController.KubeRest().Create(context.Background(), snapshot)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Snapshot %s", snapshotName)
 
-		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "", nil, nil, nil)
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "", nil, nil, nil, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s", constants.SourceReleasePlanName)
 
 		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(destinationReleasePlanAdmissionName, managedNamespace, "", devNamespace, constants.ReleaseStrategyPolicy, constants.ReleasePipelineServiceAccountDefault, []string{constants.ApplicationName}, true, &tektonutils.PipelineRef{

--- a/e2e-tests/tests/release/service/final_pipeline_finalizer_removed.go
+++ b/e2e-tests/tests/release/service/final_pipeline_finalizer_removed.go
@@ -1,0 +1,345 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	ecp "github.com/conforma/crds/api/v1alpha1"
+	"github.com/devfile/library/v2/pkg/util"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.yaml.in/yaml/v2"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	releasedImagePushRepo = "quay.io/redhat-appstudio-qe/dcmetromap"
+	sampleImage           = "quay.io/redhat-appstudio-qe/dcmetromap@sha256:544259be8bcd9e6a2066224b805d854d863064c9b64fa3a87bfcd03f5b0f28e6"
+	gitSourceURL          = "https://github.com/redhat-appstudio-qe/dc-metro-map-release"
+	gitSourceRevision     = "d49914874789147eb2de9bb6a12cd5d150bfff92"
+	pipelineExamplesURL   = "https://github.com/redhat-appstudio-qe/pipeline_examples"
+	pipelineExamplesRev   = "main"
+
+	releasePlanNameFailure  = constants.SourceReleasePlanName
+	releasePlanNameSuccess  = constants.SourceReleasePlanName + "-success"
+	managedNamespaceFailure = "final-finalizer-managed-failure"
+	managedNamespaceSuccess = "final-finalizer-managed-success"
+	rpaNameFailure          = constants.TargetReleasePlanAdmissionName
+	rpaNameSuccess          = constants.TargetReleasePlanAdmissionName + "-success"
+)
+
+// scenarioParams is used by postReleaseVerification to find the right Release and managed namespace.
+type scenarioParams struct {
+	releasePlanName     string
+	managedNamespace    string
+	expectManagedToFail bool
+}
+
+var (
+	fw           *framework.Framework
+	err          error
+	releaseCR    *releaseApi.Release
+	devNamespace string
+)
+
+var _ = ginkgo.Describe("Finalizer is removed from final pipeline", releasecommon.LabelFinal, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+
+	ginkgo.BeforeAll(func() {
+		setupFinalPipelineFinalizerSuite()
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(managedNamespaceFailure)).To(gomega.Succeed())
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(managedNamespaceSuccess)).To(gomega.Succeed())
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(fw.UserNamespace)).To(gomega.Succeed())
+		}
+	})
+
+	ginkgo.Describe("when managed pipeline fails", func() {
+		postReleaseVerification(scenarioParams{
+			releasePlanName:     releasePlanNameFailure,
+			managedNamespace:    managedNamespaceFailure,
+			expectManagedToFail: true,
+		})
+	})
+
+	ginkgo.Describe("when managed pipeline succeeds", func() {
+		postReleaseVerification(scenarioParams{
+			releasePlanName:     releasePlanNameSuccess,
+			managedNamespace:    managedNamespaceSuccess,
+			expectManagedToFail: false,
+		})
+	})
+})
+
+// setupFinalPipelineFinalizerSuite creates one dev namespace with one Application, one tenant SA,
+// one PVC, one Snapshot, and two ReleasePlans (failure and success). It creates two managed
+// namespaces, each with its own release-service SA, EC policy, and ReleasePlanAdmission.
+func setupFinalPipelineFinalizerSuite() {
+	fw, err = framework.NewFramework(utils.GetGeneratedNamespace("final-finalizer-dev"))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework")
+	devNamespace = fw.UserNamespace
+
+	tenantPullSecretName := "final-finalizer-pull-secret"
+	tenantSAName := "final-finalizer-service-account"
+
+	// Create both managed namespaces and their release-service SAs and RPAs
+	for _, m := range []struct {
+		managedNs    string
+		rpaName      string
+		pipelinePath string
+	}{
+		{managedNamespaceFailure, rpaNameFailure, "pipelines/failing_pipeline.yaml"},
+		{managedNamespaceSuccess, rpaNameSuccess, "pipelines/simple_pipeline.yaml"},
+	} {
+		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(m.managedNs)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Error when creating managedNamespace: %v", err)
+
+		managedSA, err := fw.AsKubeAdmin.CommonController.CreateServiceAccount(constants.ReleasePipelineServiceAccountDefault, m.managedNs, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create service account %s in %s: %v", constants.ReleasePipelineServiceAccountDefault, m.managedNs, err)
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(m.managedNs, managedSA)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create rolebinding for service account: %v", err)
+
+		ecPolicyName := "ffinalizer-policy-" + util.GenerateRandomString(4)
+		defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get default EC policy: %v", err)
+		defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
+			Description: "Red Hat's enterprise requirements",
+			PublicKey:   fmt.Sprintf("k8s://%s/%s", m.managedNs, constants.PublicSecretNameAuth),
+			Sources:     defaultEcPolicy.Spec.Sources,
+			Configuration: &ecp.EnterpriseContractPolicyConfiguration{
+				Collections: []string{"@slsa3"},
+				Exclude:     []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
+			},
+		}
+		_, err = fw.AsKubeAdmin.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, m.managedNs, defaultEcPolicySpec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s: %v", ecPolicyName, err)
+
+		data, err := json.Marshal(map[string]interface{}{
+			"mapping": map[string]interface{}{
+				"components": []map[string]interface{}{
+					{
+						"component":  constants.ComponentName,
+						"repository": releasedImagePushRepo,
+					},
+				},
+			},
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to marshal RPA data: %v", err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(m.rpaName, m.managedNs, "", devNamespace, ecPolicyName, constants.ReleasePipelineServiceAccountDefault, []string{constants.ApplicationNameDefault}, false, &tektonutils.PipelineRef{
+			Resolver: "git",
+			Params: []tektonutils.Param{
+				{Name: "url", Value: pipelineExamplesURL},
+				{Name: "revision", Value: pipelineExamplesRev},
+				{Name: "pathInRepo", Value: m.pipelinePath},
+			},
+		}, &runtime.RawExtension{Raw: data})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s: %v", m.rpaName, err)
+	}
+
+	// Single tenant secret and SA in dev namespace
+	sourceAuthJson := utils.GetEnv("QUAY_TOKEN", "")
+	gomega.Expect(sourceAuthJson).ToNot(gomega.BeEmpty(), "QUAY_TOKEN env var is required (dockerconfigjson format)")
+	_, err = fw.AsKubeAdmin.CommonController.GetSecret(devNamespace, tenantPullSecretName)
+	if errors.IsNotFound(err) {
+		_, err = fw.AsKubeAdmin.CommonController.CreateRegistryAuthSecret(tenantPullSecretName, devNamespace, sourceAuthJson)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to create secret %s: %v", tenantPullSecretName, err)
+	}
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	_, err = fw.AsKubeAdmin.CommonController.CreateServiceAccount(tenantSAName, devNamespace, []corev1.ObjectReference{{Name: tenantPullSecretName}}, nil)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to create service account %s in %s: %v", tenantSAName, devNamespace, err)
+
+	// Single Application in dev namespace
+	_, err = fw.AsKubeAdmin.KonfluxApiController.CreateApplication(constants.ApplicationNameDefault, devNamespace)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Application %s: %v", constants.ApplicationNameDefault, err)
+
+	data, err := json.Marshal(map[string]interface{}{
+		"mapping": map[string]interface{}{
+			"components": []map[string]interface{}{
+				{
+					"component":  constants.ComponentName,
+					"repository": releasedImagePushRepo,
+				},
+			},
+		},
+	})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to marshal RP data: %v", err)
+
+	finalPipeline := &tektonutils.ParameterizedPipeline{}
+	finalPipeline.ServiceAccountName = tenantSAName
+	finalPipeline.Timeouts = tektonv1.TimeoutFields{
+		Pipeline: &metav1.Duration{Duration: 10 * time.Minute},
+	}
+	finalPipeline.PipelineRef = tektonutils.PipelineRef{
+		Resolver: "git",
+		Params: []tektonutils.Param{
+			{Name: "url", Value: pipelineExamplesURL},
+			{Name: "revision", Value: pipelineExamplesRev},
+			{Name: "pathInRepo", Value: "pipelines/simple_pipeline.yaml"},
+		},
+		UseEmptyDir: true,
+	}
+
+	// Two ReleasePlans in dev namespace (same final pipeline, different targets)
+	_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(releasePlanNameFailure, devNamespace, constants.ApplicationNameDefault, managedNamespaceFailure, "", &runtime.RawExtension{Raw: data}, nil, finalPipeline, nil)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", releasePlanNameFailure, err)
+	_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(releasePlanNameSuccess, devNamespace, constants.ApplicationNameDefault, managedNamespaceSuccess, "", &runtime.RawExtension{Raw: data}, nil, finalPipeline, nil)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", releasePlanNameSuccess, err)
+
+	_, err = fw.AsKubeAdmin.TektonController.CreatePVCInAccessMode(constants.ReleasePvcName, devNamespace, corev1.ReadWriteOnce)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create PVC %s: %v", constants.ReleasePvcName, err)
+
+	_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithImageSource(constants.ComponentName, constants.ApplicationNameDefault, devNamespace, sampleImage, gitSourceURL, gitSourceRevision, "", "", "", "")
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create Snapshot: %v", err)
+}
+
+// getReleaseByRPName returns the Release in devNamespace whose spec.releasePlan matches releasePlanName.
+func getReleaseByRPName(fw *framework.Framework, devNamespace, releasePlanName string) (*releaseApi.Release, error) {
+	list, err := fw.AsKubeAdmin.ReleaseController.GetReleasesInNamespace(devNamespace)
+	if err != nil {
+		return nil, err
+	}
+	for i := range list.Items {
+		r := &list.Items[i]
+		if r.Spec.ReleasePlan == releasePlanName {
+			return r, nil
+		}
+	}
+	return nil, fmt.Errorf("no Release found with spec.releasePlan %q in namespace %s", releasePlanName, devNamespace)
+}
+
+// postReleaseVerification registers the shared "Post-release verification" Its.
+// It finds the Release for this scenario by releasePlanName and uses the scenario's managedNamespace.
+func postReleaseVerification(p scenarioParams) {
+	var _ = ginkgo.Describe("Post-release verification", func() {
+		ginkgo.AfterEach(func() {
+			if ginkgo.CurrentSpecReport().Failed() && releaseCR != nil {
+				release, getErr := fw.AsKubeAdmin.ReleaseController.GetRelease(releaseCR.GetName(), devNamespace)
+				if getErr == nil {
+					releaseYaml, marshalErr := yaml.Marshal(release)
+					if marshalErr == nil {
+						ginkgo.GinkgoWriter.Printf("Release CR (spec failed):\n%s\n", string(releaseYaml))
+					}
+				}
+			}
+		})
+
+		ginkgo.It("verifies that a Release CR should have been created in the dev namespace", func() {
+			gomega.Eventually(func() error {
+				var getErr error
+				releaseCR, getErr = getReleaseByRPName(fw, devNamespace, p.releasePlanName)
+				return getErr
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies that managed PipelineRun finished with expected outcome", func() {
+			assertManagedPipelineRunFinished(fw, p.managedNamespace, p.expectManagedToFail)
+		})
+
+		ginkgo.It("verifies that the Released condition on the Release is no longer Progressing.", func() {
+			gomega.Eventually(func() error {
+				var getErr error
+				releaseCR, getErr = getReleaseByRPName(fw, devNamespace, p.releasePlanName)
+				if getErr != nil {
+					return getErr
+				}
+				if releaseCR.IsReleasing() {
+					return fmt.Errorf("release %s/%s is not marked as finished yet", releaseCR.GetNamespace(), releaseCR.GetName())
+				}
+				return nil
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies that the finalizer was removed from the final pipeline", func() {
+			assertFinalizerRemovedFromFinalPipeline(fw, devNamespace)
+		})
+	})
+}
+
+func assertManagedPipelineRunFinished(fw *framework.Framework, managedNamespace string, expectFailed bool) {
+	var debugPrinted bool
+	gomega.Eventually(func() error {
+		managedPipelineRun, err := fw.AsKubeAdmin.TektonController.GetPipelineRunInNamespace(managedNamespace, releaseCR.GetName(), releaseCR.GetNamespace())
+		if err != nil {
+			if !debugPrinted {
+				debugPrinted = true
+				prList, listErr := fw.AsKubeAdmin.TektonController.GetAllPipelineRunsInNamespace(managedNamespace)
+				if listErr == nil {
+					ginkgo.GinkgoWriter.Printf("PipelineRuns in %s: %d total\n", managedNamespace, len(prList.Items))
+					for i := range prList.Items {
+						pr := &prList.Items[i]
+						ginkgo.GinkgoWriter.Printf("  - %s labels=%v\n", pr.GetName(), pr.GetLabels())
+					}
+				} else {
+					ginkgo.GinkgoWriter.Printf("Failed to list PipelineRuns in %s: %v\n", managedNamespace, listErr)
+				}
+			}
+			return fmt.Errorf("managed PipelineRun not found for release %s/%s: %w", releaseCR.GetNamespace(), releaseCR.GetName(), err)
+		}
+		if !managedPipelineRun.IsDone() {
+			return fmt.Errorf("managed PipelineRun %s/%s has not finished yet", managedPipelineRun.GetNamespace(), managedPipelineRun.GetName())
+		}
+		if expectFailed && !framework.HasPipelineRunFailed(managedPipelineRun) {
+			return fmt.Errorf("expected managed PipelineRun %s/%s to have failed", managedPipelineRun.GetNamespace(), managedPipelineRun.GetName())
+		}
+		if !expectFailed && !framework.HasPipelineRunSucceeded(managedPipelineRun) {
+			return fmt.Errorf("expected managed PipelineRun %s/%s to have succeeded", managedPipelineRun.GetNamespace(), managedPipelineRun.GetName())
+		}
+		return nil
+	}, 15*time.Minute, constants.DefaultInterval).Should(gomega.Succeed(),
+		"managed release PipelineRun should have finished with expected outcome")
+}
+
+func assertFinalizerRemovedFromFinalPipeline(fw *framework.Framework, devNamespace string) {
+	err := wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 15*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		finalPipelineRun, err := fw.AsKubeAdmin.TektonController.GetPipelineRunInNamespace(devNamespace, releaseCR.GetName(), devNamespace)
+		if err != nil {
+			ginkgo.GinkgoWriter.Printf("Final PipelineRun has not been created yet for release %s/%s\n", devNamespace, releaseCR.GetName())
+			return false, nil
+		}
+		for _, condition := range finalPipelineRun.Status.Conditions {
+			ginkgo.GinkgoWriter.Printf("PipelineRun %s reason: %s\n", finalPipelineRun.Name, condition.Reason)
+		}
+		if !finalPipelineRun.IsDone() {
+			return false, nil
+		}
+		return true, nil
+	})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "timed out waiting for final PipelineRun to complete")
+
+	gomega.Eventually(func() error {
+		finalPipelineRun, err := fw.AsKubeAdmin.TektonController.GetPipelineRunInNamespace(devNamespace, releaseCR.GetName(), devNamespace)
+		if err != nil {
+			return fmt.Errorf("failed to get final PipelineRun for release %s/%s: %w", releaseCR.GetNamespace(), releaseCR.GetName(), err)
+		}
+		finalizers := finalPipelineRun.GetFinalizers()
+		if len(finalizers) > 0 {
+			ginkgo.GinkgoWriter.Printf("Final PipelineRun %s/%s finalizers: %v\n", finalPipelineRun.GetNamespace(), finalPipelineRun.GetName(), finalizers)
+		}
+		for _, f := range finalizers {
+			if f == "appstudio.redhat.com/release-finalizer" {
+				return fmt.Errorf("release finalizer still present on final PipelineRun %s/%s", finalPipelineRun.GetNamespace(), finalPipelineRun.GetName())
+			}
+		}
+		return nil
+	}, 30*time.Second, constants.DefaultInterval).Should(gomega.Succeed(),
+		"release finalizer should have been removed from final pipeline within 30 seconds")
+}

--- a/e2e-tests/tests/release/service/happy_path.go
+++ b/e2e-tests/tests/release/service/happy_path.go
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("Release service happy path", releasecommon.LabelHappyPa
 		_, err = fw.AsKubeAdmin.KonfluxApiController.CreateApplication(constants.ApplicationNameDefault, devNamespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Application %s: %v", constants.ApplicationNameDefault, err)
 
-		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "", nil, nil, nil)
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "", nil, nil, nil, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", constants.SourceReleasePlanName, err)
 
 		data, err := json.Marshal(map[string]interface{}{

--- a/e2e-tests/tests/release/service/release_plan_and_admission_matched.go
+++ b/e2e-tests/tests/release/service/release_plan_and_admission_matched.go
@@ -37,7 +37,7 @@ var _ = ginkgo.Describe("ReleasePlan and ReleasePlanAdmission match", releasecom
 		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(managedNamespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create managed namespace %s", managedNamespace)
 
-		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "true", nil, nil, nil)
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "true", nil, nil, nil, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s", constants.SourceReleasePlanName)
 	})
 
@@ -120,7 +120,7 @@ var _ = ginkgo.Describe("ReleasePlan and ReleasePlanAdmission match", releasecom
 		})
 
 		ginkgo.It("Creates a manual release ReleasePlan CR in devNamespace", func() {
-			_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SecondReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "false", nil, nil, nil)
+			_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SecondReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "false", nil, nil, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create second ReleasePlan %s", constants.SecondReleasePlanName)
 		})
 

--- a/e2e-tests/tests/release/service/tenant_pipelines.go
+++ b/e2e-tests/tests/release/service/tenant_pipelines.go
@@ -87,7 +87,7 @@ var _ = ginkgo.Describe("Release service tenant pipeline", releasecommon.LabelTe
 
 		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, "", "", &runtime.RawExtension{
 			Raw: data,
-		}, tenantPipeline, nil)
+		}, tenantPipeline, nil, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", constants.SourceReleasePlanName, err)
 
 		_, err = fw.AsKubeAdmin.TektonController.CreatePVCInAccessMode(constants.ReleasePvcName, devNamespace, corev1.ReadWriteOnce)

--- a/e2e-tests/tests/release/testdata.go
+++ b/e2e-tests/tests/release/testdata.go
@@ -16,6 +16,7 @@ var (
 	LabelReleasePlanAdm   = ginkgo.Label("release-service", "release_plan_and_admission")
 	LabelNegative         = ginkgo.Label("release-service", "release-neg", "negMissingReleasePlan")
 	LabelNegBlockReleases = ginkgo.Label("release-service", "release-neg", "negBlockReleases")
+	LabelFinal            = ginkgo.Label("release-service", "final")
 )
 
 // ManagednamespaceSecret contains the secrets required for the managed namespace.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/onsi/gomega v1.39.1
 	github.com/operator-framework/operator-lib v0.19.0
 	github.com/tektoncd/pipeline v1.11.1
+	go.yaml.in/yaml/v2 v2.4.4
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v11.0.0+incompatible
@@ -35,6 +36,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/fatih/color v1.14.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
@@ -52,6 +54,7 @@ require (
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.28.0 // indirect
@@ -60,20 +63,25 @@ require (
 	github.com/google/go-github/v84 v84.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
+	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.6.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pjbgf/sha1cd v0.5.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
+	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
@@ -92,7 +100,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
-	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
@@ -104,6 +111,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/apiserver v0.35.4 // indirect
+	k8s.io/klog v1.0.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
@@ -113,6 +121,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/devfile/library/v2 v2.4.0
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/devfile/library/v2 v2.4.0 h1:c4dFpR/4Onb/4D8vL6zHXILHD8GS+Z5oT6T0piZl834=
+github.com/devfile/library/v2 v2.4.0/go.mod h1:kiuiFsLEl//2WraHesWXj2Z2QLTLpzn2mTT9g8I3qMI=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
@@ -54,6 +56,8 @@ github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lSh
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
+github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
+github.com/fatih/color v1.14.1/go.mod h1:2oHN61fhTpgcxD3TSWCgKDiH1+x4OiDVVGH8WlgGZGg=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
@@ -76,6 +80,7 @@ github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMj
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.18.0 h1:O831KI+0PR51hM2kep6T8k+w0/LIAD490gvqMCvL5hM=
 github.com/go-git/go-git/v5 v5.18.0/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
+github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -119,6 +124,8 @@ github.com/go-openapi/testify/v2 v2.4.2 h1:tiByHpvE9uHrrKjOszax7ZvKB7QOgizBWGBLu
 github.com/go-openapi/testify/v2 v2.4.2/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -153,6 +160,8 @@ github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 h1:EwtI+Al+DeppwYX2oX
 github.com/google/pprof v0.0.0-20260402051712-545e8a4df936/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
+github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
@@ -199,6 +208,11 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
+github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -217,6 +231,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/operator-framework/operator-lib v0.19.0 h1:az6ogYj21rtU0SF9uYctRLyKp2dtlqTsmpfehFy6Ce8=
 github.com/operator-framework/operator-lib v0.19.0/go.mod h1:KxycAjFnHt0DBtHmH3Jm7yHcY5sdrshPKTqM/HKAQ08=
+github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
+github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pjbgf/sha1cd v0.5.0 h1:a+UkboSi1znleCDUNT3M5YxjOnN1fz2FhN48FlwCxs0=
 github.com/pjbgf/sha1cd v0.5.0/go.mod h1:lhpGlyHLpQZoxMv8HcgXvZEhcGs0PG/vsZnEJ7H0iCM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -244,6 +260,8 @@ github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepq
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.2 h1:EDL9mgf4NzwMXCTfaxSD/o/a5fxDw/xL9nkU28JjdBg=
 github.com/skeema/knownhosts v1.3.2/go.mod h1:bEg3iQAuw+jyiw+484wwFJoKSLwcfd7fqRy+N0QTiow=
+github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
+github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -341,6 +359,7 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -392,6 +411,8 @@ k8s.io/client-go v0.35.4 h1:DN6fyaGuzK64UvnKO5fOA6ymSjvfGAnCAHAR0C66kD8=
 k8s.io/client-go v0.35.4/go.mod h1:2Pg9WpsS4NeOpoYTfHHfMxBG8zFMSAUi4O/qoiJC3nY=
 k8s.io/component-base v0.35.4 h1:6n1tNJ87johN0Hif0Fs8K2GMthsaUwMqCebUDLYyv7U=
 k8s.io/component-base v0.35.4/go.mod h1:qaDJgz5c1KYKla9occFmlJEfPpkuA55s90G509R+PeY=
+k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
+k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
 k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/kube-openapi v0.0.0-20260414162039-ec9c827d403f h1:4Qiq0YAoQATdgmHALJWz9rJ4fj20pB3xebpB4CFNhYM=


### PR DESCRIPTION
This commit adds a new test to the e2e suite that ensures that the finalizer is removed from the final pipeline when it completes, for both successful and failed managed pipelineRuns.

Assisted-By: Cursor