### PR TITLE
feat: add distributed tracing for release PipelineRuns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ syncer/                # Cross-namespace Snapshot syncing
 tekton/                # PipelineRun builders, status helpers, watch predicates
 metadata/              # Label/annotation/finalizer constants and utilities
 metrics/               # Prometheus gauges, histograms, counters for release lifecycle
+tracing/               # OpenTelemetry distributed tracing for PipelineRuns
 config/                # Kustomize manifests (CRDs, RBAC, webhooks, samples)
 main.go                # Entry point — registers controllers and webhooks
 ```

--- a/README.md
+++ b/README.md
@@ -51,3 +51,53 @@ by default, this operator exports the following custom metrics:
 | release_pre_processing_duration_seconds          | Histogram | How long in seconds a Release takes to start processing             |
 | release_validation_duration_seconds              | Histogram | How long in seconds a Release takes to validate                     |
 | release_total                                    | Counter   | Total number of releases reconciled by the operator.                |
+
+## Distributed tracing
+
+The operator emits OpenTelemetry spans for each release PipelineRun (tenant-collectors, managed-collectors, tenant, managed, final) on completion. Tracing is enabled by pointing the controller at an OTLP/gRPC collector; when the endpoint env var is unset, the operator installs a noop tracer provider and emits nothing.
+
+### Configuration
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP/gRPC collector URL. Unset disables tracing. `http://` sends spans in plaintext; `https://` uses TLS. | *(unset)* |
+| `OTEL_TRACES_SAMPLER` | `always_on`, `always_off`, `traceidratio`, `parentbased_always_off`, `parentbased_traceidratio`. | `parentbased_always_on` |
+| `OTEL_TRACES_SAMPLER_ARG` | Ratio for ratio-based samplers (e.g. `0.1`). | *(unused unless a ratio sampler is selected)* |
+| `TRACING_LABEL_ACTION` | Label key read from the `PipelineRun` or `Release` to populate `cicd.pipeline.action.name`. Empty string disables the attribute. | `delivery.tekton.dev/action` |
+| `TRACING_LABEL_APPLICATION` | Label key read from the `PipelineRun` or `Release` to populate `delivery.tekton.dev.application`. Empty string disables the attribute. | `delivery.tekton.dev/application` |
+| `TRACING_LABEL_COMPONENT` | Label key read from the `PipelineRun` or `Release` to populate `delivery.tekton.dev.component`. Empty string disables the attribute. | `delivery.tekton.dev/component` |
+
+### Emitted spans
+
+Per completed PipelineRun:
+
+- `waitDuration`: `pr.CreationTimestamp` to `pr.Status.StartTime`
+- `executeDuration`: `pr.Status.StartTime` to `pr.Status.CompletionTime`
+
+When a Release is rejected at validation and no PipelineRun is created, a single
+`waitDuration` span is emitted instead, spanning the Release's `CreationTimestamp`
+through the Validated condition's `LastTransitionTime` and carrying
+`cicd.pipeline.result=error` so the rejection still surfaces in the trace.
+
+Parenting follows the W3C Trace Context in the `tekton.dev/pipelinerunSpanContext`
+annotation. The annotation is copied forward from the Release CR onto each
+PipelineRun the controller creates, so all release-stage spans land under a
+single trace when a parent context is present upstream.
+
+### Span attributes
+
+Emitted spans may carry failure messages from PipelineRun and TaskRun conditions (`delivery.tekton.dev.result_message`). These can echo task parameters or step output; treat the OTLP collector at the same access-control level as controller logs.
+
+Span column values: `wait` = PipelineRun `waitDuration`, `execute` = PipelineRun `executeDuration`, `validation wait` = the waitDuration emitted on validation rejection.
+
+| Attribute | Span | Source |
+|---|---|---|
+| `namespace` | all | `PipelineRun` namespace (wait, execute); `Release` namespace (validation wait) |
+| `pipelinerun` | wait, execute | `PipelineRun` name |
+| `delivery.tekton.dev.pipelinerun_uid` | wait, execute | `PipelineRun` UID |
+| `release` | validation wait | `Release` name |
+| `cicd.pipeline.action.name` | all | Label on `PipelineRun` (wait, execute) or `Release` (validation wait); label key configurable via `TRACING_LABEL_ACTION` |
+| `delivery.tekton.dev.application` | all | Label on `PipelineRun` (wait, execute) or `Release` (validation wait); label key configurable via `TRACING_LABEL_APPLICATION` |
+| `delivery.tekton.dev.component` | all | Label on `PipelineRun` (wait, execute) or `Release` (validation wait); label key configurable via `TRACING_LABEL_COMPONENT` |
+| `cicd.pipeline.result` | execute, validation wait | execute: `Succeeded` condition mapped to the semconv `cicd.pipeline.result` enum (`success` / `failure` / `timeout` / `cancellation` / `error`). validation wait: always `error`. |
+| `delivery.tekton.dev.result_message` | execute, validation wait | execute: earliest failing TaskRun's `Succeeded` condition message, falling back to the PipelineRun's own condition message. validation wait: the Validated condition's message. Truncated to 1024 bytes (UTF-8 safe); omitted when empty. |

--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -422,6 +422,11 @@ func (r *Release) IsValid() bool {
 	return meta.IsStatusConditionTrue(r.Status.Conditions, validatedConditionType.String())
 }
 
+// GetValidatedCondition returns the Release's Validated condition, or nil if not present.
+func (r *Release) GetValidatedCondition() *metav1.Condition {
+	return meta.FindStatusCondition(r.Status.Conditions, validatedConditionType.String())
+}
+
 // IsFailed checks whether the Release has failed.
 func (r *Release) IsFailed() bool {
 	condition := meta.FindStatusCondition(r.Status.Conditions, releasedConditionType.String())

--- a/api/v1alpha1/release_types_test.go
+++ b/api/v1alpha1/release_types_test.go
@@ -848,6 +848,27 @@ var _ = Describe("Release type", func() {
 		})
 	})
 
