### PR TITLE
fix(RELEASE-2092): fix KubeArchive connectivity and logging

### DIFF
--- a/config/manager/network_policy.yaml
+++ b/config/manager/network_policy.yaml
@@ -33,6 +33,17 @@ spec:
       ports:
         - port: 443
           protocol: TCP
+    # Allow traffic to KubeArchive API server
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: product-kubearchive
+        podSelector:
+          matchLabels:
+            app: kubearchive-api-server
+      ports:
+        - port: 8081
+          protocol: TCP
     # Allow DNS queries so SeaLights can resolve the api url
     - to:
       - namespaceSelector:

--- a/kubearchive/client.go
+++ b/kubearchive/client.go
@@ -2,6 +2,7 @@ package kubearchive
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,7 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"sync"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,46 +23,50 @@ import (
 
 const (
 	apiURLConfigMapName = "kubearchive-api-url"
-	apiURLConfigMapKey  = "URL"
+
+	kaNamespace   = "product-kubearchive"
+	kaServiceName = "kubearchive-api-server"
+	kaServicePort = 8081
+
+	serviceCAConfigMapName = "openshift-service-ca.crt"
+	serviceCAConfigMapKey  = "service-ca.crt"
+
+	httpClientTimeout = 10 * time.Second
 )
 
-const kaNamespace = "product-kubearchive"
-
-// Client provides access to the KubeArchive API for retrieving archived Kubernetes resources.
-// It lazily discovers the KubeArchive API URL on first use and caches it for subsequent calls.
-// Authentication and TLS are derived from the in-cluster REST configuration.
-type Client struct {
-	mu         sync.Mutex
-	apiURL     string
-	resolved   bool
-	httpClient *http.Client
-}
-
-// NewClient creates a new KubeArchive client. The API URL is discovered lazily on the first
-// Get call using the Kubernetes client to locate the KubeArchive service.
-func NewClient() *Client {
-	return &Client{}
-}
+var (
+	discoverAPIURLFunc = discoverAPIURL
+	newHTTPClientFunc  = newHTTPClient
+)
 
 // Get retrieves an archived resource from KubeArchive by its GroupVersionResource, namespace,
-// and name. The Kubernetes client is used for one-time API URL discovery and is not needed for
-// subsequent calls. The result is unmarshaled into obj, which should be a pointer to the
-// expected resource type.
+// and name. The Kubernetes client is used to check whether KubeArchive is deployed and to load
+// the service-serving CA for TLS. The result is unmarshaled into obj.
 //
 // When multiple archived versions of the same resource exist, the KubeArchive single-resource
 // endpoint returns HTTP 500. In that case, Get falls back to the list endpoint and selects the
 // item with the highest resourceVersion (the most recently persisted version).
-func (c *Client) Get(ctx context.Context, cli client.Client, gvr schema.GroupVersionResource,
+func Get(ctx context.Context, cli client.Client, gvr schema.GroupVersionResource,
 	namespace, name string, obj client.Object) error {
 
-	apiURL, httpClient, err := c.resolve(ctx, cli)
+	logger := ctrl.LoggerFrom(ctx)
+
+	apiURL, err := discoverAPIURLFunc(ctx, cli)
 	if err != nil {
+		logger.Error(err, "Failed to discover KubeArchive API")
 		return err
 	}
 
-	logger := ctrl.LoggerFrom(ctx)
-	body, statusCode, err := c.doGet(ctx, httpClient, apiURL+buildAPIPath(gvr, namespace, name))
+	httpClient, err := newHTTPClientFunc(ctx, cli)
 	if err != nil {
+		logger.Error(err, "Failed to create KubeArchive HTTP client")
+		return err
+	}
+
+	body, statusCode, err := doGet(ctx, httpClient, apiURL+buildAPIPath(gvr, namespace, name))
+	if err != nil {
+		logger.Error(err, "KubeArchive request failed",
+			"gvr", gvr.String(), "namespace", namespace, "name", name)
 		return err
 	}
 
@@ -81,18 +86,18 @@ func (c *Client) Get(ctx context.Context, cli client.Client, gvr schema.GroupVer
 	if statusCode == http.StatusInternalServerError && strings.Contains(string(body), "more than one resource found") {
 		logger.Info("Multiple archived versions found, falling back to list endpoint",
 			"gvr", gvr.String(), "namespace", namespace, "name", name)
-		return c.getFromList(ctx, httpClient, apiURL, gvr, namespace, name, obj)
+		return getFromList(ctx, httpClient, apiURL, gvr, namespace, name, obj)
 	}
 
-	return fmt.Errorf("kubearchive returned HTTP %d for %s/%s: %s",
+	retErr := fmt.Errorf("kubearchive returned HTTP %d for %s/%s: %s",
 		statusCode, namespace, name, truncate(string(body), 200))
+	logger.Error(retErr, "Unexpected KubeArchive response",
+		"gvr", gvr.String(), "statusCode", statusCode)
+	return retErr
 }
 
 // doGet performs an HTTP GET and returns the body, status code, and any transport error.
-func (c *Client) doGet(ctx context.Context, httpClient *http.Client, url string) ([]byte, int, error) {
-	logger := ctrl.LoggerFrom(ctx)
-	logger.Info("Fetching resource from KubeArchive", "url", url)
-
+func doGet(ctx context.Context, httpClient *http.Client, url string) ([]byte, int, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, 0, fmt.Errorf("building kubearchive request: %w", err)
@@ -112,13 +117,13 @@ func (c *Client) doGet(ctx context.Context, httpClient *http.Client, url string)
 
 // getFromList queries the list endpoint with a fieldSelector to retrieve only archived
 // versions matching the given name, then picks the one with the highest resourceVersion.
-func (c *Client) getFromList(ctx context.Context, httpClient *http.Client,
+func getFromList(ctx context.Context, httpClient *http.Client,
 	apiURL string, gvr schema.GroupVersionResource,
 	namespace, name string, obj client.Object) error {
 
 	listURL := apiURL + buildListAPIPath(gvr, namespace) +
 		"?fieldSelector=" + url.QueryEscape("metadata.name="+name)
-	body, statusCode, err := c.doGet(ctx, httpClient, listURL)
+	body, statusCode, err := doGet(ctx, httpClient, listURL)
 	if err != nil {
 		return err
 	}
@@ -170,67 +175,66 @@ func (c *Client) getFromList(ctx context.Context, httpClient *http.Client,
 	return json.Unmarshal(bestRaw, obj)
 }
 
-// resolve lazily discovers the KubeArchive API URL and builds an authenticated HTTP client
-// on first call, caching both for subsequent use. If discovery has already been attempted
-// and failed, it returns the cached error without retrying.
-func (c *Client) resolve(ctx context.Context, cli client.Client) (string, *http.Client, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.resolved {
-		if c.apiURL == "" {
-			return "", nil, fmt.Errorf("kubearchive is not available on this cluster")
-		}
-		return c.apiURL, c.httpClient, nil
-	}
-
-	logger := ctrl.LoggerFrom(ctx)
-	apiURL, err := discoverAPIURL(ctx, cli)
-	c.resolved = true
-	if err != nil {
-		logger.Info("KubeArchive not available on this cluster", "error", err)
-		return "", nil, fmt.Errorf("kubearchive discovery failed: %w", err)
-	}
-
-	c.apiURL = apiURL
-	if c.httpClient == nil {
-		c.httpClient, err = newHTTPClient()
-		if err != nil {
-			return "", nil, fmt.Errorf("creating kubearchive HTTP client: %w", err)
-		}
-	}
-	logger.Info("Discovered KubeArchive API", "url", apiURL)
-	return c.apiURL, c.httpClient, nil
-}
-
-// discoverAPIURL finds the KubeArchive API server URL by reading the well-known
-// ConfigMap "kubearchive-api-url" from the product-kubearchive namespace. The
-// ConfigMap is deployed by infra-deployments and contains a single key "URL"
-// with the route URL.
+// discoverAPIURL checks whether KubeArchive is deployed on this cluster by
+// looking for the well-known ConfigMap "kubearchive-api-url" in the
+// product-kubearchive namespace. If present, it returns the in-cluster service
+// URL so that the controller communicates directly with the KubeArchive API
+// server over the cluster network, avoiding external route egress restrictions.
 func discoverAPIURL(ctx context.Context, cli client.Client) (string, error) {
 	cm := &corev1.ConfigMap{}
 	if err := cli.Get(ctx, types.NamespacedName{Namespace: kaNamespace, Name: apiURLConfigMapName}, cm); err != nil {
 		return "", fmt.Errorf("ConfigMap %q not found in namespace %q: %w", apiURLConfigMapName, kaNamespace, err)
 	}
-	if u, ok := cm.Data[apiURLConfigMapKey]; ok &&
-		(strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")) {
-		return strings.TrimRight(u, "/"), nil
-	}
-	return "", fmt.Errorf("ConfigMap %q in namespace %q has no valid URL", apiURLConfigMapName, kaNamespace)
+	return fmt.Sprintf("https://%s.%s.svc.cluster.local:%d", kaServiceName, kaNamespace, kaServicePort), nil
 }
 
-// newHTTPClient builds an HTTP client that carries the in-cluster service account
-// bearer token for KubeArchive authentication. The cluster CA is cleared so that
-// Go falls back to the system CA bundle, which can verify the external route TLS
-// certificate (signed by a public CA, not the cluster CA).
-func newHTTPClient() (*http.Client, error) {
+// loadServiceCA reads the OpenShift service-serving CA bundle from the
+// well-known "openshift-service-ca.crt" ConfigMap in the product-kubearchive
+// namespace. The ConfigMap is auto-populated by the service-ca operator in
+// every namespace.
+func loadServiceCA(ctx context.Context, cli client.Client) ([]byte, error) {
+	cm := &corev1.ConfigMap{}
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: kaNamespace, Name: serviceCAConfigMapName}, cm); err != nil {
+		return nil, fmt.Errorf("ConfigMap %q not found in namespace %q: %w", serviceCAConfigMapName, kaNamespace, err)
+	}
+	pem, ok := cm.Data[serviceCAConfigMapKey]
+	if !ok || len(pem) == 0 {
+		return nil, fmt.Errorf("ConfigMap %q in namespace %q has no %q key", serviceCAConfigMapName, kaNamespace, serviceCAConfigMapKey)
+	}
+	return []byte(pem), nil
+}
+
+// newHTTPClient builds an HTTP client that carries the in-cluster service
+// account bearer token for KubeArchive authentication and trusts the
+// service-serving CA for TLS verification of the internal service endpoint.
+func newHTTPClient(ctx context.Context, cli client.Client) (*http.Client, error) {
+	caData, err := loadServiceCA(ctx, cli)
+	if err != nil {
+		return nil, fmt.Errorf("loading service-serving CA: %w", err)
+	}
+
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, fmt.Errorf("loading in-cluster config: %w", err)
 	}
-	cfg.TLSClientConfig.CAFile = ""
-	cfg.TLSClientConfig.CAData = nil
-	return rest.HTTPClientFor(cfg)
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caData) {
+		return nil, fmt.Errorf("failed to parse service-serving CA bundle")
+	}
+
+	cfg.TLSClientConfig = rest.TLSClientConfig{CAData: caData}
+	cfg.Timeout = httpClientTimeout
+
+	transport, err := rest.TransportFor(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("building transport: %w", err)
+	}
+
+	return &http.Client{
+		Transport: transport,
+		Timeout:   httpClientTimeout,
+	}, nil
 }
 
 // buildAPIPath constructs the REST API path for a named resource, mirroring the

--- a/kubearchive/client_test.go
+++ b/kubearchive/client_test.go
@@ -19,11 +19,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func newResolvedClient(server *httptest.Server) *Client {
-	return &Client{
-		resolved:   true,
-		apiURL:     server.URL,
-		httpClient: server.Client(),
+// stubHTTPClient overrides the package-level function variables so that Get
+// uses the supplied httptest.Server instead of building a real in-cluster
+// client. It returns a cleanup function that restores the originals.
+func stubHTTPClient(server *httptest.Server) func() {
+	origDiscover := discoverAPIURLFunc
+	origNewHTTP := newHTTPClientFunc
+
+	discoverAPIURLFunc = func(_ context.Context, _ client.Client) (string, error) {
+		return server.URL, nil
+	}
+	newHTTPClientFunc = func(_ context.Context, _ client.Client) (*http.Client, error) {
+		return server.Client(), nil
+	}
+
+	return func() {
+		discoverAPIURLFunc = origDiscover
+		newHTTPClientFunc = origNewHTTP
 	}
 }
 
@@ -81,21 +93,22 @@ var _ = Describe("KubeArchive Client", func() {
 			Expect(corev1.AddToScheme(scheme)).To(Succeed())
 		})
 
-		It("returns the URL from the ConfigMap", func() {
+		It("returns the internal service URL when the ConfigMap exists", func() {
 			cm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      apiURLConfigMapName,
 					Namespace: kaNamespace,
 				},
 				Data: map[string]string{
-					apiURLConfigMapKey: "https://kubearchive.example.com/",
+					"URL": "https://kubearchive.example.com/",
 				},
 			}
 			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
 
 			url, err := discoverAPIURL(ctx, cli)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(url).To(Equal("https://kubearchive.example.com"))
+			Expect(url).To(Equal(fmt.Sprintf("https://%s.%s.svc.cluster.local:%d",
+				kaServiceName, kaNamespace, kaServicePort)))
 		})
 
 		It("returns an error when no ConfigMap exists", func() {
@@ -105,154 +118,32 @@ var _ = Describe("KubeArchive Client", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not found in namespace"))
 		})
-
-		It("returns an error when the ConfigMap has a non-HTTP URL value", func() {
-			cm := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      apiURLConfigMapName,
-					Namespace: kaNamespace,
-				},
-				Data: map[string]string{
-					apiURLConfigMapKey: "ftp://bad-url.example.com",
-				},
-			}
-			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
-
-			_, err := discoverAPIURL(ctx, cli)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("no valid URL"))
-		})
-
-		It("trims trailing slash from the URL", func() {
-			cm := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      apiURLConfigMapName,
-					Namespace: kaNamespace,
-				},
-				Data: map[string]string{
-					apiURLConfigMapKey: "https://example.com///",
-				},
-			}
-			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
-
-			url, err := discoverAPIURL(ctx, cli)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(url).To(Equal("https://example.com"))
-		})
 	})
 
-	Describe("Get", func() {
-		var (
-			ctx context.Context
-			gvr schema.GroupVersionResource
-		)
+	Describe("doGet", func() {
+		var ctx context.Context
 
 		BeforeEach(func() {
 			ctx = context.Background()
-			gvr = schema.GroupVersionResource{
-				Group: "appstudio.redhat.com", Version: "v1alpha1", Resource: "snapshots",
-			}
 		})
 
-		It("unmarshals a 200 response into the target object", func() {
+		It("returns the body and status code on success", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				snap := applicationapiv1alpha1.Snapshot{
-					ObjectMeta: metav1.ObjectMeta{Name: "my-snap", Namespace: "ns"},
-					Spec:       applicationapiv1alpha1.SnapshotSpec{Application: "my-app"},
-				}
 				w.WriteHeader(http.StatusOK)
-				json.NewEncoder(w).Encode(snap)
+				fmt.Fprint(w, "hello")
 			}))
 			defer server.Close()
 
-			c := newResolvedClient(server)
-			obj := &applicationapiv1alpha1.Snapshot{}
-			err := c.Get(ctx, nil, gvr, "ns", "my-snap", obj)
+			body, status, err := doGet(ctx, server.Client(), server.URL+"/test")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(obj.Name).To(Equal("my-snap"))
-			Expect(obj.Spec.Application).To(Equal("my-app"))
+			Expect(status).To(Equal(http.StatusOK))
+			Expect(string(body)).To(Equal("hello"))
 		})
 
-		It("returns a NotFound error on 404", func() {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusNotFound)
-				w.Write([]byte("not found"))
-			}))
-			defer server.Close()
-
-			c := newResolvedClient(server)
-			obj := &applicationapiv1alpha1.Snapshot{}
-			err := c.Get(ctx, nil, gvr, "ns", "missing", obj)
+		It("returns an error when the server is unreachable", func() {
+			_, _, err := doGet(ctx, http.DefaultClient, "http://127.0.0.1:1")
 			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsNotFound(err)).To(BeTrue())
-		})
-
-		It("falls back to the list endpoint on HTTP 500 with 'more than one resource found'", func() {
-			callCount := 0
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				callCount++
-				if callCount == 1 {
-					w.WriteHeader(http.StatusInternalServerError)
-					w.Write([]byte("more than one resource found"))
-					return
-				}
-				list := map[string]interface{}{
-					"items": []map[string]interface{}{
-						{
-							"apiVersion": "appstudio.redhat.com/v1alpha1",
-							"kind":       "Snapshot",
-							"metadata":   map[string]interface{}{"name": "target", "namespace": "ns", "resourceVersion": "100"},
-							"spec":       map[string]interface{}{"application": "old-app"},
-						},
-						{
-							"apiVersion": "appstudio.redhat.com/v1alpha1",
-							"kind":       "Snapshot",
-							"metadata":   map[string]interface{}{"name": "target", "namespace": "ns", "resourceVersion": "200"},
-							"spec":       map[string]interface{}{"application": "latest-app"},
-						},
-					},
-				}
-				w.WriteHeader(http.StatusOK)
-				json.NewEncoder(w).Encode(list)
-			}))
-			defer server.Close()
-
-			c := newResolvedClient(server)
-			obj := &applicationapiv1alpha1.Snapshot{}
-			err := c.Get(ctx, nil, gvr, "ns", "target", obj)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(obj.Name).To(Equal("target"))
-			Expect(obj.ResourceVersion).To(Equal("200"))
-			Expect(obj.Spec.Application).To(Equal("latest-app"))
-			Expect(callCount).To(Equal(2))
-		})
-
-		It("returns an error on unexpected HTTP status codes", func() {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusForbidden)
-				w.Write([]byte("forbidden"))
-			}))
-			defer server.Close()
-
-			c := newResolvedClient(server)
-			obj := &applicationapiv1alpha1.Snapshot{}
-			err := c.Get(ctx, nil, gvr, "ns", "snap", obj)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("HTTP 403"))
-		})
-
-		It("returns an error on HTTP 500 without the duplicate-resource message", func() {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte("internal server error"))
-			}))
-			defer server.Close()
-
-			c := newResolvedClient(server)
-			obj := &applicationapiv1alpha1.Snapshot{}
-			err := c.Get(ctx, nil, gvr, "ns", "snap", obj)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("HTTP 500"))
+			Expect(err.Error()).To(ContainSubstring("kubearchive request"))
 		})
 	})
 
