### PR TITLE
refactor(KONFLUX-14226): allow specifying any author on RPs

### DIFF
--- a/api/v1alpha1/webhooks/author/webhook.go
+++ b/api/v1alpha1/webhooks/author/webhook.go
@@ -92,16 +92,16 @@ func (w *Webhook) handleRelease(req admission.Request) admission.Response {
 		}
 
 		if release.GetLabels()[metadata.AuthorLabel] != oldRelease.GetLabels()[metadata.AuthorLabel] {
-			return admission.Errored(http.StatusBadRequest, errors.New("release author label cannnot be updated"))
+			return admission.Errored(http.StatusBadRequest, errors.New("release author label cannot be updated"))
 		}
 	}
 	return admission.Allowed("Success")
 }
 
 // handleReleasePlan takes an incoming admission request and returns an admission response. If the
-// attribution label is set to true, the current user is set as the author. If the attribution label
-// is false, the author label is removed. The only exception is if the attribution label remains true
-// during an update and the author value is not modified, the previous author label remains.
+// attribution label is set to true and no author is provided, the current user is set as the author.
+// If the attribution label is false, the author label is removed. Finally, if the attribution label
+// is true and an author is provided, no change is made.
 func (w *Webhook) handleReleasePlan(req admission.Request) admission.Response {
 	releasePlan := &v1alpha1.ReleasePlan{}
 	err := json.Unmarshal(req.Object.Raw, releasePlan)
@@ -114,26 +114,10 @@ func (w *Webhook) handleReleasePlan(req admission.Request) admission.Response {
 	}
 
 	switch req.AdmissionRequest.Operation {
-	case admissionv1.Create:
-		if releasePlan.GetLabels()[metadata.AttributionLabel] == "true" {
+	case admissionv1.Create, admissionv1.Update:
+		// Only add the current user as author if attribution is true and no author is provided
+		if releasePlan.GetLabels()[metadata.AttributionLabel] == "true" && releasePlan.GetLabels()[metadata.AuthorLabel] == "" {
 			w.setAuthorLabel(req.UserInfo.Username, releasePlan)
-		}
-	case admissionv1.Update:
-		oldReleasePlan := &v1alpha1.ReleasePlan{}
-		err := json.Unmarshal(req.OldObject.Raw, oldReleasePlan)
-		if err != nil {
-			return admission.Errored(http.StatusBadRequest, errors.Wrap(err, "error decoding object"))
-		}
-
-		if releasePlan.GetLabels()[metadata.AttributionLabel] == "true" {
-			author := releasePlan.GetLabels()[metadata.AuthorLabel]
-
-			if oldReleasePlan.GetLabels()[metadata.AttributionLabel] != "true" || author == w.sanitizeLabelValue(req.UserInfo.Username) {
-				w.setAuthorLabel(req.UserInfo.Username, releasePlan)
-			} else {
-				// Preserve previous author if the new author does not match the user making the change
-				w.setAuthorLabel(oldReleasePlan.GetLabels()[metadata.AuthorLabel], releasePlan)
-			}
 		}
 	}
 

--- a/api/v1alpha1/webhooks/author/webhook_test.go
+++ b/api/v1alpha1/webhooks/author/webhook_test.go
@@ -223,7 +223,7 @@ var _ = Describe("Author webhook", Ordered, func() {
 				Expect(rsp.AdmissionResponse.Allowed).To(BeFalse())
 				Expect(rsp.AdmissionResponse.Result).To(Equal(&metav1.Status{
 					Code:    http.StatusBadRequest,
-					Message: "release author label cannnot be updated",
+					Message: "release author label cannot be updated",
 				}))
 			})
 		})