+	When("GetValidatedCondition method is called", func() {
+		var release *Release
+
+		BeforeEach(func() {
+			release = &Release{}
+		})
+
+		It("should return the Validated condition when present alongside other conditions", func() {
+			conditions.SetCondition(&release.Status.Conditions, releasedConditionType, metav1.ConditionFalse, FailedReason)
+			conditions.SetCondition(&release.Status.Conditions, validatedConditionType, metav1.ConditionTrue, SucceededReason)
+			condition := release.GetValidatedCondition()
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Type).To(Equal(validatedConditionType.String()))
+		})
+
+		It("should return nil when the Validated condition is missing", func() {
+			conditions.SetCondition(&release.Status.Conditions, releasedConditionType, metav1.ConditionFalse, FailedReason)
+			Expect(release.GetValidatedCondition()).To(BeNil())
+		})
+	})
+
 	When("IsFailed method is called", func() {
 		var release *Release
 

--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -38,6 +38,7 @@ import (
 	"github.com/konflux-ci/release-service/syncer"
 	"github.com/konflux-ci/release-service/tekton"
 	"github.com/konflux-ci/release-service/tekton/utils"
+	"github.com/konflux-ci/release-service/tracing"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -734,6 +735,7 @@ func (a *adapter) EnsureReleaseExpirationTimeIsAdded() (controller.OperationResu
 // validation checks.
 func (a *adapter) EnsureReleaseIsValid() (controller.OperationResult, error) {
 	patch := client.MergeFrom(a.release.DeepCopy())
+	releaseAlreadyFinished := a.release.HasReleaseFinished()
 
 	result := controller.Validate(a.validations...)
 	if !result.Valid {
@@ -743,19 +745,24 @@ func (a *adapter) EnsureReleaseIsValid() (controller.OperationResult, error) {
 		a.release.MarkReleaseFailed("Release validation failed")
 	}
 
-	// IsReleasing will be false if MarkReleaseFailed was called
+	// IsReleasing will be false if MarkReleaseFailed was called (this or a prior reconcile).
 	if a.release.IsReleasing() {
 		a.release.MarkValidated()
 		return controller.RequeueOnErrorOrContinue(a.client.Status().Patch(a.ctx, a.release, patch))
 	}
 
+	err := a.client.Status().Patch(a.ctx, a.release, patch)
+	if err == nil && !releaseAlreadyFinished && !result.Valid {
+		a.emitValidationFailureWaitSpan()
+	}
+
 	if !a.release.AreAllProcessingPhasesFinished() {
 		a.logger.Info("EnsureReleaseIsValid: release finished but not all phases finished, continuing so we can complete properly",
 			"Release", fmt.Sprintf("%s/%s", a.release.Namespace, a.release.Name))
-		return controller.RequeueOnErrorOrContinue(a.client.Status().Patch(a.ctx, a.release, patch))
+		return controller.RequeueOnErrorOrContinue(err)
 	}
 
-	return controller.RequeueOnErrorOrStop(a.client.Status().Patch(a.ctx, a.release, patch))
+	return controller.RequeueOnErrorOrStop(err)
 }
 
 // EnsureTenantPipelineProcessingIsTracked is an operation that will ensure that the Release Tenant PipelineRun status
@@ -1173,6 +1180,7 @@ func (a *adapter) getCollectorsPipelineRunBuilder(pipelineType metadata.Pipeline
 
 	return utils.NewPipelineRunBuilder(pipelineType.String(), namespace).
 		WithAnnotations(metadata.GetAnnotationsWithPrefix(a.release, integrationgitops.PipelinesAsCodePrefix)).
+		WithAnnotations(metadata.GetAnnotationsWithPrefix(a.release, metadata.SpanContextAnnotation)).
 		WithFinalizer(metadata.ReleaseFinalizer).
 		WithLabels(map[string]string{
 			metadata.PipelinesTypeLabel:    pipelineType.String(),
@@ -1314,6 +1322,7 @@ func (a *adapter) createTenantCollectorsPipelineRun(releasePlan *v1alpha1.Releas
 func (a *adapter) createFinalPipelineRun(releasePlan *v1alpha1.ReleasePlan, snapshot *applicationapiv1alpha1.Snapshot) (*tektonv1.PipelineRun, error) {
 	builder := utils.NewPipelineRunBuilder(metadata.FinalPipelineType.String(), releasePlan.Namespace).
 		WithAnnotations(metadata.GetAnnotationsWithPrefix(a.release, integrationgitops.PipelinesAsCodePrefix)).
+		WithAnnotations(metadata.GetAnnotationsWithPrefix(a.release, metadata.SpanContextAnnotation)).
 		WithFinalizer(metadata.ReleaseFinalizer).
 		WithLabels(map[string]string{
 			metadata.ApplicationNameLabel:  releasePlan.Spec.Application,
@@ -1364,6 +1373,7 @@ func (a *adapter) createFinalPipelineRun(releasePlan *v1alpha1.ReleasePlan, snap
 func (a *adapter) createManagedPipelineRun(resources *loader.ProcessingResources, taskRunSpecs []tektonv1.PipelineTaskRunSpec, timeouts tektonv1.TimeoutFields) (*tektonv1.PipelineRun, error) {
 	builder := utils.NewPipelineRunBuilder(metadata.ManagedPipelineType.String(), resources.ReleasePlanAdmission.Namespace).
 		WithAnnotations(metadata.GetAnnotationsWithPrefix(a.release, integrationgitops.PipelinesAsCodePrefix)).
+		WithAnnotations(metadata.GetAnnotationsWithPrefix(a.release, metadata.SpanContextAnnotation)).
 		WithFinalizer(metadata.ReleaseFinalizer).
 		WithLabels(map[string]string{
 			metadata.ApplicationNameLabel:  resources.ReleasePlan.Spec.Application,
@@ -1420,6 +1430,7 @@ func (a *adapter) createManagedPipelineRun(resources *loader.ProcessingResources
 func (a *adapter) createTenantPipelineRun(releasePlan *v1alpha1.ReleasePlan, snapshot *applicationapiv1alpha1.Snapshot) (*tektonv1.PipelineRun, error) {
 	builder := utils.NewPipelineRunBuilder(metadata.TenantPipelineType.String(), releasePlan.Namespace).
 		WithAnnotations(metadata.GetAnnotationsWithPrefix(a.release, integrationgitops.PipelinesAsCodePrefix)).
+		WithAnnotations(metadata.GetAnnotationsWithPrefix(a.release, metadata.SpanContextAnnotation)).
 		WithFinalizer(metadata.ReleaseFinalizer).
 		WithLabels(map[string]string{
 			metadata.ApplicationNameLabel:  releasePlan.Spec.Application,
@@ -1911,6 +1922,49 @@ func (a *adapter) registerManagedProcessingData(releasePipelineRun *tektonv1.Pip
 	return a.client.Status().Patch(a.ctx, a.release, patch)
 }
 
+// emitValidationFailureWaitSpan emits a waitDuration span measuring how long a Release waited before rejection.
+func (a *adapter) emitValidationFailureWaitSpan() {
+	cond := a.release.GetValidatedCondition()
+	if cond == nil {
+		return
+	}
+	createdAt := a.release.CreationTimestamp.Time
+	validatedAt := cond.LastTransitionTime.Time
+	if validatedAt.IsZero() {
+		validatedAt = time.Now()
+	}
+
+	parentCtx, _ := tracing.CtxFromSpanContext(a.release.Annotations[metadata.SpanContextAnnotation])
+	if !tracing.EmitReleaseValidationFailureWait(
+		parentCtx,
+		a.release.Name, a.release.Namespace,
+		a.release.Labels,
+		createdAt, validatedAt,
+		cond.Message,
+		tracing.LoadLabelNames(),
+	) {
+		a.logger.Info("Skipped release-validation waitDuration emission", "release.Name", a.release.Name)
+	}
+}
+
+// emitTimingSpans emits timing spans for a completed PipelineRun.
+func (a *adapter) emitTimingSpans(pipelineRun *tektonv1.PipelineRun) {
+	if pipelineRun == nil {
+		return
+	}
+	spanContext := pipelineRun.Annotations[metadata.SpanContextAnnotation]
+	tracing.EmitTimingSpans(a.ctx, a.client, pipelineRun, tracing.LoadLabelNames(), spanContext)
+}
+
+// patchStatusAndEmitSpans persists the Release status and, on success, emits timing spans.
+func (a *adapter) patchStatusAndEmitSpans(patch client.Patch, pipelineRun *tektonv1.PipelineRun) error {
+	if err := a.client.Status().Patch(a.ctx, a.release, patch); err != nil {
+		return err
+	}
+	a.emitTimingSpans(pipelineRun)
+	return nil
+}
+
 // registerTenantCollectorsProcessingStatus updates the status of the Release being processed by monitoring the status of the
 // associated tenant collectors Release PipelineRun and setting the appropriate state in the Release. If the PipelineRun hasn't
 // started/succeeded, no action will be taken.
@@ -1942,7 +1996,7 @@ func (a *adapter) registerTenantCollectorsProcessingStatus(pipelineRun *tektonv1
 		a.release.MarkReleaseFailed("Release processing failed on tenant collectors pipelineRun")
 	}
 
-	return a.client.Status().Patch(a.ctx, a.release, patch)
+	return a.patchStatusAndEmitSpans(patch, pipelineRun)
 }
 
 // registerTenantProcessingStatus updates the status of the Release being processed by monitoring the status of the
@@ -1976,7 +2030,7 @@ func (a *adapter) registerTenantProcessingStatus(pipelineRun *tektonv1.PipelineR
 		a.release.MarkReleaseFailed("Release processing failed on tenant pipelineRun")
 	}
 
-	return a.client.Status().Patch(a.ctx, a.release, patch)
+	return a.patchStatusAndEmitSpans(patch, pipelineRun)
 }
 
 // registerManagedCollectorsProcessingStatus updates the status of the Release being processed by monitoring the status of the
@@ -2010,7 +2064,7 @@ func (a *adapter) registerManagedCollectorsProcessingStatus(pipelineRun *tektonv
 		a.release.MarkReleaseFailed("Release processing failed on managed collectors pipelineRun")
 	}
 
-	return a.client.Status().Patch(a.ctx, a.release, patch)
+	return a.patchStatusAndEmitSpans(patch, pipelineRun)
 }
 
 // registerManagedProcessingStatus updates the status of the Release being processed by monitoring the status of the
@@ -2063,7 +2117,7 @@ func (a *adapter) registerManagedProcessingStatus(pipelineRun *tektonv1.Pipeline
 		a.release.MarkCurrentManagedPipelineAttemptFailed(message, failureReason, failureInfo.TaskName, failureInfo.StepName, failureInfo.SuccessfulTasks)
 	}
 
-	return a.client.Status().Patch(a.ctx, a.release, patch)
+	return a.patchStatusAndEmitSpans(patch, pipelineRun)
 }
 
 // registerFinalProcessingStatus updates the status of the Release being processed by monitoring the status of the
@@ -2097,7 +2151,7 @@ func (a *adapter) registerFinalProcessingStatus(pipelineRun *tektonv1.PipelineRu
 		a.release.MarkReleaseFailed("Release processing failed on final pipelineRun")
 	}
 
-	return a.client.Status().Patch(a.ctx, a.release, patch)
+	return a.patchStatusAndEmitSpans(patch, pipelineRun)
 }
 
 // validateApplication will ensure that the same Application is used in both the Snapshot and the ReleasePlan. If the

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -37,6 +38,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/operator-lib/handler"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -88,6 +91,27 @@ func (c *createAfterNErrorClient) Create(ctx context.Context, obj ctrlclient.Obj
 		return c.createErr
 	}
 	return c.Client.Create(ctx, obj, opts...)
+}
+
+// recordingExporter captures spans in memory for assertions about what was emitted.
+type recordingExporter struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (e *recordingExporter) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.spans = append(e.spans, spans...)
+	return nil
+}
+
+func (e *recordingExporter) Shutdown(context.Context) error { return nil }
+
+func (e *recordingExporter) Spans() []sdktrace.ReadOnlySpan {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]sdktrace.ReadOnlySpan(nil), e.spans...)
 }
 
 var _ = Describe("Release adapter", Ordered, func() {
@@ -2300,8 +2324,18 @@ var _ = Describe("Release adapter", Ordered, func() {
 		})
 
 		It("should mark the release as failed if a validation fails", func() {
+			prev := otel.GetTracerProvider()
+			exporter := &recordingExporter{}
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(adapter.ctx)
+			})
+
 			adapter.validations = []controller.ValidationFunction{
 				func() *controller.ValidationResult {
+					adapter.release.MarkValidationFailed("test validation failed")
 					return &controller.ValidationResult{Valid: false}
 				},
 			}
@@ -2317,6 +2351,36 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(adapter.release.IsValid()).To(BeFalse())
 			Expect(adapter.release.HasReleaseFinished()).To(BeTrue())
+			Expect(exporter.Spans()).NotTo(BeEmpty())
+		})
+
+		It("does not re-emit the validation-failure span when the Release has already been marked failed", func() {
+			prev := otel.GetTracerProvider()
+			exporter := &recordingExporter{}
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(adapter.ctx)
+			})
+
+			adapter.validations = []controller.ValidationFunction{
+				func() *controller.ValidationResult {
+					return &controller.ValidationResult{Valid: false}
+				},
+			}
+			adapter.release.MarkValidationFailed("prior validation failure")
+			adapter.release.MarkReleaseFailed("prior failure")
+			adapter.release.MarkTenantCollectorsPipelineProcessingSkipped()
+			adapter.release.MarkManagedCollectorsPipelineProcessingSkipped()
+			adapter.release.MarkTenantPipelineProcessingSkipped()
+			adapter.release.MarkManagedPipelineProcessingSkipped()
+			adapter.release.MarkFinalPipelineProcessingSkipped()
+			Expect(adapter.client.Status().Update(adapter.ctx, adapter.release)).To(Succeed())
+
+			_, err := adapter.EnsureReleaseIsValid()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.Spans()).To(BeEmpty())
 		})
 
 		It("should not stop reconciling if not all phases are complete, but still mark release as invalid", func() {
@@ -4223,6 +4287,26 @@ var _ = Describe("Release adapter", Ordered, func() {
 			}
 			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", revision)))
 		})
+
+		It("propagates the span context annotation when present", func() {
+			adapter.release.Annotations = map[string]string{
+				metadata.SpanContextAnnotation: "{\"traceparent\":\"00-abc123-def456-01\"}",
+			}
+			newRPA := releasePlanAdmission.DeepCopy()
+			newRPA.Spec.Collectors = &v1alpha1.Collectors{
+				Items: []v1alpha1.CollectorItem{{Name: "foo", Type: "bar", Params: []v1alpha1.Param{}}},
+			}
+			tracedPipelineRun, err := adapter.createManagedCollectorsPipelineRun(newRPA)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tracedPipelineRun.GetAnnotations()).To(HaveKeyWithValue(
+				metadata.SpanContextAnnotation, "{\"traceparent\":\"00-abc123-def456-01\"}",
+			))
+			Expect(k8sClient.Delete(ctx, tracedPipelineRun)).To(Succeed())
+		})
+
+		It("does not set the span context annotation when absent", func() {
+			Expect(pipelineRun.GetAnnotations()).NotTo(HaveKey(metadata.SpanContextAnnotation))
+		})
 	})
 
 	When("createTenantCollectorsPipelineRun is called", func() {
@@ -4307,6 +4391,26 @@ var _ = Describe("Release adapter", Ordered, func() {
 				}
 			}
 			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", revision)))
+		})
+
+		It("propagates the span context annotation when present", func() {
+			adapter.release.Annotations = map[string]string{
+				metadata.SpanContextAnnotation: "{\"traceparent\":\"00-abc123-def456-01\"}",
+			}
+			newRP := releasePlan.DeepCopy()
+			newRP.Spec.Collectors = &v1alpha1.Collectors{
+				Items: []v1alpha1.CollectorItem{{Name: "foo", Type: "bar", Params: []v1alpha1.Param{}}},
+			}
+			tracedPipelineRun, err := adapter.createTenantCollectorsPipelineRun(newRP, releasePlanAdmission)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tracedPipelineRun.GetAnnotations()).To(HaveKeyWithValue(
+				metadata.SpanContextAnnotation, "{\"traceparent\":\"00-abc123-def456-01\"}",
+			))
+			Expect(k8sClient.Delete(ctx, tracedPipelineRun)).To(Succeed())
+		})
+
+		It("does not set the span context annotation when absent", func() {
+			Expect(pipelineRun.GetAnnotations()).NotTo(HaveKey(metadata.SpanContextAnnotation))
 		})
 	})
 
@@ -4487,6 +4591,22 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(emptyDirPipelineRun.Spec.Workspaces[0].EmptyDir).NotTo(BeNil())
 			Expect(emptyDirPipelineRun.Spec.Workspaces[0].VolumeClaimTemplate).To(BeNil())
 			Expect(k8sClient.Delete(ctx, emptyDirPipelineRun)).To(Succeed())
+		})
+
+		It("propagates the span context annotation when present", func() {
+			adapter.release.Annotations = map[string]string{
+				metadata.SpanContextAnnotation: "{\"traceparent\":\"00-abc123-def456-01\"}",
+			}
+			tracedPipelineRun, err := adapter.createTenantPipelineRun(newReleasePlan, snapshot)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tracedPipelineRun.GetAnnotations()).To(HaveKeyWithValue(
+				metadata.SpanContextAnnotation, "{\"traceparent\":\"00-abc123-def456-01\"}",
+			))
+			Expect(k8sClient.Delete(ctx, tracedPipelineRun)).To(Succeed())
+		})
+
+		It("does not set the span context annotation when absent", func() {
+			Expect(pipelineRun.GetAnnotations()).NotTo(HaveKey(metadata.SpanContextAnnotation))
 		})
 	})
 
@@ -4833,6 +4953,25 @@ var _ = Describe("Release adapter", Ordered, func() {
 				Expect(pipelineRun.Spec.Workspaces[0].VolumeClaimTemplate).To(BeNil())
 			})
 		})