@@ -283,9 +174,8 @@ var _ = Describe("KubeArchive Client", func() {
 			}))
 			defer server.Close()
 
-			c := newResolvedClient(server)
 			obj := &applicationapiv1alpha1.Snapshot{}
-			err := c.getFromList(ctx, server.Client(), server.URL, gvr, "ns", "snap", obj)
+			err := getFromList(ctx, server.Client(), server.URL, gvr, "ns", "snap", obj)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(obj.ResourceVersion).To(Equal("300"))
 		})
@@ -303,9 +193,8 @@ var _ = Describe("KubeArchive Client", func() {
 			}))
 			defer server.Close()
 
-			c := newResolvedClient(server)
 			obj := &applicationapiv1alpha1.Snapshot{}
-			err := c.getFromList(ctx, server.Client(), server.URL, gvr, "ns", "target", obj)
+			err := getFromList(ctx, server.Client(), server.URL, gvr, "ns", "target", obj)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(obj.Name).To(Equal("target"))
 			Expect(obj.ResourceVersion).To(Equal("100"))
@@ -319,9 +208,8 @@ var _ = Describe("KubeArchive Client", func() {
 			}))
 			defer server.Close()
 
-			c := newResolvedClient(server)
 			obj := &applicationapiv1alpha1.Snapshot{}