@@ -271,6 +271,19 @@ var _ = Describe("Author webhook", Ordered, func() {
 				// The json functions replace `/` so checking the entire value does not work
 				Expect(patch.Path).To(ContainSubstring("author"))
 				Expect(patch.Value).To(Equal("admin"))
+			})
+
+			It("should leave user as the value for the author label when attribution is set to true", func() {
+				releasePlan.Labels = map[string]string{
+					metadata.AttributionLabel: "true",
+					metadata.AuthorLabel:      "user",
+				}
+				admissionRequest.Object.Raw, err = json.Marshal(releasePlan)
+				Expect(err).NotTo(HaveOccurred())
+
+				rsp := webhook.Handle(ctx, admissionRequest)
+				Expect(rsp.AdmissionResponse.Allowed).To(BeTrue())
+				Expect(len(rsp.Patches)).To(Equal(0))
 			})
 
 			It("should allow the operation with no patch if the Attribution label is missing", func() {
@@ -328,8 +341,7 @@ var _ = Describe("Author webhook", Ordered, func() {
 					}
 				})
 
-				It("should maintain author value if trying to set it to a different user", func() {
-					previousReleasePlan.Labels[metadata.AuthorLabel] = "admin"
+				It("should set the author to be the provided user", func() {
 					releasePlan.Labels[metadata.AuthorLabel] = "user"
 					admissionRequest.Object.Raw, err = json.Marshal(releasePlan)
 					Expect(err).NotTo(HaveOccurred())
@@ -338,41 +350,23 @@ var _ = Describe("Author webhook", Ordered, func() {
 
 					rsp := webhook.Handle(ctx, admissionRequest)
 					Expect(rsp.AdmissionResponse.Allowed).To(BeTrue())
-					Expect(rsp.AdmissionResponse.Patch).To(BeNil())
+					Expect(len(rsp.Patches)).To(Equal(0))
+				})
+
+				It("should set the author to be the current user if one isn't provided", func() {
+					admissionRequest.Object.Raw, err = json.Marshal(releasePlan)
+					Expect(err).NotTo(HaveOccurred())
+					admissionRequest.OldObject.Raw, err = json.Marshal(previousReleasePlan)
+					Expect(err).NotTo(HaveOccurred())
+
+					rsp := webhook.Handle(ctx, admissionRequest)
+					Expect(rsp.AdmissionResponse.Allowed).To(BeTrue())
 					Expect(len(rsp.Patches)).To(Equal(1))
 					patch := rsp.Patches[0]
-					Expect(patch.Operation).To(Equal("replace"))
+					Expect(patch.Operation).To(Equal("add"))
 					// The json functions replace `/` so checking the entire value does not work
 					Expect(patch.Path).To(ContainSubstring("author"))
 					Expect(patch.Value).To(Equal("admin"))
-				})
-
-				It("should allow the change if author value is not modified", func() {
-					previousReleasePlan.Labels[metadata.AuthorLabel] = "user"
-					releasePlan.Labels[metadata.AuthorLabel] = "user"
-					admissionRequest.Object.Raw, err = json.Marshal(releasePlan)
-					Expect(err).NotTo(HaveOccurred())
-					admissionRequest.OldObject.Raw, err = json.Marshal(previousReleasePlan)
-					Expect(err).NotTo(HaveOccurred())
-
-					rsp := webhook.Handle(ctx, admissionRequest)
-					Expect(rsp.AdmissionResponse.Allowed).To(BeTrue())
-					Expect(rsp.AdmissionResponse.Patch).To(BeNil())
-					Expect(len(rsp.Patches)).To(Equal(0))
-				})
-
-				It("should allow changing the author to the current user", func() {
-					previousReleasePlan.Labels[metadata.AuthorLabel] = "user"
-					releasePlan.Labels[metadata.AuthorLabel] = "admin"
-					admissionRequest.Object.Raw, err = json.Marshal(releasePlan)
-					Expect(err).NotTo(HaveOccurred())
-					admissionRequest.OldObject.Raw, err = json.Marshal(previousReleasePlan)
-					Expect(err).NotTo(HaveOccurred())
-
-					rsp := webhook.Handle(ctx, admissionRequest)
-					Expect(rsp.AdmissionResponse.Allowed).To(BeTrue())
-					Expect(rsp.AdmissionResponse.Patch).To(BeNil())
-					Expect(len(rsp.Patches)).To(Equal(0))
 				})
 			})
 
@@ -415,8 +409,19 @@ var _ = Describe("Author webhook", Ordered, func() {
 					}
 				})
 
-				It("should set the author to be current user if provided different user", func() {
+				It("should set the author to be the provided user", func() {
 					releasePlan.Labels[metadata.AuthorLabel] = "user"
+					admissionRequest.Object.Raw, err = json.Marshal(releasePlan)
+					Expect(err).NotTo(HaveOccurred())
+					admissionRequest.OldObject.Raw, err = json.Marshal(previousReleasePlan)
+					Expect(err).NotTo(HaveOccurred())
+
+					rsp := webhook.Handle(ctx, admissionRequest)
+					Expect(rsp.AdmissionResponse.Allowed).To(BeTrue())
+					Expect(len(rsp.Patches)).To(Equal(0))
+				})
+
+				It("should set the author to be the current user if one isn't provided", func() {
 					admissionRequest.Object.Raw, err = json.Marshal(releasePlan)
 					Expect(err).NotTo(HaveOccurred())
 					admissionRequest.OldObject.Raw, err = json.Marshal(previousReleasePlan)
@@ -426,7 +431,7 @@ var _ = Describe("Author webhook", Ordered, func() {
 					Expect(rsp.AdmissionResponse.Allowed).To(BeTrue())
 					Expect(len(rsp.Patches)).To(Equal(1))
 					patch := rsp.Patches[0]
-					Expect(patch.Operation).To(Equal("replace"))
+					Expect(patch.Operation).To(Equal("add"))
 					// The json functions replace `/` so checking the entire value does not work
 					Expect(patch.Path).To(ContainSubstring("author"))
 					Expect(patch.Value).To(Equal("admin"))


### PR DESCRIPTION
This commit modifies the author webhook to make it so that you can set the author to be someone other than the current user. The piece about whether or not the author label should exist based on the attribution value is unchanged; all this does is remove the part that prevented setting the author to someone other than yourself.

The reason for this is to allow setting actual human authors when using deployment strategies such as ArgoCD.