+
+		It("propagates the span context annotation when present", func() {
+			adapter.release.Annotations = map[string]string{
+				metadata.SpanContextAnnotation: "{\"traceparent\":\"00-abc123-def456-01\"}",
+			}
+			tracedPipelineRun, err := adapter.createManagedPipelineRun(resources, resources.ReleasePlanAdmission.Spec.Pipeline.TaskRunSpecs, resources.ReleasePlanAdmission.Spec.Pipeline.Timeouts)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tracedPipelineRun.GetAnnotations()).To(HaveKeyWithValue(
+				metadata.SpanContextAnnotation, "{\"traceparent\":\"00-abc123-def456-01\"}",
+			))
+			Expect(k8sClient.Delete(ctx, tracedPipelineRun)).To(Succeed())
+		})
+
+		It("does not set the span context annotation when absent", func() {
+			plainPipelineRun, err := adapter.createManagedPipelineRun(resources, resources.ReleasePlanAdmission.Spec.Pipeline.TaskRunSpecs, resources.ReleasePlanAdmission.Spec.Pipeline.Timeouts)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(plainPipelineRun.GetAnnotations()).NotTo(HaveKey(metadata.SpanContextAnnotation))
+			Expect(k8sClient.Delete(ctx, plainPipelineRun)).To(Succeed())
+		})
 	})
 
 	When("createFinalPipelineRun is called", func() {
@@ -4952,6 +5091,22 @@ var _ = Describe("Release adapter", Ordered, func() {
 		It("has owner annotations", func() {
 			Expect(pipelineRun.GetAnnotations()[handler.NamespacedNameAnnotation]).To(ContainSubstring(adapter.release.Name))
 			Expect(pipelineRun.GetAnnotations()[handler.TypeAnnotation]).To(ContainSubstring("Release"))
+		})
+
+		It("propagates the span context annotation when present", func() {
+			adapter.release.Annotations = map[string]string{
+				metadata.SpanContextAnnotation: "{\"traceparent\":\"00-abc123-def456-01\"}",
+			}
+			tracedPipelineRun, err := adapter.createFinalPipelineRun(newReleasePlan, snapshot)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tracedPipelineRun.GetAnnotations()).To(HaveKeyWithValue(
+				metadata.SpanContextAnnotation, "{\"traceparent\":\"00-abc123-def456-01\"}",
+			))
+			Expect(k8sClient.Delete(ctx, tracedPipelineRun)).To(Succeed())
+		})
+
+		It("does not set the span context annotation when absent", func() {
+			Expect(pipelineRun.GetAnnotations()).NotTo(HaveKey(metadata.SpanContextAnnotation))
 		})
 
 		It("has release labels", func() {
@@ -5929,7 +6084,10 @@ var _ = Describe("Release adapter", Ordered, func() {
 	})
 
 	When("registerManagedCollectorsProcessingStatus is called", func() {
-		var adapter *adapter
+		var (
+			adapter  *adapter
+			exporter *recordingExporter
+		)
 
 		AfterEach(func() {
 			_ = adapter.client.Delete(ctx, adapter.release)
@@ -5937,6 +6095,14 @@ var _ = Describe("Release adapter", Ordered, func() {
 
 		BeforeEach(func() {
 			adapter = createReleaseAndAdapter()
+			prev := otel.GetTracerProvider()
+			exporter = &recordingExporter{}
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(adapter.ctx)
+			})
 		})
 
 		It("does nothing if there is no PipelineRun", func() {
@@ -5953,20 +6119,26 @@ var _ = Describe("Release adapter", Ordered, func() {
 		It("sets the Release as Managed Collectors Processed if the PipelineRun succeeded", func() {
 			pipelineRun := &tektonv1.PipelineRun{}
 			pipelineRun.Status.MarkSucceeded("", "")
+			pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 			adapter.release.MarkManagedCollectorsPipelineProcessing()
 
 			Expect(adapter.registerManagedCollectorsProcessingStatus(pipelineRun)).To(Succeed())
 			Expect(adapter.release.IsManagedCollectorsPipelineProcessedSuccessfully()).To(BeTrue())
+			Expect(exporter.Spans()).NotTo(BeEmpty())
 		})
 
 		It("sets the Release as ManagedCollectors Processing failed if the PipelineRun didn't succeed", func() {
 			pipelineRun := &tektonv1.PipelineRun{}
 			pipelineRun.Status.MarkFailed("", "")
+			pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 			adapter.release.MarkManagedCollectorsPipelineProcessing()
 
 			Expect(adapter.registerManagedCollectorsProcessingStatus(pipelineRun)).To(Succeed())
 			Expect(adapter.release.HasManagedCollectorsPipelineProcessingFinished()).To(BeTrue())
 			Expect(adapter.release.IsManagedCollectorsPipelineProcessedSuccessfully()).To(BeFalse())
+			Expect(exporter.Spans()).NotTo(BeEmpty())
 		})
 
 		It("sets the Release as failed if the PipelineRun is deleted while still running", func() {
@@ -5979,11 +6151,15 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(adapter.registerManagedCollectorsProcessingStatus(pipelineRun)).To(Succeed())
 			Expect(adapter.release.HasManagedCollectorsPipelineProcessingFinished()).To(BeTrue())
 			Expect(adapter.release.IsManagedCollectorsPipelineProcessedSuccessfully()).To(BeFalse())
+			Expect(exporter.Spans()).To(BeEmpty())
 		})
 	})
 
 	When("registerTenantCollectorsProcessingStatus is called", func() {
-		var adapter *adapter
+		var (
+			adapter  *adapter
+			exporter *recordingExporter
+		)
 
 		AfterEach(func() {
 			_ = adapter.client.Delete(ctx, adapter.release)
@@ -5991,6 +6167,14 @@ var _ = Describe("Release adapter", Ordered, func() {
 
 		BeforeEach(func() {
 			adapter = createReleaseAndAdapter()
+			prev := otel.GetTracerProvider()
+			exporter = &recordingExporter{}
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(adapter.ctx)
+			})
 		})
 
 		It("does nothing if there is no PipelineRun", func() {
@@ -6007,20 +6191,26 @@ var _ = Describe("Release adapter", Ordered, func() {
 		It("sets the Release as Tenant Collectors Processed if the PipelineRun succeeded", func() {
 			pipelineRun := &tektonv1.PipelineRun{}
 			pipelineRun.Status.MarkSucceeded("", "")
+			pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 			adapter.release.MarkTenantCollectorsPipelineProcessing()
 
 			Expect(adapter.registerTenantCollectorsProcessingStatus(pipelineRun)).To(Succeed())
 			Expect(adapter.release.IsTenantCollectorsPipelineProcessedSuccessfully()).To(BeTrue())
+			Expect(exporter.Spans()).NotTo(BeEmpty())
 		})
 
 		It("sets the Release as Tenant Collectors Processing failed if the PipelineRun didn't succeed", func() {
 			pipelineRun := &tektonv1.PipelineRun{}
 			pipelineRun.Status.MarkFailed("", "")
+			pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 			adapter.release.MarkTenantCollectorsPipelineProcessing()
 
 			Expect(adapter.registerTenantCollectorsProcessingStatus(pipelineRun)).To(Succeed())
 			Expect(adapter.release.HasTenantCollectorsPipelineProcessingFinished()).To(BeTrue())
 			Expect(adapter.release.IsTenantCollectorsPipelineProcessedSuccessfully()).To(BeFalse())
+			Expect(exporter.Spans()).NotTo(BeEmpty())
 		})
 
 		It("sets the Release as failed if the PipelineRun is deleted while still running", func() {
@@ -6033,11 +6223,15 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(adapter.registerTenantCollectorsProcessingStatus(pipelineRun)).To(Succeed())
 			Expect(adapter.release.HasTenantCollectorsPipelineProcessingFinished()).To(BeTrue())
 			Expect(adapter.release.IsTenantCollectorsPipelineProcessedSuccessfully()).To(BeFalse())
+			Expect(exporter.Spans()).To(BeEmpty())
 		})
 	})
 
 	When("registerTenantProcessingStatus is called", func() {
-		var adapter *adapter
+		var (
+			adapter  *adapter
+			exporter *recordingExporter
+		)
 
 		AfterEach(func() {
 			_ = adapter.client.Delete(ctx, adapter.release)
@@ -6045,6 +6239,14 @@ var _ = Describe("Release adapter", Ordered, func() {
 
 		BeforeEach(func() {
 			adapter = createReleaseAndAdapter()
+			prev := otel.GetTracerProvider()
+			exporter = &recordingExporter{}
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(adapter.ctx)
+			})
 		})
 
 		It("does nothing if there is no PipelineRun", func() {
@@ -6061,20 +6263,26 @@ var _ = Describe("Release adapter", Ordered, func() {
 		It("sets the Release as Tenant Processed if the PipelineRun succeeded", func() {
 			pipelineRun := &tektonv1.PipelineRun{}
 			pipelineRun.Status.MarkSucceeded("", "")
+			pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 			adapter.release.MarkTenantPipelineProcessing()
 
 			Expect(adapter.registerTenantProcessingStatus(pipelineRun)).To(Succeed())
 			Expect(adapter.release.IsTenantPipelineProcessedSuccessfully()).To(BeTrue())
+			Expect(exporter.Spans()).NotTo(BeEmpty())
 		})
 
 		It("sets the Release as Tenant Processing failed if the PipelineRun didn't succeed", func() {
 			pipelineRun := &tektonv1.PipelineRun{}
 			pipelineRun.Status.MarkFailed("", "")
+			pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 			adapter.release.MarkTenantPipelineProcessing()
 
 			Expect(adapter.registerTenantProcessingStatus(pipelineRun)).To(Succeed())
 			Expect(adapter.release.HasTenantPipelineProcessingFinished()).To(BeTrue())
 			Expect(adapter.release.IsTenantPipelineProcessedSuccessfully()).To(BeFalse())
+			Expect(exporter.Spans()).NotTo(BeEmpty())
 		})
 
 		It("sets the Release as failed if the PipelineRun is deleted while still running", func() {
@@ -6087,11 +6295,15 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(adapter.registerTenantProcessingStatus(pipelineRun)).To(Succeed())
 			Expect(adapter.release.HasTenantPipelineProcessingFinished()).To(BeTrue())
 			Expect(adapter.release.IsTenantPipelineProcessedSuccessfully()).To(BeFalse())
+			Expect(exporter.Spans()).To(BeEmpty())
 		})
 	})
 
 	When("registerManagedProcessingStatus is called", func() {
-		var adapter *adapter
+		var (
+			adapter  *adapter
+			exporter *recordingExporter
+		)
 
 		AfterEach(func() {
 			_ = adapter.client.Delete(ctx, adapter.release)
@@ -6099,6 +6311,14 @@ var _ = Describe("Release adapter", Ordered, func() {
 
 		BeforeEach(func() {
 			adapter = createReleaseAndAdapter()
+			prev := otel.GetTracerProvider()
+			exporter = &recordingExporter{}
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(adapter.ctx)
+			})
 		})
 
 		It("does nothing if there is no PipelineRun", func() {
@@ -6115,16 +6335,21 @@ var _ = Describe("Release adapter", Ordered, func() {
 		It("sets the Release as Managed Processed if the PipelineRun succeeded", func() {
 			pipelineRun := &tektonv1.PipelineRun{}
 			pipelineRun.Status.MarkSucceeded("", "")
+			pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 			adapter.release.Status.ManagedPipelineAttempts = []v1alpha1.PipelineAttempt{{PipelineRun: "default/pr"}}
 			adapter.release.MarkCurrentManagedPipelineAttemptProcessing()
 
 			Expect(adapter.registerManagedProcessingStatus(pipelineRun)).To(Succeed())
 			Expect(adapter.release.IsManagedPipelineProcessedSuccessfully()).To(BeTrue())
+			Expect(exporter.Spans()).NotTo(BeEmpty())
 		})
 
 		It("marks the attempt as failed but does not finalize the phase if the PipelineRun didn't succeed", func() {
 			pipelineRun := &tektonv1.PipelineRun{}
 			pipelineRun.Status.MarkFailed("", "")
+			pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 			adapter.release.Status.ManagedPipelineAttempts = []v1alpha1.PipelineAttempt{{PipelineRun: "default/pr"}}
 			adapter.release.MarkCurrentManagedPipelineAttemptProcessing()
 
@@ -6133,6 +6358,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(attempt.Status).To(Equal(v1alpha1.AttemptFailedReason))
 			Expect(adapter.release.HasManagedPipelineProcessingFinished()).To(BeFalse())
 			Expect(adapter.release.IsFailed()).To(BeFalse())
+			Expect(exporter.Spans()).NotTo(BeEmpty())
 		})
 
 		It("marks the attempt as failed if the PipelineRun is deleted while still running", func() {
@@ -6147,6 +6373,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 			attempt := adapter.release.GetCurrentManagedPipelineAttempt()
 			Expect(attempt.Status).To(Equal(v1alpha1.AttemptFailedReason))
 			Expect(adapter.release.HasManagedPipelineProcessingFinished()).To(BeFalse())
+			Expect(exporter.Spans()).To(BeEmpty())
 		})
 
 		It("does nothing if the current attempt is already done", func() {
@@ -6161,11 +6388,15 @@ var _ = Describe("Release adapter", Ordered, func() {
 
 			Expect(adapter.registerManagedProcessingStatus(pipelineRun)).To(Succeed())
 			Expect(adapter.release.GetCurrentManagedPipelineAttempt().Status).To(Equal(v1alpha1.AttemptSucceededReason))
+			Expect(exporter.Spans()).To(BeEmpty())
 		})
 	})
 
 	When("registerFinalProcessingStatus is called", func() {
-		var adapter *adapter
+		var (
+			adapter  *adapter
+			exporter *recordingExporter
+		)
 
 		AfterEach(func() {
 			_ = adapter.client.Delete(ctx, adapter.release)
@@ -6173,6 +6404,14 @@ var _ = Describe("Release adapter", Ordered, func() {
 
 		BeforeEach(func() {
 			adapter = createReleaseAndAdapter()
+			prev := otel.GetTracerProvider()
+			exporter = &recordingExporter{}
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(adapter.ctx)
+			})
 		})
 
 		It("does nothing if there is no PipelineRun", func() {
@@ -6189,20 +6428,26 @@ var _ = Describe("Release adapter", Ordered, func() {
 		It("sets the Release as Final Processed if the PipelineRun succeeded", func() {
 			pipelineRun := &tektonv1.PipelineRun{}
 			pipelineRun.Status.MarkSucceeded("", "")
+			pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 			adapter.release.MarkFinalPipelineProcessing()
 
 			Expect(adapter.registerFinalProcessingStatus(pipelineRun)).To(Succeed())
 			Expect(adapter.release.IsFinalPipelineProcessedSuccessfully()).To(BeTrue())
+			Expect(exporter.Spans()).NotTo(BeEmpty())
 		})
 
 		It("sets the Release as Final Processing failed if the PipelineRun didn't succeed", func() {
 			pipelineRun := &tektonv1.PipelineRun{}
 			pipelineRun.Status.MarkFailed("", "")
+			pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 			adapter.release.MarkFinalPipelineProcessing()
 
 			Expect(adapter.registerFinalProcessingStatus(pipelineRun)).To(Succeed())
 			Expect(adapter.release.HasFinalPipelineProcessingFinished()).To(BeTrue())
 			Expect(adapter.release.IsFinalPipelineProcessedSuccessfully()).To(BeFalse())
+			Expect(exporter.Spans()).NotTo(BeEmpty())
 		})
 
 		It("sets the Release as failed if the PipelineRun is deleted while still running", func() {
@@ -6215,6 +6460,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(adapter.registerFinalProcessingStatus(pipelineRun)).To(Succeed())
 			Expect(adapter.release.HasFinalPipelineProcessingFinished()).To(BeTrue())
 			Expect(adapter.release.IsFinalPipelineProcessedSuccessfully()).To(BeFalse())
+			Expect(exporter.Spans()).To(BeEmpty())
 		})
 	})
 
@@ -7310,6 +7556,180 @@ var _ = Describe("Release adapter", Ordered, func() {
 			result, err := adapter.getFailedTaskRunLogs(pipelineRun)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeEmpty())
+		})
+	})
+
+	When("emitTimingSpans is called", func() {
+		var (
+			adapter     *adapter
+			pipelineRun *tektonv1.PipelineRun
+		)
+
+		BeforeEach(func() {
+			adapter = createReleaseAndAdapter()
+			pipelineRun = &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "release-pr-",
+					Namespace:    "default",
+					Labels: map[string]string{
+						metadata.PipelinesTypeLabel: metadata.FinalPipelineType.String(),
+					},
+				},
+				Spec: tektonv1.PipelineRunSpec{
+					PipelineRef: &tektonv1.PipelineRef{Name: "release"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pipelineRun)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			_ = adapter.client.Delete(ctx, adapter.release)
+			Expect(k8sClient.Delete(ctx, pipelineRun)).To(Succeed())
+		})
+
+		It("does nothing when the PipelineRun is nil", func() {
+			adapter.emitTimingSpans(nil)
+		})
+
+		It("does not emit when the global tracer provider is the noop", func() {
+			adapter.emitTimingSpans(pipelineRun)
+		})
+
+		It("emits spans when the run has completed and a tracer provider is active", func() {
+			prev := otel.GetTracerProvider()
+			exporter := &recordingExporter{}
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(adapter.ctx)
+			})
+
+			start := time.Now().Add(-time.Minute)
+			end := time.Now()
+			pipelineRun.Status = tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					StartTime:      &metav1.Time{Time: start},
+					CompletionTime: &metav1.Time{Time: end},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, pipelineRun)).To(Succeed())
+
+			adapter.emitTimingSpans(pipelineRun)
+
+			Expect(exporter.Spans()).NotTo(BeEmpty())
+		})
+	})
+
+	When("emitValidationFailureWaitSpan is called", func() {
+		var adapter *adapter
+
+		BeforeEach(func() {
+			adapter = createReleaseAndAdapter()
+			adapter.release.Status.StartTime = &metav1.Time{Time: time.Now()}
+			adapter.release.MarkReleaseFailed("Release validation failed")
+			adapter.release.MarkValidationFailed("missing required field")
+			Expect(k8sClient.Status().Update(ctx, adapter.release)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			_ = adapter.client.Delete(ctx, adapter.release)
+		})
+
+		It("does nothing when the Validated condition is absent", func() {
+			prev := otel.GetTracerProvider()
+			exporter := &recordingExporter{}
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(adapter.ctx)
+			})
+
+			adapter.release.Status.Conditions = nil
+			Expect(k8sClient.Status().Update(ctx, adapter.release)).To(Succeed())
+
+			adapter.emitValidationFailureWaitSpan()
+
+			Expect(exporter.Spans()).To(BeEmpty())
+		})
+
+		It("does not emit when the global tracer provider is the noop", func() {
+			adapter.emitValidationFailureWaitSpan()
+		})
+
+		It("emits a span when the Validated condition is present and a tracer provider is active", func() {
+			prev := otel.GetTracerProvider()
+			exporter := &recordingExporter{}
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(adapter.ctx)
+			})
+
+			adapter.emitValidationFailureWaitSpan()
+
+			Expect(exporter.Spans()).NotTo(BeEmpty())
+		})
+	})
+
+	When("patchStatusAndEmitSpans is called", func() {
+		var (
+			adapter  *adapter
+			exporter *recordingExporter
+		)
+
+		AfterEach(func() {
+			_ = adapter.client.Delete(ctx, adapter.release)
+		})
+
+		BeforeEach(func() {
+			adapter = createReleaseAndAdapter()
+			adapter.release.MarkReleasing("")
+			Expect(k8sClient.Status().Update(ctx, adapter.release)).To(Succeed())
+			prev := otel.GetTracerProvider()
+			exporter = &recordingExporter{}
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(adapter.ctx)
+			})
+		})
+
+		It("persists the status patch and emits timing spans on success", func() {
+			patch := ctrlclient.MergeFrom(adapter.release.DeepCopy())
+			adapter.release.MarkValidated()
+
+			pipelineRun := &tektonv1.PipelineRun{}
+			pipelineRun.Status.MarkSucceeded("", "")
+			pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+
+			Expect(adapter.patchStatusAndEmitSpans(patch, pipelineRun)).To(Succeed())
+
+			fresh := &v1alpha1.Release{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: adapter.release.Namespace, Name: adapter.release.Name,
+			}, fresh)).To(Succeed())
+			Expect(fresh.IsValid()).To(BeTrue())
+			Expect(exporter.Spans()).NotTo(BeEmpty())
+		})
+
+		It("returns the patch error and skips emitting spans", func() {
+			patch := ctrlclient.MergeFrom(adapter.release.DeepCopy())
+			adapter.release.MarkValidated()
+
+			pipelineRun := &tektonv1.PipelineRun{}
+			pipelineRun.Status.MarkSucceeded("", "")
+			pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+
+			Expect(k8sClient.Delete(ctx, adapter.release)).To(Succeed())
+
+			Expect(adapter.patchStatusAndEmitSpans(patch, pipelineRun)).NotTo(Succeed())
+			Expect(exporter.Spans()).To(BeEmpty())
 		})
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,10 @@ require (
 	github.com/onsi/gomega v1.42.1
 	github.com/operator-framework/operator-lib v0.19.0
 	github.com/tektoncd/pipeline v1.13.1
+	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
+	go.opentelemetry.io/otel/sdk v1.44.0
+	go.opentelemetry.io/otel/trace v1.44.0
 	go.yaml.in/yaml/v2 v2.4.4
 	k8s.io/api v0.35.6
 	k8s.io/apimachinery v0.36.2
@@ -87,18 +91,14 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect
-	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.54.0 // indirect

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"os"
@@ -30,6 +31,7 @@ import (
 	"github.com/konflux-ci/operator-toolkit/webhook"
 	"github.com/konflux-ci/release-service/api/v1alpha1/webhooks"
 	"github.com/konflux-ci/release-service/metadata"
+	"github.com/konflux-ci/release-service/tracing"
 
 	"go.uber.org/zap/zapcore"
 
@@ -108,6 +110,18 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	tracerProvider := tracing.New()
+	tracing.SetupLabelNames()
+	// OTel pushes spans through an exporter; without this Shutdown call, in-flight spans are lost on exit.
+	// Prometheus metrics are scraped externally and need no equivalent flush.
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := tracerProvider.Shutdown(shutdownCtx); err != nil {
+			setupLog.Error(err, "failed to shutdown tracer provider")
+		}
+	}()
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will

--- a/metadata/labels.go
+++ b/metadata/labels.go
@@ -62,6 +62,12 @@ const (
 	PipelinesAsCodePrefix = "pac.test.appstudio.openshift.io"
 )
 
+// Distributed tracing annotations
+const (
+	// SpanContextAnnotation is Tekton's contract for propagating a traceparent across PipelineRun reconcilers.
+	SpanContextAnnotation = "tekton.dev/pipelinerunSpanContext"
+)
+
 // Prefixes to be used by Release Pipelines labels
 var (
 	// pipelinesLabelPrefix is the prefix of the pipelines label

--- a/tracing/suite_test.go
+++ b/tracing/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Tracing Suite")
+}

--- a/tracing/timing_spans.go
+++ b/tracing/timing_spans.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
+	"go.opentelemetry.io/otel/trace"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+// CtxFromSpanContext extracts the parent span context from a PipelineRun annotation.
+func CtxFromSpanContext(jsonCarrier string) (context.Context, bool) {
+	if jsonCarrier == "" {
+		return context.Background(), false
+	}
+	var carrier map[string]string
+	if err := json.Unmarshal([]byte(jsonCarrier), &carrier); err != nil {
+		setupLog.Info("ignoring malformed span context annotation", "error", err)
+		return context.Background(), false
+	}
+	ctx := otel.GetTextMapPropagator().Extract(context.Background(), propagation.MapCarrier(carrier))
+	sc := trace.SpanContextFromContext(ctx)
+	return ctx, sc.IsValid()
+}
+
+// setCommonAttributes sets the span attributes that identify a PipelineRun.
+func setCommonAttributes(span trace.Span, pr *tektonv1.PipelineRun, labels LabelNames) {
+	span.SetAttributes(
+		NamespaceKey.String(pr.Namespace),
+		PipelineRunKey.String(pr.Name),
+		DeliveryPipelineRunUIDKey.String(string(pr.UID)),
+	)
+	prLabels := pr.GetLabels()
+	for _, m := range []struct {
+		labelName string
+		key       attribute.Key
+	}{
+		{labels.Action, semconv.CICDPipelineActionNameKey},
+		{labels.Application, DeliveryApplicationKey},
+		{labels.Component, DeliveryComponentKey},
+	} {
+		if m.labelName == "" {
+			continue
+		}
+		if v := prLabels[m.labelName]; v != "" {
+			span.SetAttributes(m.key.String(v))
+		}
+	}
+}
+
+// setOutcomeAttributes records the PipelineRun's terminal status on a timing span.
+func setOutcomeAttributes(span trace.Span, pr *tektonv1.PipelineRun, failureMsg string) {
+	cond := pr.Status.GetCondition(apis.ConditionSucceeded)
+	if cond == nil {
+		return
+	}
+	span.SetAttributes(ResultEnum(cond))
+	if cond.Status == corev1.ConditionFalse {
+		msg := failureMsg
+		if msg == "" {
+			msg = cond.Message
+		}
+		if msg != "" {
+			span.SetAttributes(DeliveryResultMessageKey.String(TruncateResultMessage(msg)))
+		}
+	}
+}
+
+// EmitWaitDuration records the time between a PipelineRun's creation and start.
+func EmitWaitDuration(ctx context.Context, pr *tektonv1.PipelineRun, labels LabelNames) {
+	if pr.Status.StartTime == nil {
+		return
+	}
+	start := pr.CreationTimestamp.Time
+	end := pr.Status.StartTime.Time
+	if end.Before(start) {
+		return
+	}
+
+	tr := otel.Tracer(TracerName)
+	_, span := tr.Start(ctx, SpanWaitDuration, trace.WithTimestamp(start))
+
+	setCommonAttributes(span, pr, labels)
+	span.End(trace.WithTimestamp(end))
+}
+
+// EmitExecuteDuration records the time between a PipelineRun's start and completion, plus its result and failure message.
+func EmitExecuteDuration(ctx context.Context, pr *tektonv1.PipelineRun, labels LabelNames, failureMsg string) {
+	if pr.Status.StartTime == nil || pr.Status.CompletionTime == nil {
+		return
+	}
+	start := pr.Status.StartTime.Time
+	end := pr.Status.CompletionTime.Time
+	if end.Before(start) {
+		return
+	}
+
+	tr := otel.Tracer(TracerName)
+	_, span := tr.Start(ctx, SpanExecuteDuration, trace.WithTimestamp(start))
+
+	setCommonAttributes(span, pr, labels)
+	setOutcomeAttributes(span, pr, failureMsg)
+	span.End(trace.WithTimestamp(end))
+}
+
+// EmitReleaseValidationFailureWait records the time between a Release's creation and validation rejection, plus its result and failure message.
+func EmitReleaseValidationFailureWait(
+	parentCtx context.Context,
+	releaseName, releaseNamespace string,
+	releaseLabels map[string]string,
+	createdAt, validatedAt time.Time,
+	validationMessage string,
+	labels LabelNames,
+) bool {
+	if !sdkTracerProviderActive() {
+		return false
+	}
+	if validatedAt.Before(createdAt) {
+		return false
+	}
+
+	tr := otel.Tracer(TracerName)
+	_, span := tr.Start(parentCtx, SpanWaitDuration, trace.WithTimestamp(createdAt))
+
+	span.SetAttributes(
+		NamespaceKey.String(releaseNamespace),
+		ReleaseKey.String(releaseName),
+	)
+	for _, m := range []struct {
+		labelName string
+		key       attribute.Key
+	}{
+		{labels.Action, semconv.CICDPipelineActionNameKey},
+		{labels.Application, DeliveryApplicationKey},
+		{labels.Component, DeliveryComponentKey},
+	} {
+		if m.labelName == "" {
+			continue
+		}
+		if v := releaseLabels[m.labelName]; v != "" {
+			span.SetAttributes(m.key.String(v))
+		}
+	}
+
+	span.SetAttributes(semconv.CICDPipelineResultError)
+	if validationMessage != "" {
+		span.SetAttributes(DeliveryResultMessageKey.String(TruncateResultMessage(validationMessage)))
+	}
+
+	span.End(trace.WithTimestamp(validatedAt))
+	return true
+}
+
+// EmitTimingSpans emits the timing spans for a PipelineRun.
+func EmitTimingSpans(ctx context.Context, c client.Client, pr *tektonv1.PipelineRun, labels LabelNames, spanContext string) bool {
+	if !sdkTracerProviderActive() {
+		return false
+	}
+
+	parentCtx, ok := CtxFromSpanContext(spanContext)
+	if !ok {
+		parentCtx = context.Background()
+	}
+
+	if pr.Status.StartTime == nil || pr.Status.CompletionTime == nil {
+		return false
+	}
+
+	EmitWaitDuration(parentCtx, pr, labels)
+	EmitExecuteDuration(parentCtx, pr, labels, resolveFailureMessage(ctx, c, pr))
+
+	return true
+}
+
+// resolveFailureMessage returns the failure detail for a failed PipelineRun.
+func resolveFailureMessage(ctx context.Context, c client.Client, pr *tektonv1.PipelineRun) string {
+	cond := pr.Status.GetCondition(apis.ConditionSucceeded)
+	if cond == nil || cond.Status != corev1.ConditionFalse {
+		return ""
+	}
+	if msg := EarliestFailingTaskRunMessage(ctx, c, pr); msg != "" {
+		return msg
+	}
+	return cond.Message
+}

--- a/tracing/timing_spans_test.go
+++ b/tracing/timing_spans_test.go
@@ -1,0 +1,625 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
+	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+func makeCompletedPR(status corev1.ConditionStatus, reason, message string) *tektonv1.PipelineRun {
+	start := time.Now().Add(-time.Minute)
+	completion := time.Now()
+	return &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "rel-pr",
+			Namespace:         "trace-demo-managed",
+			CreationTimestamp: metav1.NewTime(start.Add(-30 * time.Second)),
+		},
+		Status: tektonv1.PipelineRunStatus{
+			PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+				StartTime:      &metav1.Time{Time: start},
+				CompletionTime: &metav1.Time{Time: completion},
+			},
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:    apis.ConditionSucceeded,
+					Status:  status,
+					Reason:  reason,
+					Message: message,
+				}},
+			},
+		},
+	}
+}
+
+var _ = Describe("EmitWaitDuration", func() {
+	It("emits identity and label-driven attributes", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		creation := time.Now().Add(-time.Minute)
+		start := time.Now()
+		pr := &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "rel-pr",
+				Namespace:         "trace-demo-managed",
+				UID:               types.UID("uid-abc"),
+				CreationTimestamp: metav1.NewTime(creation),
+				Labels: map[string]string{
+					DefaultTracingLabelAction:      "release",
+					DefaultTracingLabelApplication: "my-app",
+					DefaultTracingLabelComponent:   "my-comp",
+				},
+			},
+			Status: tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					StartTime: &metav1.Time{Time: start},
+				},
+			},
+		}
+		EmitWaitDuration(context.Background(), pr, defaultLabels())
+
+		spans := exp.GetSpans()
+		Expect(spans).To(HaveLen(1))
+		s := spans[0]
+		Expect(spanAttr(s, string(NamespaceKey))).To(Equal("trace-demo-managed"))
+		Expect(spanAttr(s, string(PipelineRunKey))).To(Equal("rel-pr"))
+		Expect(spanAttr(s, string(DeliveryPipelineRunUIDKey))).To(Equal("uid-abc"))
+		Expect(spanAttr(s, string(semconv.CICDPipelineActionNameKey))).To(Equal("release"))
+		Expect(spanAttr(s, string(DeliveryApplicationKey))).To(Equal("my-app"))
+		Expect(spanAttr(s, string(DeliveryComponentKey))).To(Equal("my-comp"))
+	})
+
+	It("omits label-driven attributes when the labels are absent on the PipelineRun", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		pr := &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute))},
+			Status: tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					StartTime: &metav1.Time{Time: time.Now()},
+				},
+			},
+		}
+		EmitWaitDuration(context.Background(), pr, defaultLabels())
+
+		s := exp.GetSpans()[0]
+		Expect(hasAttr(s, string(semconv.CICDPipelineActionNameKey))).To(BeFalse())
+		Expect(hasAttr(s, string(DeliveryApplicationKey))).To(BeFalse())
+		Expect(hasAttr(s, string(DeliveryComponentKey))).To(BeFalse())
+	})
+
+	It("treats an empty configured label name as disabling that attribute", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		partial := LabelNames{
+			Action:      "",
+			Application: DefaultTracingLabelApplication,
+			Component:   DefaultTracingLabelComponent,
+		}
+		pr := &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute)),
+				Labels: map[string]string{
+					DefaultTracingLabelAction:      "should-not-be-emitted",
+					DefaultTracingLabelApplication: "present-app",
+				},
+			},
+			Status: tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					StartTime: &metav1.Time{Time: time.Now()},
+				},
+			},
+		}
+		EmitWaitDuration(context.Background(), pr, partial)
+
+		s := exp.GetSpans()[0]
+		Expect(hasAttr(s, string(semconv.CICDPipelineActionNameKey))).To(BeFalse())
+		Expect(spanAttr(s, string(DeliveryApplicationKey))).To(Equal("present-app"))
+	})
+})
+
+var _ = Describe("EmitExecuteDuration outcome attributes", func() {
+	DescribeTable("maps the Succeeded condition to cicd.pipeline.result and result_message",
+		func(status corev1.ConditionStatus, reason, message, failureMsg, wantResult, wantMessage string, expectMsg bool) {
+			exp, tp := newTracerProvider()
+			DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+			pr := makeCompletedPR(status, reason, message)
+			EmitExecuteDuration(context.Background(), pr, defaultLabels(), failureMsg)
+
+			s := exp.GetSpans()[0]
+			Expect(spanAttr(s, string(semconv.CICDPipelineResultKey))).To(Equal(wantResult))
+			if expectMsg {
+				Expect(spanAttr(s, string(DeliveryResultMessageKey))).To(Equal(wantMessage))
+			} else {
+				Expect(hasAttr(s, string(DeliveryResultMessageKey))).To(BeFalse())
+			}
+		},
+		Entry("success omits result_message",
+			corev1.ConditionTrue, tektonv1.PipelineRunReasonSuccessful.String(),
+			"All steps completed", "",
+			semconv.CICDPipelineResultSuccess.Value.AsString(), "", false),
+		Entry("failure with walker-supplied message",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonFailed.String(),
+			"pr-level fallback", "failing-taskrun exit 1",
+			semconv.CICDPipelineResultFailure.Value.AsString(), "failing-taskrun exit 1", true),
+		Entry("failure without a walker message falls back to the PipelineRun condition message",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonFailedValidation.String(),
+			"validation failed", "",
+			semconv.CICDPipelineResultError.Value.AsString(), "validation failed", true),
+		Entry("timeout maps correctly",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonTimedOut.String(), "", "",
+			semconv.CICDPipelineResultTimeout.Value.AsString(), "", false),
+		Entry("cancelled maps correctly",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonCancelled.String(), "", "",
+			semconv.CICDPipelineResultCancellation.Value.AsString(), "", false),
+	)
+
+	It("truncates an overlong failure message", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		pr := makeCompletedPR(corev1.ConditionFalse, tektonv1.PipelineRunReasonFailed.String(), "")
+		long := strings.Repeat("x", MaxResultMessageLen*2)
+		EmitExecuteDuration(context.Background(), pr, defaultLabels(), long)
+
+		got := spanAttr(exp.GetSpans()[0], string(DeliveryResultMessageKey))
+		Expect(len(got)).To(BeNumerically("<=", MaxResultMessageLen))
+		Expect(got).To(HaveSuffix(TruncatedSuffix))
+	})
+
+	It("emits no result attribute when the Succeeded condition is missing", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		pr := makeCompletedPR(corev1.ConditionTrue, "", "")
+		pr.Status.Conditions = duckv1.Conditions{}
+		EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+
+		s := exp.GetSpans()[0]
+		Expect(hasAttr(s, string(semconv.CICDPipelineResultKey))).To(BeFalse())
+		Expect(hasAttr(s, string(DeliveryResultMessageKey))).To(BeFalse())
+	})
+})
+
+var _ = Describe("EmitWaitDuration negative paths", func() {
+	It("emits no span when StartTime is unset", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		pr := &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute))},
+		}
+		EmitWaitDuration(context.Background(), pr, defaultLabels())
+		Expect(exp.GetSpans()).To(BeEmpty())
+	})
+
+	It("emits no span when StartTime is before CreationTimestamp (clock skew)", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		now := time.Now()
+		pr := &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(now)},
+			Status: tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					StartTime: &metav1.Time{Time: now.Add(-time.Second)},
+				},
+			},
+		}
+		EmitWaitDuration(context.Background(), pr, defaultLabels())
+		Expect(exp.GetSpans()).To(BeEmpty())
+	})
+})
+
+var _ = Describe("EmitExecuteDuration negative paths", func() {
+	It("emits no span when StartTime is unset", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		now := time.Now()
+		pr := &tektonv1.PipelineRun{
+			Status: tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					CompletionTime: &metav1.Time{Time: now},
+				},
+			},
+		}
+		EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+		Expect(exp.GetSpans()).To(BeEmpty())
+	})
+
+	It("emits no span when CompletionTime is unset", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		now := time.Now()
+		pr := &tektonv1.PipelineRun{
+			Status: tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					StartTime: &metav1.Time{Time: now.Add(-time.Minute)},
+				},
+			},
+		}
+		EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+		Expect(exp.GetSpans()).To(BeEmpty())
+	})
+
+	It("emits no span when CompletionTime is before StartTime (clock skew)", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		now := time.Now()
+		pr := &tektonv1.PipelineRun{
+			Status: tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					StartTime:      &metav1.Time{Time: now},
+					CompletionTime: &metav1.Time{Time: now.Add(-time.Second)},
+				},
+			},
+		}
+		EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+		Expect(exp.GetSpans()).To(BeEmpty())
+	})
+})
+
+var _ = Describe("CtxFromSpanContext", func() {
+	It("returns a fresh Background context with ok=false for an empty carrier", func() {
+		ctx, ok := CtxFromSpanContext("")
+		Expect(ok).To(BeFalse())
+		Expect(trace.SpanContextFromContext(ctx).IsValid()).To(BeFalse())
+	})
+
+	It("returns Background with ok=false when the carrier JSON is malformed", func() {
+		ctx, ok := CtxFromSpanContext("{not-json")
+		Expect(ok).To(BeFalse())
+		Expect(trace.SpanContextFromContext(ctx).IsValid()).To(BeFalse())
+	})
+
+	It("returns ok=false when the JSON is valid but carries no traceparent", func() {
+		ctx, ok := CtxFromSpanContext(`{"unrelated":"value"}`)
+		Expect(ok).To(BeFalse())
+		Expect(trace.SpanContextFromContext(ctx).IsValid()).To(BeFalse())
+	})
+
+	It("round-trips a real W3C trace context with the same TraceID and SpanID", func() {
+		_, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		parentCtx, parentSpan := otel.Tracer("test").Start(context.Background(), "parent")
+		defer parentSpan.End()
+		want := parentSpan.SpanContext()
+
+		carrier := propagation.MapCarrier{}
+		otel.GetTextMapPropagator().Inject(parentCtx, carrier)
+		encoded, err := json.Marshal(map[string]string(carrier))
+		Expect(err).NotTo(HaveOccurred())
+
+		got, ok := CtxFromSpanContext(string(encoded))
+		Expect(ok).To(BeTrue())
+		gotSC := trace.SpanContextFromContext(got)
+		Expect(gotSC.TraceID()).To(Equal(want.TraceID()))
+		Expect(gotSC.SpanID()).To(Equal(want.SpanID()))
+		Expect(gotSC.IsRemote()).To(BeTrue())
+	})
+})
+
+var _ = Describe("resolveFailureMessage", func() {
+	now := time.Now()
+	mkPR := func(status corev1.ConditionStatus, message string, children ...string) *tektonv1.PipelineRun {
+		pr := &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "rel-pr", Namespace: "ns"}}
+		pr.Status.Conditions = duckv1.Conditions{{
+			Type:    apis.ConditionSucceeded,
+			Status:  status,
+			Message: message,
+		}}
+		for _, n := range children {
+			pr.Status.ChildReferences = append(pr.Status.ChildReferences, tektonv1.ChildStatusReference{Name: n})
+		}
+		return pr
+	}
+	mkFailingTR := func(name, message string) *tektonv1.TaskRun {
+		tr := &tektonv1.TaskRun{ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "ns",
+			Labels:    map[string]string{"tekton.dev/pipelineRun": "rel-pr"},
+		}}
+		tr.Status.CompletionTime = &metav1.Time{Time: now}
+		tr.Status.Conditions = duckv1.Conditions{{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Message: message,
+		}}
+		return tr
+	}
+
+	It("returns empty when the Succeeded condition is missing", func() {
+		pr := &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Namespace: "ns"}}
+		Expect(resolveFailureMessage(context.Background(), newFakeClient(), pr)).To(Equal(""))
+	})
+
+	It("returns empty when the PipelineRun succeeded", func() {
+		pr := mkPR(corev1.ConditionTrue, "all good")
+		Expect(resolveFailureMessage(context.Background(), newFakeClient(), pr)).To(Equal(""))
+	})
+
+	It("prefers the failing TaskRun message over the PipelineRun condition message", func() {
+		pr := mkPR(corev1.ConditionFalse, "pr-level fallback", "tr-fail")
+		c := newFakeClient(mkFailingTR("tr-fail", "taskrun-level reason"))
+		Expect(resolveFailureMessage(context.Background(), c, pr)).To(Equal("taskrun-level reason"))
+	})
+
+	It("falls back to the PipelineRun condition message when no TaskRun message is available", func() {
+		pr := mkPR(corev1.ConditionFalse, "pr-level only", "tr-missing")
+		Expect(resolveFailureMessage(context.Background(), newFakeClient(), pr)).To(Equal("pr-level only"))
+	})
+})
+
+var _ = Describe("EmitTimingSpans", func() {
+	makeRunningPR := func() *tektonv1.PipelineRun {
+		creation := time.Now().Add(-2 * time.Minute)
+		start := time.Now().Add(-time.Minute)
+		return &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "rel-pr",
+				Namespace:         "ns",
+				UID:               types.UID("uid-running"),
+				CreationTimestamp: metav1.NewTime(creation),
+			},
+			Status: tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					StartTime: &metav1.Time{Time: start},
+				},
+			},
+		}
+	}
+
+	It("returns false and emits nothing when the global TracerProvider is the noop", func() {
+		prev := otel.GetTracerProvider()
+		otel.SetTracerProvider(tracenoop.NewTracerProvider())
+		DeferCleanup(func() { otel.SetTracerProvider(prev) })
+
+		ok := EmitTimingSpans(context.Background(), newFakeClient(), makeCompletedPR(corev1.ConditionTrue, "", ""), defaultLabels(), "")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns false when the PipelineRun has not started yet", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		pr := &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "rel-pr",
+				Namespace:         "ns",
+				CreationTimestamp: metav1.NewTime(time.Now()),
+			},
+		}
+		Expect(EmitTimingSpans(context.Background(), newFakeClient(), pr, defaultLabels(), "")).To(BeFalse())
+		Expect(exp.GetSpans()).To(BeEmpty())
+	})
+
+	It("does not emit while the PipelineRun is still running", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		Expect(EmitTimingSpans(context.Background(), newFakeClient(), makeRunningPR(), defaultLabels(), "")).To(BeFalse())
+		Expect(exp.GetSpans()).To(BeEmpty())
+	})
+
+	It("emits both waitDuration and executeDuration when the PipelineRun has completed", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		pr := makeCompletedPR(corev1.ConditionTrue, tektonv1.PipelineRunReasonSuccessful.String(), "ok")
+		Expect(EmitTimingSpans(context.Background(), newFakeClient(), pr, defaultLabels(), "")).To(BeTrue())
+
+		names := []string{}
+		for _, s := range exp.GetSpans() {
+			names = append(names, s.Name())
+		}
+		Expect(names).To(ConsistOf(SpanWaitDuration, SpanExecuteDuration))
+	})
+
+	It("parents the emitted spans under a valid injected trace context", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		parentCtx, parentSpan := otel.Tracer("upstream").Start(context.Background(), "parent")
+		want := parentSpan.SpanContext().TraceID()
+		parentSpan.End()
+
+		carrier := propagation.MapCarrier{}
+		otel.GetTextMapPropagator().Inject(parentCtx, carrier)
+		encoded, err := json.Marshal(map[string]string(carrier))
+		Expect(err).NotTo(HaveOccurred())
+
+		pr := makeCompletedPR(corev1.ConditionTrue, tektonv1.PipelineRunReasonSuccessful.String(), "ok")
+		Expect(EmitTimingSpans(context.Background(), newFakeClient(), pr, defaultLabels(), string(encoded))).To(BeTrue())
+
+		emitted := []string{}
+		for _, s := range exp.GetSpans() {
+			if s.Name() == SpanWaitDuration || s.Name() == SpanExecuteDuration {
+				emitted = append(emitted, s.Name())
+				Expect(s.Parent().TraceID()).To(Equal(want),
+					"timing span %q should be parented under the injected trace", s.Name())
+			}
+		}
+		Expect(emitted).To(ConsistOf(SpanWaitDuration, SpanExecuteDuration))
+	})
+
+	It("falls back to a root trace when the carrier annotation is malformed", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		pr := makeCompletedPR(corev1.ConditionTrue, tektonv1.PipelineRunReasonSuccessful.String(), "ok")
+		Expect(EmitTimingSpans(context.Background(), newFakeClient(), pr, defaultLabels(), "{not-json")).To(BeTrue())
+
+		for _, s := range exp.GetSpans() {
+			Expect(s.Parent().IsValid()).To(BeFalse(),
+				"span %q should be a root span when the injected carrier is unusable", s.Name())
+		}
+	})
+
+	It("threads the failing-TaskRun message into executeDuration's result_message", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		pr := makeCompletedPR(corev1.ConditionFalse, tektonv1.PipelineRunReasonFailed.String(), "pr-level fallback")
+		pr.Status.ChildReferences = []tektonv1.ChildStatusReference{{Name: "tr-fail"}}
+
+		failingTR := &tektonv1.TaskRun{ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr-fail",
+			Namespace: pr.Namespace,
+			Labels:    map[string]string{"tekton.dev/pipelineRun": pr.Name},
+		}}
+		failingTR.Status.CompletionTime = pr.Status.CompletionTime
+		failingTR.Status.Conditions = duckv1.Conditions{{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Message: "taskrun-level reason",
+		}}
+
+		Expect(EmitTimingSpans(context.Background(), newFakeClient(failingTR), pr, defaultLabels(), "")).To(BeTrue())
+
+		var execute trace.SpanContext
+		var resultMessage string
+		for _, s := range exp.GetSpans() {
+			if s.Name() == SpanExecuteDuration {
+				execute = s.SpanContext()
+				resultMessage = spanAttr(s, string(DeliveryResultMessageKey))
+			}
+		}
+		Expect(execute.IsValid()).To(BeTrue(), "executeDuration span should have been emitted")
+		Expect(resultMessage).To(Equal("taskrun-level reason"))
+	})
+})
+
+var _ = Describe("EmitReleaseValidationFailureWait", func() {
+	var (
+		createdAt   = time.Now().Add(-time.Minute)
+		validatedAt = time.Now()
+		labels      = defaultLabels()
+	)
+
+	It("returns false and emits nothing when the global TracerProvider is the noop", func() {
+		otel.SetTracerProvider(tracenoop.NewTracerProvider())
+		Expect(EmitReleaseValidationFailureWait(
+			context.Background(),
+			"rel", "ns", nil,
+			createdAt, validatedAt,
+			"validation failed",
+			labels,
+		)).To(BeFalse())
+	})
+
+	It("returns false when validatedAt precedes createdAt", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		Expect(EmitReleaseValidationFailureWait(
+			context.Background(),
+			"rel", "ns", nil,
+			validatedAt, createdAt,
+			"validation failed",
+			labels,
+		)).To(BeFalse())
+		Expect(exp.GetSpans()).To(BeEmpty())
+	})
+
+	It("emits a waitDuration span carrying cicd.pipeline.result=error and result_message", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		Expect(EmitReleaseValidationFailureWait(
+			context.Background(),
+			"rel-pr", "trace-demo-managed",
+			map[string]string{
+				DefaultTracingLabelApplication: "my-app",
+				DefaultTracingLabelComponent:   "my-comp",
+			},
+			createdAt, validatedAt,
+			"missing required author label",
+			labels,
+		)).To(BeTrue())
+
+		spans := exp.GetSpans()
+		Expect(spans).To(HaveLen(1))
+		s := spans[0]
+		Expect(s.Name()).To(Equal(SpanWaitDuration))
+		Expect(s.StartTime()).To(BeTemporally("~", createdAt, time.Second))
+		Expect(s.EndTime()).To(BeTemporally("~", validatedAt, time.Second))
+		Expect(spanAttr(s, string(NamespaceKey))).To(Equal("trace-demo-managed"))
+		Expect(spanAttr(s, string(ReleaseKey))).To(Equal("rel-pr"))
+		Expect(spanAttr(s, string(semconv.CICDPipelineResultKey))).To(Equal(semconv.CICDPipelineResultError.Value.AsString()))
+		Expect(spanAttr(s, string(DeliveryResultMessageKey))).To(Equal("missing required author label"))
+		Expect(spanAttr(s, string(DeliveryApplicationKey))).To(Equal("my-app"))
+		Expect(spanAttr(s, string(DeliveryComponentKey))).To(Equal("my-comp"))
+	})
+
+	It("omits result_message when the supplied message is empty", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		Expect(EmitReleaseValidationFailureWait(
+			context.Background(),
+			"rel", "ns", nil,
+			createdAt, validatedAt,
+			"",
+			labels,
+		)).To(BeTrue())
+		s := exp.GetSpans()[0]
+		Expect(hasAttr(s, string(DeliveryResultMessageKey))).To(BeFalse())
+	})
+
+	It("truncates an overlong result message", func() {
+		exp, tp := newTracerProvider()
+		DeferCleanup(func() error { return tp.Shutdown(context.Background()) })
+
+		long := strings.Repeat("x", MaxResultMessageLen*2)
+		Expect(EmitReleaseValidationFailureWait(
+			context.Background(),
+			"rel", "ns", nil,
+			createdAt, validatedAt,
+			long,
+			labels,
+		)).To(BeTrue())
+		emitted := spanAttr(exp.GetSpans()[0], string(DeliveryResultMessageKey))
+		Expect(len(emitted)).To(BeNumerically("<=", MaxResultMessageLen))
+		Expect(emitted).To(HaveSuffix(TruncatedSuffix))
+	})
+})

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"unicode/utf8"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
+	"go.opentelemetry.io/otel/trace/noop"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Tracing configuration
+const (
+	TracerName      = "release-service"
+	EnvOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
+	EnvTracesSampler    = "OTEL_TRACES_SAMPLER"
+	EnvTracesSamplerArg = "OTEL_TRACES_SAMPLER_ARG"
+
+	EnvTracingLabelAction      = "TRACING_LABEL_ACTION"
+	EnvTracingLabelApplication = "TRACING_LABEL_APPLICATION"
+	EnvTracingLabelComponent   = "TRACING_LABEL_COMPONENT"
+)
+
+const AttrNamespace = "delivery.tekton.dev"
+
+// Span names
+const (
+	SpanWaitDuration    = "waitDuration"
+	SpanExecuteDuration = "executeDuration"
+)
+
+// MaxResultMessageLen caps delivery.tekton.dev.result_message to fit typical tracing-backend limits.
+const MaxResultMessageLen = 1024
+
+const TruncatedSuffix = "...[truncated]"
+
+var (
+	DefaultTracingLabelAction      = AttrNamespace + "/action"
+	DefaultTracingLabelApplication = AttrNamespace + "/application"
+	DefaultTracingLabelComponent   = AttrNamespace + "/component"
+)
+
+var (
+	NamespaceKey   = attribute.Key("namespace")
+	PipelineRunKey = attribute.Key("pipelinerun")
+	ReleaseKey     = attribute.Key("release")
+
+	DeliveryPipelineRunUIDKey = attribute.Key(AttrNamespace + ".pipelinerun_uid")
+	DeliveryApplicationKey    = attribute.Key(AttrNamespace + ".application")
+	DeliveryComponentKey      = attribute.Key(AttrNamespace + ".component")
+	DeliveryResultMessageKey  = attribute.Key(AttrNamespace + ".result_message")
+)
+
+// ResultEnum returns the cicd.pipeline.result span attribute matching the PipelineRun's terminal condition.
+func ResultEnum(cond *apis.Condition) attribute.KeyValue {
+	if cond == nil {
+		return semconv.CICDPipelineResultError
+	}
+	if cond.Status == corev1.ConditionTrue {
+		return semconv.CICDPipelineResultSuccess
+	}
+	switch cond.Reason {
+	case tektonv1.PipelineRunReasonCancelled.String(),
+		tektonv1.PipelineRunReasonCancelledRunningFinally.String(),
+		tektonv1.PipelineRunReasonStoppedRunningFinally.String():
+		return semconv.CICDPipelineResultCancellation
+	case tektonv1.PipelineRunReasonTimedOut.String():
+		return semconv.CICDPipelineResultTimeout
+	case tektonv1.PipelineRunReasonFailed.String():
+		return semconv.CICDPipelineResultFailure
+	}
+	return semconv.CICDPipelineResultError
+}
+
+// TruncateResultMessage caps msg at MaxResultMessageLen to fit within span attribute size limits.
+func TruncateResultMessage(msg string) string {
+	if len(msg) <= MaxResultMessageLen {
+		return msg
+	}
+	keep := MaxResultMessageLen - len(TruncatedSuffix)
+	if keep < 0 {
+		keep = 0
+	}
+	head := msg[:keep]
+	for len(head) > 0 {
+		r, size := utf8.DecodeLastRuneInString(head)
+		if r != utf8.RuneError || size > 1 {
+			break
+		}
+		head = head[:len(head)-size]
+	}
+	return head + TruncatedSuffix
+}
+
+type LabelNames struct {
+	Action      string
+	Application string
+	Component   string
+}
+
+var labelNames LabelNames
+
+// SetupLabelNames populates the cached label config from env.
+func SetupLabelNames() {
+	labelNames = LabelNames{
+		Action:      envOr(EnvTracingLabelAction, DefaultTracingLabelAction),
+		Application: envOr(EnvTracingLabelApplication, DefaultTracingLabelApplication),
+		Component:   envOr(EnvTracingLabelComponent, DefaultTracingLabelComponent),
+	}
+}
+
+// LoadLabelNames returns the cached label config populated by SetupLabelNames.
+func LoadLabelNames() LabelNames { return labelNames }
+
+func envOr(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return fallback
+}
+
+// samplerFromEnv returns the OTel sampler corresponding to env config.
+func samplerFromEnv() sdktrace.Sampler {
+	name := os.Getenv(EnvTracesSampler)
+	argStr := os.Getenv(EnvTracesSamplerArg)
+	arg, err := strconv.ParseFloat(argStr, 64)
+	if err != nil && argStr != "" {
+		setupLog.Error(err, "ignoring malformed sampler argument", "env", EnvTracesSamplerArg, "value", argStr)
+	}
+	if argStr == "" && (name == "traceidratio" || name == "parentbased_traceidratio") {
+		setupLog.Info("ratio sampler selected without "+EnvTracesSamplerArg+"; defaulting to 0% sampling", "env", EnvTracesSampler, "value", name)
+	}
+	switch name {
+	case "always_on":
+		return sdktrace.AlwaysSample()
+	case "always_off":
+		return sdktrace.NeverSample()
+	case "traceidratio":
+		return sdktrace.TraceIDRatioBased(arg)
+	case "parentbased_always_off":
+		return sdktrace.ParentBased(sdktrace.NeverSample())
+	case "parentbased_traceidratio":
+		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(arg))
+	}
+	return sdktrace.ParentBased(sdktrace.AlwaysSample())
+}
+
+// EarliestFailingTaskRunMessage returns the failure message from the earliest-completed failing TaskRun of a PipelineRun.
+func EarliestFailingTaskRunMessage(ctx context.Context, c client.Client, pr *tektonv1.PipelineRun) string {
+	trList := &tektonv1.TaskRunList{}
+	if err := c.List(ctx, trList,
+		client.InNamespace(pr.Namespace),
+		client.MatchingLabels{"tekton.dev/pipelineRun": pr.Name}); err != nil {
+		return ""
+	}
+	var (
+		earliestTime *metav1.Time
+		earliestMsg  string
+	)
+	for i := range trList.Items {
+		tr := &trList.Items[i]
+		if tr.Status.CompletionTime == nil {
+			continue
+		}
+		cond := tr.Status.GetCondition(apis.ConditionSucceeded)
+		if cond == nil || cond.Status != corev1.ConditionFalse {
+			continue
+		}
+		if earliestTime == nil || tr.Status.CompletionTime.Before(earliestTime) {
+			earliestTime = tr.Status.CompletionTime
+			earliestMsg = cond.Message
+		}
+	}
+	return earliestMsg
+}
+
+var setupLog = ctrl.Log.WithName("tracing")
+
+var providerWarningOnce sync.Once
+
+// sdkTracerProviderActive returns false and warns once via otel.Handle when the provider is neither sdktrace nor noop.
+func sdkTracerProviderActive() bool {
+	tp := otel.GetTracerProvider()
+	if _, ok := tp.(*sdktrace.TracerProvider); ok {
+		return true
+	}
+	if _, isNoop := tp.(noop.TracerProvider); isNoop {
+		return false
+	}
+	providerWarningOnce.Do(func() {
+		otel.Handle(fmt.Errorf("release-service tracing: global provider %T is neither *sdktrace.TracerProvider (installed by tracing.New when OTEL_EXPORTER_OTLP_ENDPOINT is set) nor noop.TracerProvider (default when unset); timing spans will be dropped", tp))
+	})
+	return false
+}
+
+type TracerProvider struct {
+	shutdown func(context.Context) error
+}
+
+// New configures the OTel SDK from environment and installs it as the global tracer provider.
+func New() *TracerProvider {
+	if os.Getenv(EnvOTLPEndpoint) == "" {
+		setupLog.Info("OTLP endpoint not configured, using noop tracer provider")
+		return &TracerProvider{shutdown: func(context.Context) error { return nil }}
+	}
+
+	exporter, err := otlptracegrpc.New(context.Background(),
+		otlptracegrpc.WithEndpointURL(os.Getenv(EnvOTLPEndpoint)),
+	)
+	if err != nil {
+		setupLog.Error(err, "failed to create OTLP exporter, using noop tracer provider")
+		return &TracerProvider{shutdown: func(context.Context) error { return nil }}
+	}
+
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(TracerName),
+		),
+	)
+	if err != nil {
+		setupLog.Error(err, "failed to create resource")
+		res = resource.Default()
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+		sdktrace.WithSampler(samplerFromEnv()),
+	)
+
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	setupLog.Info("tracing initialized", "endpoint", os.Getenv(EnvOTLPEndpoint))
+
+	return &TracerProvider{shutdown: tp.Shutdown}
+}
+
+// Shutdown flushes pending spans before process exit.
+func (tp *TracerProvider) Shutdown(ctx context.Context) error {
+	if tp.shutdown != nil {
+		return tp.shutdown(ctx)
+	}
+	return nil
+}

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -1,0 +1,441 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func withEnv(key, value string) {
+	prev, hadPrev := os.LookupEnv(key)
+	Expect(os.Setenv(key, value)).To(Succeed())
+	DeferCleanup(func() {
+		if hadPrev {
+			Expect(os.Setenv(key, prev)).To(Succeed())
+		} else {
+			Expect(os.Unsetenv(key)).To(Succeed())
+		}
+	})
+}
+
+func unsetEnv(key string) {
+	prev, hadPrev := os.LookupEnv(key)
+	Expect(os.Unsetenv(key)).To(Succeed())
+	DeferCleanup(func() {
+		if hadPrev {
+			Expect(os.Setenv(key, prev)).To(Succeed())
+		} else {
+			Expect(os.Unsetenv(key)).To(Succeed())
+		}
+	})
+}
+
+func resetGlobalProviderOnCleanup() {
+	prev := otel.GetTracerProvider()
+	prevProp := otel.GetTextMapPropagator()
+	otel.SetTracerProvider(tracenoop.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator())
+	DeferCleanup(func() {
+		otel.SetTracerProvider(prev)
+		otel.SetTextMapPropagator(prevProp)
+	})
+}
+
+type testExporter struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (e *testExporter) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.spans = append(e.spans, spans...)
+	return nil
+}
+
+func (e *testExporter) Shutdown(context.Context) error { return nil }
+
+func (e *testExporter) GetSpans() []sdktrace.ReadOnlySpan {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.spans
+}
+
+func newTracerProvider() (*testExporter, *sdktrace.TracerProvider) {
+	exp := &testExporter{}
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	return exp, tp
+}
+
+func newFakeClient(objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	Expect(tektonv1.AddToScheme(scheme)).To(Succeed())
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+func spanAttr(s sdktrace.ReadOnlySpan, key string) string {
+	for _, attr := range s.Attributes() {
+		if string(attr.Key) == key {
+			return attr.Value.String()
+		}
+	}
+	return ""
+}
+
+func hasAttr(s sdktrace.ReadOnlySpan, key string) bool {
+	for _, attr := range s.Attributes() {
+		if string(attr.Key) == key {
+			return true
+		}
+	}
+	return false
+}
+
+func defaultLabels() LabelNames {
+	return LabelNames{
+		Action:      DefaultTracingLabelAction,
+		Application: DefaultTracingLabelApplication,
+		Component:   DefaultTracingLabelComponent,
+	}
+}
+
+var _ = Describe("ResultEnum", func() {
+	DescribeTable("maps PipelineRun Succeeded condition to the semconv enum",
+		func(status corev1.ConditionStatus, reason, want string) {
+			cond := &apis.Condition{Status: status, Reason: reason}
+			Expect(ResultEnum(cond).Value.AsString()).To(Equal(want))
+		},
+		Entry("success",
+			corev1.ConditionTrue, tektonv1.PipelineRunReasonSuccessful.String(),
+			semconv.CICDPipelineResultSuccess.Value.AsString()),
+		Entry("completed is also success",
+			corev1.ConditionTrue, tektonv1.PipelineRunReasonCompleted.String(),
+			semconv.CICDPipelineResultSuccess.Value.AsString()),
+		Entry("failure",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonFailed.String(),
+			semconv.CICDPipelineResultFailure.Value.AsString()),
+		Entry("timeout",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonTimedOut.String(),
+			semconv.CICDPipelineResultTimeout.Value.AsString()),
+		Entry("cancelled",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonCancelled.String(),
+			semconv.CICDPipelineResultCancellation.Value.AsString()),
+		Entry("cancelled-running-finally",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonCancelledRunningFinally.String(),
+			semconv.CICDPipelineResultCancellation.Value.AsString()),
+		Entry("stopped-running-finally",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonStoppedRunningFinally.String(),
+			semconv.CICDPipelineResultCancellation.Value.AsString()),
+		Entry("validation failure falls back to error",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonFailedValidation.String(),
+			semconv.CICDPipelineResultError.Value.AsString()),
+		Entry("unknown reason falls back to error",
+			corev1.ConditionFalse, "SomeFutureTektonReason",
+			semconv.CICDPipelineResultError.Value.AsString()),
+	)
+
+	It("returns error when the condition is nil", func() {
+		Expect(ResultEnum(nil).Value.AsString()).To(Equal(semconv.CICDPipelineResultError.Value.AsString()))
+	})
+})
+
+var _ = Describe("TruncateResultMessage", func() {
+	It("passes a short message through unchanged", func() {
+		Expect(TruncateResultMessage("short")).To(Equal("short"))
+	})
+
+	It("passes a message exactly at the limit through unchanged", func() {
+		msg := strings.Repeat("a", MaxResultMessageLen)
+		Expect(TruncateResultMessage(msg)).To(Equal(msg))
+	})
+
+	It("truncates and suffixes a message over the limit", func() {
+		msg := strings.Repeat("a", MaxResultMessageLen+50)
+		got := TruncateResultMessage(msg)
+		Expect(len(got)).To(BeNumerically("<=", MaxResultMessageLen))
+		Expect(got).To(HaveSuffix(TruncatedSuffix))
+	})
+
+	It("preserves UTF-8 boundaries when truncating", func() {
+		prefix := strings.Repeat("a", MaxResultMessageLen-len(TruncatedSuffix)-2)
+		msg := prefix + "世" + strings.Repeat("b", 100)
+		got := TruncateResultMessage(msg)
+		head := strings.TrimSuffix(got, TruncatedSuffix)
+		Expect(head).NotTo(Equal(got))
+		for _, r := range head {
+			Expect(r).NotTo(Equal('�'))
+		}
+	})
+})
+
+var _ = Describe("EarliestFailingTaskRunMessage", func() {
+	var (
+		t1 metav1.Time
+		t2 metav1.Time
+		t3 metav1.Time
+	)
+
+	BeforeEach(func() {
+		now := time.Now()
+		t1 = metav1.NewTime(now.Add(-3 * time.Minute))
+		t2 = metav1.NewTime(now.Add(-2 * time.Minute))
+		t3 = metav1.NewTime(now.Add(-time.Minute))
+	})
+
+	mkTR := func(name string, completion *metav1.Time, status corev1.ConditionStatus, message string) *tektonv1.TaskRun {
+		tr := &tektonv1.TaskRun{ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "ns",
+			Labels:    map[string]string{"tekton.dev/pipelineRun": "pr"},
+		}}
+		tr.Status.CompletionTime = completion
+		if completion != nil {
+			tr.Status.Conditions = duckv1.Conditions{{
+				Type:    apis.ConditionSucceeded,
+				Status:  status,
+				Message: message,
+			}}
+		}
+		return tr
+	}
+
+	mkPR := func(names ...string) *tektonv1.PipelineRun {
+		pr := &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "pr", Namespace: "ns"}}
+		for _, n := range names {
+			pr.Status.ChildReferences = append(pr.Status.ChildReferences, tektonv1.ChildStatusReference{Name: n})
+		}
+		return pr
+	}
+
+	It("returns empty when the PipelineRun has no child references", func() {
+		got := EarliestFailingTaskRunMessage(context.Background(), newFakeClient(), mkPR())
+		Expect(got).To(Equal(""))
+	})
+
+	It("returns empty when the only child succeeded", func() {
+		c := newFakeClient(mkTR("tr-ok", &t2, corev1.ConditionTrue, "done"))
+		Expect(EarliestFailingTaskRunMessage(context.Background(), c, mkPR("tr-ok"))).To(Equal(""))
+	})
+
+	It("returns the failing child's message when one child fails", func() {
+		c := newFakeClient(mkTR("tr-fail", &t2, corev1.ConditionFalse, "boom"))
+		Expect(EarliestFailingTaskRunMessage(context.Background(), c, mkPR("tr-fail"))).To(Equal("boom"))
+	})
+
+	It("returns the earliest failing message when multiple children fail", func() {
+		c := newFakeClient(
+			mkTR("tr-late", &t3, corev1.ConditionFalse, "late"),
+			mkTR("tr-early", &t1, corev1.ConditionFalse, "early"),
+		)
+		Expect(EarliestFailingTaskRunMessage(context.Background(), c, mkPR("tr-late", "tr-early"))).To(Equal("early"))
+	})
+
+	It("picks the failing child when success and failure are mixed", func() {
+		c := newFakeClient(
+			mkTR("tr-ok", &t1, corev1.ConditionTrue, "done"),
+			mkTR("tr-fail", &t2, corev1.ConditionFalse, "bad"),
+		)
+		Expect(EarliestFailingTaskRunMessage(context.Background(), c, mkPR("tr-ok", "tr-fail"))).To(Equal("bad"))
+	})
+
+	It("skips incomplete children", func() {
+		c := newFakeClient(
+			mkTR("tr-running", nil, corev1.ConditionUnknown, ""),
+			mkTR("tr-fail", &t2, corev1.ConditionFalse, "later"),
+		)
+		Expect(EarliestFailingTaskRunMessage(context.Background(), c, mkPR("tr-running", "tr-fail"))).To(Equal("later"))
+	})
+
+	It("returns only what the List finds when some referenced TaskRuns are absent from the cluster", func() {
+		c := newFakeClient(mkTR("tr-fail", &t2, corev1.ConditionFalse, "present-failure"))
+		Expect(EarliestFailingTaskRunMessage(context.Background(), c, mkPR("tr-fail", "tr-missing"))).To(Equal("present-failure"))
+	})
+})
+
+var _ = Describe("LoadLabelNames", func() {
+	envKeys := []string{
+		EnvTracingLabelAction,
+		EnvTracingLabelApplication,
+		EnvTracingLabelComponent,
+	}
+
+	saveEnv := func() map[string]string {
+		saved := map[string]string{}
+		for _, k := range envKeys {
+			if v, ok := os.LookupEnv(k); ok {
+				saved[k] = v
+			}
+		}
+		return saved
+	}
+
+	restoreEnv := func(saved map[string]string) {
+		for _, k := range envKeys {
+			Expect(os.Unsetenv(k)).To(Succeed())
+		}
+		for k, v := range saved {
+			Expect(os.Setenv(k, v)).To(Succeed())
+		}
+	}
+
+	BeforeEach(func() {
+		SetupLabelNames()
+		DeferCleanup(SetupLabelNames)
+	})
+
+	It("returns the delivery.tekton.dev/* defaults when env vars are unset", func() {
+		saved := saveEnv()
+		DeferCleanup(restoreEnv, saved)
+		for _, k := range envKeys {
+			Expect(os.Unsetenv(k)).To(Succeed())
+		}
+		SetupLabelNames()
+		got := LoadLabelNames()
+		Expect(got.Action).To(Equal(DefaultTracingLabelAction))
+		Expect(got.Application).To(Equal(DefaultTracingLabelApplication))
+		Expect(got.Component).To(Equal(DefaultTracingLabelComponent))
+	})
+
+	It("treats an explicit empty-string as disabling the attribute", func() {
+		saved := saveEnv()
+		DeferCleanup(restoreEnv, saved)
+		for _, k := range envKeys {
+			Expect(os.Setenv(k, "")).To(Succeed())
+		}
+		SetupLabelNames()
+		got := LoadLabelNames()
+		Expect(got.Action).To(Equal(""))
+		Expect(got.Application).To(Equal(""))
+		Expect(got.Component).To(Equal(""))
+	})
+})
+
+var _ = Describe("samplerFromEnv", func() {
+	DescribeTable("returns the sampler that matches the requested decision tree",
+		func(samplerEnv, argEnv, wantPrefix string) {
+			if samplerEnv == "" {
+				unsetEnv(EnvTracesSampler)
+			} else {
+				withEnv(EnvTracesSampler, samplerEnv)
+			}
+			if argEnv == "" {
+				unsetEnv(EnvTracesSamplerArg)
+			} else {
+				withEnv(EnvTracesSamplerArg, argEnv)
+			}
+			Expect(samplerFromEnv().Description()).To(HavePrefix(wantPrefix))
+		},
+		Entry("always_on selects the unconditional sampler",
+			"always_on", "", "AlwaysOnSampler"),
+		Entry("always_off selects the never-sample sampler",
+			"always_off", "", "AlwaysOffSampler"),
+		Entry("traceidratio with arg=0.5 selects the matching ratio sampler",
+			"traceidratio", "0.5", "TraceIDRatioBased{0.5"),
+		Entry("traceidratio with no arg falls back to ratio 0",
+			"traceidratio", "", "TraceIDRatioBased{0"),
+		Entry("parentbased_always_off honors a parent's sampling decision but defaults off",
+			"parentbased_always_off", "", "ParentBased{root:AlwaysOffSampler"),
+		Entry("parentbased_traceidratio applies the ratio at the root",
+			"parentbased_traceidratio", "0.25", "ParentBased{root:TraceIDRatioBased{0.25"),
+		Entry("unset env defaults to parent-based always-on",
+			"", "", "ParentBased{root:AlwaysOnSampler"),
+		Entry("unrecognized env value falls back to the default",
+			"some-future-otel-keyword", "", "ParentBased{root:AlwaysOnSampler"),
+	)
+})
+
+var _ = Describe("New", func() {
+	It("disables sampling when the OTLP endpoint env var is unset", func() {
+		unsetEnv(EnvOTLPEndpoint)
+		resetGlobalProviderOnCleanup()
+
+		tp := New()
+		Expect(tp).NotTo(BeNil())
+
+		_, isSDK := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+		Expect(isSDK).To(BeFalse())
+
+		_, span := otel.Tracer("no-endpoint-probe").Start(context.Background(), "probe")
+		defer span.End()
+		Expect(span.SpanContext().IsSampled()).To(BeFalse())
+
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+	})
+
+	It("installs an SDK TracerProvider and a W3C TraceContext propagator when the endpoint is well-formed", func() {
+		withEnv(EnvOTLPEndpoint, "http://localhost:4317")
+		resetGlobalProviderOnCleanup()
+
+		tp := New()
+		Expect(tp).NotTo(BeNil())
+
+		_, isSDK := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+		Expect(isSDK).To(BeTrue())
+		_, isW3C := otel.GetTextMapPropagator().(propagation.TraceContext)
+		Expect(isW3C).To(BeTrue())
+
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+	})
+})
+
+var _ = Describe("TracerProvider.Shutdown", func() {
+	It("returns nil for a noop-backed provider", func() {
+		unsetEnv(EnvOTLPEndpoint)
+		resetGlobalProviderOnCleanup()
+
+		tp := New()
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+	})
+
+	It("is idempotent for an SDK-backed provider", func() {
+		withEnv(EnvOTLPEndpoint, "http://localhost:4317")
+		resetGlobalProviderOnCleanup()
+
+		tp := New()
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+		// A second call must not panic or surface an error.
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+	})
+
+	It("is a noop on a TracerProvider with no shutdown hook", func() {
+		tp := &TracerProvider{}
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+	})
+})


### PR DESCRIPTION
Emit waitDuration and executeDuration spans per release PipelineRun, parented under
the tekton.dev/pipelinerunSpanContext annotation that the Release CR carries forward.
When a Release CR is rejected at the validation gate (no PipelineRun ever runs),
emit a waitDuration span so the rejection surfaces in the trace instead of
disappearing. Span attributes follow the delivery tracing schema established in
[konflux-ci/architecture ADR 0062](https://github.com/konflux-ci/architecture/blob/main/ADR/0062-distributed-tracing.md);
sampling and label names are env-var configurable.

Validated end-to-end on a CRC dev cluster: build PR → Snapshot → Release → release
PR composes under one trace ID, with all four services emitting against the ADR-0062
schema.

Assisted-by: Claude Code