-			err := c.getFromList(ctx, server.Client(), server.URL, gvr, "ns", "snap", obj)
+			err := getFromList(ctx, server.Client(), server.URL, gvr, "ns", "snap", obj)
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
@@ -338,9 +226,8 @@ var _ = Describe("KubeArchive Client", func() {
 			}))
 			defer server.Close()
 
-			c := newResolvedClient(server)
 			obj := &applicationapiv1alpha1.Snapshot{}
-			err := c.getFromList(ctx, server.Client(), server.URL, gvr, "ns", "snap", obj)
+			err := getFromList(ctx, server.Client(), server.URL, gvr, "ns", "snap", obj)
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
@@ -352,9 +239,8 @@ var _ = Describe("KubeArchive Client", func() {
 			}))
 			defer server.Close()
 
-			c := newResolvedClient(server)
 			obj := &applicationapiv1alpha1.Snapshot{}
-			err := c.getFromList(ctx, server.Client(), server.URL, gvr, "ns", "snap", obj)
+			err := getFromList(ctx, server.Client(), server.URL, gvr, "ns", "snap", obj)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("HTTP 503"))
 		})
@@ -368,130 +254,217 @@ var _ = Describe("KubeArchive Client", func() {
 			}))
 			defer server.Close()
 
-			c := newResolvedClient(server)
 			obj := &applicationapiv1alpha1.Snapshot{}
