### PR TITLE
feat(RELEASE-2422): add AGENTS.md lint check and document key patterns

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -113,6 +113,18 @@ jobs:
           fetch-depth: 0
       - name: Check if dockerimage build is working
         run: docker build -f ./Dockerfile .
+  check-agents-md:
+    name: Check AGENTS.md line count
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Enforce AGENTS.md max 60 lines
+        run: |
+          lines=$(grep -c '.' AGENTS.md)
+          if [ "$lines" -gt 60 ]; then
+            echo "AGENTS.md has $lines non-empty lines (max 60)"
+            exit 1
+          fi
   gitlint:
     name: Run gitlint checks
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,13 +26,10 @@ main.go                # Entry point — registers controllers and webhooks
 ```
 
 ## Architecture
-
 ### Adapter Pattern
-
 Each controller delegates to an **adapter** (`adapter.go`) that holds the K8s client, resource under reconciliation, an `ObjectLoader`, and a `Syncer`. All domain logic lives in adapter methods, not in the controller.
 
 ### Reconciliation Pipeline
-
 The Release controller runs ~20 sequential **operations** via `controller.ReconcileHandler()` from operator-toolkit. Each returns `(OperationResult, error)` — failure requeues, success continues. The pipeline stages are:
 
 1. Finalizer management and config loading
@@ -43,7 +40,6 @@ The Release controller runs ~20 sequential **operations** via `controller.Reconc
 PipelineRuns are watched via `EnqueueRequestForAnnotation` — when a PipelineRun updates, the owning Release is re-reconciled.
 
 ### Resource Loading
-
 `loader.ObjectLoader` centralizes all K8s Gets with error classification (retriable vs permanent) and KubeArchive fallback for deleted resources. A mock implementation exists for tests.
 
 ## Development Guidelines
@@ -58,6 +54,9 @@ PipelineRuns are watched via `EnqueueRequestForAnnotation` — when a PipelineRu
 
 ## Key Patterns
 
+- **Idempotent operations**: every `Ensure*` function starts with gate conditions that skip work already done (e.g. `HasTenantPipelineProcessingFinished()`) or wait for prerequisites (e.g. `HasManagedCollectorsPipelineProcessingFinished()`), making reconciliation safe to re-run at any point
+- **Patching discipline**: status is updated via `client.Status().Patch()` with `client.MergeFrom(a.release.DeepCopy())` only in state-changing operations (marking phases, registering pipeline data) — read-only and tracking operations must not patch
+- **Error handling**: `handlePipelineCreationError` splits errors into retriable (requeue) vs permanent (mark phase failed + **continue**, not stop) — continuing is required so downstream operations can mark their phases as skipped via the `IsFailed()` gate; stopping would hang the release since status-only patches don't trigger `GenerationChangedPredicate`
 - **PipelineRunBuilder** (`tekton/utils/`): fluent API — `.WithParams()`, `.WithWorkspace()`, `.WithPipelineRef()`, `.WithTimeouts()`
 - **Metadata utilities** (`metadata/`): prefix-based label filtering, safe-copy helpers that don't clobber existing keys
 - **Metrics**: registered during reconciliation — `RegisterNewRelease()`, `RegisterCompletedRelease()`, `RegisterValidatedRelease()` with start/completion times


### PR DESCRIPTION
Add CI job to enforce AGENTS.md stays under 60 non-empty lines.
Add error handling, idempotency, and patching discipline to
Key Patterns section in AGENTS.md.

Assisted-by: Claude Code