-			_ = c.getFromList(ctx, server.Client(), server.URL, gvr, "ns", "my-snap", obj)
+			_ = getFromList(ctx, server.Client(), server.URL, gvr, "ns", "my-snap", obj)
 			Expect(receivedQuery).To(Equal("metadata.name=my-snap"))
 		})
 	})
+})
 
-	Describe("resolve", func() {
-		var (
-			ctx    context.Context
-			scheme *runtime.Scheme
-		)
+var _ = Describe("loadServiceCA", func() {
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+	)
 
-		BeforeEach(func() {
-			ctx = context.Background()
-			scheme = runtime.NewScheme()
-			Expect(corev1.AddToScheme(scheme)).To(Succeed())
-		})
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	})
 
-		It("returns cached values on subsequent calls", func() {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-			defer server.Close()
+	It("returns the CA data from the ConfigMap", func() {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceCAConfigMapName,
+				Namespace: kaNamespace,
+			},
+			Data: map[string]string{
+				serviceCAConfigMapKey: "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n",
+			},
+		}
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
 
-			c := &Client{
-				resolved:   true,
-				apiURL:     server.URL,
-				httpClient: server.Client(),
+		data, err := loadServiceCA(ctx, cli)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(ContainSubstring("BEGIN CERTIFICATE"))
+	})
+
+	It("returns an error when the ConfigMap does not exist", func() {
+		cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		_, err := loadServiceCA(ctx, cli)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found in namespace"))
+	})
+
+	It("returns an error when the CA key is missing", func() {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceCAConfigMapName,
+				Namespace: kaNamespace,
+			},
+			Data: map[string]string{},
+		}
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+		_, err := loadServiceCA(ctx, cli)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no"))
+	})
+})
+
+var _ = Describe("Get", func() {
+	var (
+		ctx context.Context
+		gvr schema.GroupVersionResource
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		gvr = schema.GroupVersionResource{
+			Group: "appstudio.redhat.com", Version: "v1alpha1", Resource: "snapshots",
+		}
+	})
+
+	It("unmarshals a 200 response into the target object", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			snap := applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-snap", Namespace: "ns"},
+				Spec:       applicationapiv1alpha1.SnapshotSpec{Application: "my-app"},
 			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(snap)
+		}))
+		defer server.Close()
+		cleanup := stubHTTPClient(server)
+		defer cleanup()
 
-			url, httpClient, err := c.resolve(ctx, nil)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(url).To(Equal(server.URL))
-			Expect(httpClient).To(Equal(server.Client()))
-		})
-
-		It("returns an error when already resolved but apiURL is empty", func() {
-			c := &Client{resolved: true, apiURL: ""}
-			_, _, err := c.resolve(ctx, nil)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("not available"))
-		})
-
-		It("returns an error when no ConfigMap is found during discovery", func() {
-			cli := fake.NewClientBuilder().WithScheme(scheme).Build()
-			c := NewClient()
-
-			_, _, err := c.resolve(ctx, cli)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("kubearchive discovery failed"))
-		})
+		obj := &applicationapiv1alpha1.Snapshot{}
+		err := Get(ctx, nil, gvr, "ns", "my-snap", obj)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(obj.Name).To(Equal("my-snap"))
+		Expect(obj.Spec.Application).To(Equal("my-app"))
 	})
 
-	Describe("doGet", func() {
-		var ctx context.Context
+	It("returns a NotFound error on 404", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte("not found"))
+		}))
+		defer server.Close()
+		cleanup := stubHTTPClient(server)
+		defer cleanup()
 
-		BeforeEach(func() {
-			ctx = context.Background()
-		})
-
-		It("returns the body and status code on success", func() {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, "hello")
-			}))
-			defer server.Close()
-
-			c := newResolvedClient(server)
-			body, status, err := c.doGet(ctx, server.Client(), server.URL+"/test")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(status).To(Equal(http.StatusOK))
-			Expect(string(body)).To(Equal("hello"))
-		})
-
-		It("returns an error when the server is unreachable", func() {
-			c := &Client{}
-			_, _, err := c.doGet(ctx, http.DefaultClient, "http://127.0.0.1:1")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("kubearchive request"))
-		})
+		obj := &applicationapiv1alpha1.Snapshot{}
+		err := Get(ctx, nil, gvr, "ns", "missing", obj)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
 
-	Describe("Get with resolve", func() {
-		It("discovers the API URL from the ConfigMap and makes the request", func() {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				snap := applicationapiv1alpha1.Snapshot{
-					ObjectMeta: metav1.ObjectMeta{Name: "my-snap", Namespace: "ns"},
-					Spec:       applicationapiv1alpha1.SnapshotSpec{Application: "my-app"},
-				}
-				w.WriteHeader(http.StatusOK)
-				json.NewEncoder(w).Encode(snap)
-			}))
-			defer server.Close()
-
-			s := runtime.NewScheme()
-			Expect(corev1.AddToScheme(s)).To(Succeed())
-			cm := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      apiURLConfigMapName,
-					Namespace: kaNamespace,
+	It("falls back to the list endpoint on HTTP 500 with 'more than one resource found'", func() {
+		callCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("more than one resource found"))
+				return
+			}
+			list := map[string]interface{}{
+				"items": []map[string]interface{}{
+					{
+						"apiVersion": "appstudio.redhat.com/v1alpha1",
+						"kind":       "Snapshot",
+						"metadata":   map[string]interface{}{"name": "target", "namespace": "ns", "resourceVersion": "100"},
+						"spec":       map[string]interface{}{"application": "old-app"},
+					},
+					{
+						"apiVersion": "appstudio.redhat.com/v1alpha1",
+						"kind":       "Snapshot",
+						"metadata":   map[string]interface{}{"name": "target", "namespace": "ns", "resourceVersion": "200"},
+						"spec":       map[string]interface{}{"application": "latest-app"},
+					},
 				},
-				Data: map[string]string{apiURLConfigMapKey: server.URL},
 			}
-			cli := fake.NewClientBuilder().WithScheme(s).WithObjects(cm).Build()
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(list)
+		}))
+		defer server.Close()
+		cleanup := stubHTTPClient(server)
+		defer cleanup()
 
-			c := &Client{httpClient: server.Client()}
-			gvr := schema.GroupVersionResource{
-				Group: "appstudio.redhat.com", Version: "v1alpha1", Resource: "snapshots",
-			}
-			obj := &applicationapiv1alpha1.Snapshot{}
-			err := c.Get(context.Background(), cli, gvr, "ns", "my-snap", obj)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(obj.Name).To(Equal("my-snap"))
-			Expect(obj.Spec.Application).To(Equal("my-app"))
-		})
+		obj := &applicationapiv1alpha1.Snapshot{}
+		err := Get(ctx, nil, gvr, "ns", "target", obj)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(obj.Name).To(Equal("target"))
+		Expect(obj.ResourceVersion).To(Equal("200"))
+		Expect(obj.Spec.Application).To(Equal("latest-app"))
+		Expect(callCount).To(Equal(2))
+	})
+
+	It("returns an error on unexpected HTTP status codes", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte("forbidden"))
+		}))
+		defer server.Close()
+		cleanup := stubHTTPClient(server)
+		defer cleanup()
+
+		obj := &applicationapiv1alpha1.Snapshot{}
+		err := Get(ctx, nil, gvr, "ns", "snap", obj)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("HTTP 403"))
+	})
+
+	It("returns an error on HTTP 500 without the duplicate-resource message", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("internal server error"))
+		}))
+		defer server.Close()
+		cleanup := stubHTTPClient(server)
+		defer cleanup()
+
+		obj := &applicationapiv1alpha1.Snapshot{}
+		err := Get(ctx, nil, gvr, "ns", "snap", obj)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("HTTP 500"))
+	})
+
+	It("returns an error when API URL discovery fails", func() {
+		origDiscover := discoverAPIURLFunc
+		defer func() { discoverAPIURLFunc = origDiscover }()
+
+		discoverAPIURLFunc = func(_ context.Context, _ client.Client) (string, error) {
+			return "", fmt.Errorf("discovery boom")
+		}
+
+		obj := &applicationapiv1alpha1.Snapshot{}
+		err := Get(ctx, nil, gvr, "ns", "snap", obj)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("discovery boom"))
+	})
+
+	It("returns an error when HTTP client creation fails", func() {
+		origDiscover := discoverAPIURLFunc
+		origNewHTTP := newHTTPClientFunc
+		defer func() {
+			discoverAPIURLFunc = origDiscover
+			newHTTPClientFunc = origNewHTTP
+		}()
+
+		discoverAPIURLFunc = func(_ context.Context, _ client.Client) (string, error) {
+			return "https://fake", nil
+		}
+		newHTTPClientFunc = func(_ context.Context, _ client.Client) (*http.Client, error) {
+			return nil, fmt.Errorf("client boom")
+		}
+
+		obj := &applicationapiv1alpha1.Snapshot{}
+		err := Get(ctx, nil, gvr, "ns", "snap", obj)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("client boom"))
 	})
 })
-
-var _ = Describe("NewClient", func() {
-	It("returns a non-nil client", func() {
-		c := NewClient()
-		Expect(c).NotTo(BeNil())
-		Expect(c.resolved).To(BeFalse())
-	})
-})
-
-// compile-time check that *Client satisfies usage with controller-runtime client.Client.
-var _ client.Client = (client.Client)(nil)

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -45,25 +45,23 @@ type ObjectLoader interface {
 	GetProcessingResources(ctx context.Context, cli client.Client, release *v1alpha1.Release) (*ProcessingResources, error)
 }
 
-// KubeArchiveClient is the subset of kubearchive.Client used by the loader,
-// extracted as an interface to allow substitution in tests.
-type KubeArchiveClient interface {
-	Get(ctx context.Context, cli client.Client, gvr schema.GroupVersionResource,
-		namespace, name string, obj client.Object) error
-}
+// KubeArchiveGetFunc is the function signature for retrieving archived
+// resources from KubeArchive, matching kubearchive.Get.
+type KubeArchiveGetFunc func(ctx context.Context, cli client.Client, gvr schema.GroupVersionResource,
+	namespace, name string, obj client.Object) error
 
 type loader struct {
-	kaClient KubeArchiveClient
+	kaGet KubeArchiveGetFunc
 }
 
 func NewLoader() ObjectLoader {
 	return &loader{
-		kaClient: kubearchive.NewClient(),
+		kaGet: kubearchive.Get,
 	}
 }
 
-func newLoader(kaClient KubeArchiveClient) ObjectLoader {
-	return &loader{kaClient: kaClient}
+func newLoader(kaGet KubeArchiveGetFunc) ObjectLoader {
+	return &loader{kaGet: kaGet}
 }
 
 // GetActiveReleasePlanAdmission returns the ReleasePlanAdmission targeted by the given ReleasePlan.
@@ -353,7 +351,7 @@ func (l *loader) GetSnapshot(ctx context.Context, cli client.Client, release *v1
 	snapshot := &applicationapiv1alpha1.Snapshot{}
 	err := toolkit.GetObject(release.Spec.Snapshot, release.Namespace, cli, ctx, snapshot)
 	if err != nil && apierrors.IsNotFound(err) {
-		kaErr := l.kaClient.Get(ctx, cli,
+		kaErr := l.kaGet(ctx, cli,
 			schema.GroupVersionResource{
 				Group:    "appstudio.redhat.com",
 				Version:  "v1alpha1",

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -754,11 +754,9 @@ var _ = Describe("Release Adapter", Ordered, func() {
 
 		It("does not call KubeArchive when the snapshot exists in the cluster", func() {
 			called := false
-			kaLoader := newLoader(&fakeKAClient{
-				getFunc: func(_ context.Context, _ client.Client, _ schema.GroupVersionResource, _, _ string, _ client.Object) error {
-					called = true
-					return fmt.Errorf("should not be called")
-				},
+			kaLoader := newLoader(func(_ context.Context, _ client.Client, _ schema.GroupVersionResource, _, _ string, _ client.Object) error {
+				called = true
+				return fmt.Errorf("should not be called")
 			})
 			returnedObject, err := kaLoader.GetSnapshot(ctx, k8sClient, release)
 			Expect(err).NotTo(HaveOccurred())
@@ -770,14 +768,12 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			missingRelease := release.DeepCopy()
 			missingRelease.Spec.Snapshot = "archived-snapshot"
 
-			kaLoader := newLoader(&fakeKAClient{
-				getFunc: func(_ context.Context, _ client.Client, _ schema.GroupVersionResource, _, _ string, obj client.Object) error {
-					snap := obj.(*applicationapiv1alpha1.Snapshot)
-					snap.Name = "archived-snapshot"
-					snap.Namespace = "default"
-					snap.Spec.Application = "recovered-app"
-					return nil
-				},
+			kaLoader := newLoader(func(_ context.Context, _ client.Client, _ schema.GroupVersionResource, _, _ string, obj client.Object) error {
+				snap := obj.(*applicationapiv1alpha1.Snapshot)
+				snap.Name = "archived-snapshot"
+				snap.Namespace = "default"
+				snap.Spec.Application = "recovered-app"
+				return nil
 			})
 			returnedObject, err := kaLoader.GetSnapshot(ctx, k8sClient, missingRelease)
 			Expect(err).NotTo(HaveOccurred())
@@ -789,10 +785,8 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			missingRelease := release.DeepCopy()
 			missingRelease.Spec.Snapshot = "gone-snapshot"
 
-			kaLoader := newLoader(&fakeKAClient{
-				getFunc: func(_ context.Context, _ client.Client, _ schema.GroupVersionResource, _, _ string, _ client.Object) error {
-					return fmt.Errorf("kubearchive unavailable")
-				},
+			kaLoader := newLoader(func(_ context.Context, _ client.Client, _ schema.GroupVersionResource, _, _ string, _ client.Object) error {
+				return fmt.Errorf("kubearchive unavailable")
 			})
 			_, err := kaLoader.GetSnapshot(ctx, k8sClient, missingRelease)
 			Expect(err).To(HaveOccurred())
@@ -1034,16 +1028,6 @@ var _ = Describe("Release Adapter", Ordered, func() {
 	}
 
 })
-
-type fakeKAClient struct {
-	getFunc func(ctx context.Context, cli client.Client, gvr schema.GroupVersionResource,
-		namespace, name string, obj client.Object) error
-}
-
-func (f *fakeKAClient) Get(ctx context.Context, cli client.Client, gvr schema.GroupVersionResource,
-	namespace, name string, obj client.Object) error {
-	return f.getFunc(ctx, cli, gvr, namespace, name, obj)
-}
 
 var _ = Describe("Loader helpers", func() {
 	Describe("IsRetryableCreationError", func() {


### PR DESCRIPTION
The KubeArchive client was connecting via the external route, which is blocked by the controller's egress NetworkPolicy, causing a 30-second hang followed by silent failure. Switch to the in-cluster service URL (kubearchive-api-server.product-kubearchive.svc.cluster.local:8081), load the OpenShift service-serving CA for TLS verification, and add a 10-second HTTP client timeout.

Remove the Client struct and caching mechanism — discovery and client construction are lightweight and the cache was ineffective since the loader was recreated on every reconciliation.

Add error-level logging on all failure paths so KubeArchive issues are visible in controller logs. Allow egress to the KubeArchive API server on port 8081 in the NetworkPolicy.

Assisted-by: Cursor