### PR TITLE
fix(RELEASE-2389): fail Release on invalid git config

### DIFF
--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -2226,6 +2226,40 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(adapter.release.IsFailed()).To(BeTrue())
 			Expect(adapter.release.HasTenantPipelineProcessingFinished()).To(BeTrue())
 		})
+
+		It("should mark tenant pipeline and release as failed when git resolver has empty URL/revision", func() {
+			newReleasePlan := releasePlan.DeepCopy()
+			newReleasePlan.Spec.TenantPipeline = &tektonutils.ParameterizedPipeline{
+				Pipeline: tektonutils.Pipeline{
+					PipelineRef: tektonutils.PipelineRef{
+						Resolver: "git",
+						Params: []tektonutils.Param{
+							{Name: "url", Value: ""},
+							{Name: "revision", Value: ""},
+							{Name: "pathInRepo", Value: ""},
+						},
+					},
+				},
+			}
+
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ReleasePlanContextKey,
+					Resource:   newReleasePlan,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   snapshot,
+				},
+			})
+			adapter.release.MarkManagedCollectorsPipelineProcessingSkipped()
+
+			result, err := adapter.EnsureTenantPipelineIsProcessed()
+			Expect(!result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.release.IsFailed()).To(BeTrue())
+			Expect(adapter.release.HasTenantPipelineProcessingFinished()).To(BeTrue())
+		})
 	})
 
 	When("EnsureReleaseIsValid is called", func() {

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -79,6 +79,7 @@ make test-e2e LABEL=negManagedPipelineRunCreationDenied
 | `release_plan_and_admission` | ReleasePlan ↔ ReleasePlanAdmission matching |
 | `release-neg` | Negative/error scenarios |
 | `negManagedPipelineRunCreationDenied` | Managed release `PipelineRun` create denied by quota; failure is surfaced on `Release` status |
+| `negTenantPipelineInvalidGitRef` | Tenant pipeline with invalid git resolver config (empty URL/revision/pathInRepo); failure is surfaced on `Release` status |
 
 ## Writing Tests
 

--- a/e2e-tests/tests/release/service/invalid_git_config_surfaced.go
+++ b/e2e-tests/tests/release/service/invalid_git_config_surfaced.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"strings"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	meta "k8s.io/apimachinery/pkg/api/meta"
+)
+
+const tenantPipelineRunCreationFailedMsg = "Release processing failed on tenant pipelineRun creation"
+
+// When a ReleasePlan has an invalid git resolver configuration (empty URL/revision),
+// the controller must mark the Release failed and surface a message instead of requeueing forever.
+var _ = ginkgo.Describe("Invalid git config in tenant pipeline is surfaced on Release status", releasecommon.LabelNegTenantPipelineInvalidGitRef, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+
+	var fw *framework.Framework
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+	var err error
+	var devNamespace = "invalid-git-config"
+	var sampleImage = "quay.io/hacbs-release-tests/dcmetromap@sha256:544259be8bcd9e6a2066224b805d854d863064c9b64fa3a87bfcd03f5b0f28e6"
+	var gitSourceURL = constants.GitSourceComponentUrl
+	var gitSourceRevision = "d49914874789147eb2de9bb6a12cd5d150bfff92"
+
+	var releaseCR *releaseApi.Release
+
+	ginkgo.BeforeAll(func() {
+		fw, err = framework.NewFramework(utils.GetGeneratedNamespace(devNamespace))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework: %v", err)
+		devNamespace = fw.UserNamespace
+
+		_, err = fw.AsKubeAdmin.KonfluxApiController.CreateApplication(constants.ApplicationNameDefault, devNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Application %s: %v", constants.ApplicationNameDefault, err)
+
+		invalidTenantPipeline := &tektonutils.ParameterizedPipeline{
+			Pipeline: tektonutils.Pipeline{
+				PipelineRef: tektonutils.PipelineRef{
+					Resolver: "git",
+					Params: []tektonutils.Param{
+						{Name: "url", Value: ""},
+						{Name: "revision", Value: ""},
+						{Name: "pathInRepo", Value: ""},
+					},
+				},
+			},
+		}
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, "", "", nil, invalidTenantPipeline, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", constants.SourceReleasePlanName, err)
+
+		_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithImageSource(constants.ComponentName, constants.ApplicationNameDefault, devNamespace, sampleImage, gitSourceURL, gitSourceRevision, "", "", "", "")
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create Snapshot: %v", err)
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(fw.UserNamespace)).To(gomega.Succeed())
+		}
+	})
+
+	ginkgo.It("marks the Release failed with a clear message when tenant pipeline has invalid git config", func() {
+		gomega.Eventually(func() bool {
+			releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetFirstReleaseInNamespace(devNamespace)
+			if err != nil {
+				return false
+			}
+			if !releaseCR.HasReleaseFinished() || !releaseCR.IsFailed() {
+				return false
+			}
+			cond := meta.FindStatusCondition(releaseCR.Status.Conditions, "Released")
+			if cond == nil {
+				return false
+			}
+			return strings.Contains(cond.Message, tenantPipelineRunCreationFailedMsg)
+		}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.BeTrue(),
+			"expected Release to finish failed with %q on Released condition", tenantPipelineRunCreationFailedMsg)
+	})
+})

--- a/e2e-tests/tests/release/testdata.go
+++ b/e2e-tests/tests/release/testdata.go
@@ -17,6 +17,7 @@ var (
 	LabelNegative                            = ginkgo.Label("release-service", "release-neg", "negMissingReleasePlan")
 	LabelNegBlockReleases                    = ginkgo.Label("release-service", "release-neg", "negBlockReleases")
 	LabelNegManagedPipelineRunCreationDenied = ginkgo.Label("release-service", "release-neg", "negManagedPipelineRunCreationDenied")
+	LabelNegTenantPipelineInvalidGitRef      = ginkgo.Label("release-service", "release-neg", "negTenantPipelineInvalidGitRef")
 	LabelFinal                               = ginkgo.Label("release-service", "final")
 )
 

--- a/git/references.go
+++ b/git/references.go
@@ -17,6 +17,7 @@ limitations under the License.
 package git
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -25,6 +26,14 @@ import (
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// Sentinel errors for git configuration problems that won't resolve on retry.
+var (
+	// ErrInvalidGitResolverConfig indicates the git resolver configuration is invalid (e.g., empty URL or revision).
+	ErrInvalidGitResolverConfig = errors.New("invalid git configuration")
+	// ErrBranchNotFound indicates the specified branch does not exist in the repository.
+	ErrBranchNotFound = errors.New("branch not found")
 )
 
 var shaRegex = regexp.MustCompile("^[a-f0-9]{40}$")
@@ -45,10 +54,29 @@ func isRateLimitError(err error) bool {
 		strings.Contains(errStr, "403")
 }
 
+// ValidateGitResolverConfig validates the git resolver configuration parameters.
+// Returns ErrInvalidGitResolverConfig if any required parameter is empty or whitespace-only.
+func ValidateGitResolverConfig(url, revision, pathInRepo string) error {
+	var missing []string
+	if strings.TrimSpace(url) == "" {
+		missing = append(missing, "url")
+	}
+	if strings.TrimSpace(revision) == "" {
+		missing = append(missing, "revision")
+	}
+	if strings.TrimSpace(pathInRepo) == "" {
+		missing = append(missing, "pathInRepo")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("%w: %s cannot be empty", ErrInvalidGitResolverConfig, strings.Join(missing, ", "))
+	}
+	return nil
+}
+
 // ResolveBranchToSHA resolves a git branch reference to a commit SHA using go-git
 func ResolveBranchToSHA(repoURL, revision string) (string, error) {
 	if repoURL == "" || revision == "" {
-		return "", fmt.Errorf("invalid configuration: repository URL and revision cannot be empty")
+		return "", fmt.Errorf("%w: repository URL and revision cannot be empty", ErrInvalidGitResolverConfig)
 	}
 
 	if IsSHA(revision) {
@@ -97,5 +125,5 @@ func ResolveBranchToSHA(repoURL, revision string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("branch lookup failed: branch '%s' not found in repository", revision)
+	return "", fmt.Errorf("%w: branch '%s' not found in repository", ErrBranchNotFound, revision)
 }

--- a/git/references_test.go
+++ b/git/references_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package git
 
 import (
+	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -80,25 +81,25 @@ var _ = Describe("Git References", func() {
 			Expect(result).To(Equal(sha))
 		})
 
-		It("should return error for empty URL", func() {
+		It("should return ErrInvalidGitResolverConfig for empty URL", func() {
 			_, err := ResolveBranchToSHA("", "main")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("invalid configuration"))
+			Expect(errors.Is(err, ErrInvalidGitResolverConfig)).To(BeTrue(), "error should wrap ErrInvalidGitResolverConfig")
 			Expect(err.Error()).To(ContainSubstring("repository URL and revision cannot be empty"))
 		})
 
-		It("should return error for empty revision", func() {
+		It("should return ErrInvalidGitResolverConfig for empty revision", func() {
 			_, err := ResolveBranchToSHA("https://github.com/org/repo.git", "")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("invalid configuration"))
+			Expect(errors.Is(err, ErrInvalidGitResolverConfig)).To(BeTrue(), "error should wrap ErrInvalidGitResolverConfig")
 			Expect(err.Error()).To(ContainSubstring("repository URL and revision cannot be empty"))
 		})
 
-		It("should return error for branch not found in repository", func() {
+		It("should return ErrBranchNotFound for branch not found in repository", func() {
 			// Use a real public repository but with a non-existent branch
 			_, err := ResolveBranchToSHA("https://github.com/octocat/Hello-World.git", "nonexistent-branch-xyz")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("branch lookup failed"))
+			Expect(errors.Is(err, ErrBranchNotFound)).To(BeTrue(), "error should wrap ErrBranchNotFound")
 			Expect(err.Error()).To(ContainSubstring("branch 'nonexistent-branch-xyz' not found"))
 		})
 
@@ -116,6 +117,37 @@ var _ = Describe("Git References", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resolvedSHA).NotTo(BeEmpty())
 			Expect(IsSHA(resolvedSHA)).To(BeTrue())
+		})
+	})
+
+	Describe("ValidateGitResolverConfig", func() {
+		It("should return nil for valid configuration", func() {
+			err := ValidateGitResolverConfig("https://github.com/org/repo", "main", "pipelines/release.yaml")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return ErrInvalidGitResolverConfig for empty URL", func() {
+			err := ValidateGitResolverConfig("", "main", "pipelines/release.yaml")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrInvalidGitResolverConfig)).To(BeTrue())
+		})
+
+		It("should return ErrInvalidGitResolverConfig for empty revision", func() {
+			err := ValidateGitResolverConfig("https://github.com/org/repo", "", "pipelines/release.yaml")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrInvalidGitResolverConfig)).To(BeTrue())
+		})
+
+		It("should return ErrInvalidGitResolverConfig for empty pathInRepo", func() {
+			err := ValidateGitResolverConfig("https://github.com/org/repo", "main", "")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrInvalidGitResolverConfig)).To(BeTrue())
+		})
+
+		It("should return ErrInvalidGitResolverConfig when all params are empty", func() {
+			err := ValidateGitResolverConfig("", "", "")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrInvalidGitResolverConfig)).To(BeTrue())
 		})
 	})
 })

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/git"
 	"github.com/konflux-ci/release-service/kubearchive"
 	"github.com/konflux-ci/release-service/metadata"
 )
@@ -408,13 +409,29 @@ func (l *loader) GetProcessingResources(ctx context.Context, cli client.Client, 
 	return resources, nil
 }
 
+// isInvalidGitConfigError checks if the error is a permanent git configuration error
+// that won't resolve on retry (e.g., empty URL/revision, non-existent branch).
+// Uses errors.Is() for type-safe detection of sentinel errors from git package.
+func isInvalidGitConfigError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, git.ErrInvalidGitResolverConfig) || errors.Is(err, git.ErrBranchNotFound)
+}
+
 // IsRetryableCreationError returns true if the error is transient and the creation should be
 // retried. Returns false for known permanent failures (e.g. admission webhook denial, invalid
-// resource spec, insufficient RBAC) that will not resolve on retry.
+// resource spec, insufficient RBAC, invalid git configuration) that will not resolve on retry.
 func IsRetryableCreationError(err error) bool {
 	if err == nil {
 		return false
 	}
+
+	// Git configuration errors are permanent and won't resolve on retry
+	if isInvalidGitConfigError(err) {
+		return false
+	}
+
 	return !apierrors.IsBadRequest(err) &&
 		!apierrors.IsInvalid(err) &&
 		!apierrors.IsForbidden(err) &&

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -13,6 +13,7 @@ import (
 	ecapiv1alpha1 "github.com/conforma/crds/api/v1alpha1"
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/git"
 	"github.com/konflux-ci/release-service/metadata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1045,6 +1046,10 @@ var _ = Describe("Loader helpers", func() {
 			Entry("unauthorized", errors.NewUnauthorized("not authorized")),
 			Entry("method not supported", errors.NewMethodNotSupported(schema.GroupResource{}, "patch")),
 			Entry("request entity too large", errors.NewRequestEntityTooLargeError("payload too large")),
+			Entry("git invalid config (empty URL/revision)",
+				fmt.Errorf("git resolution failed: %w: repository URL and revision cannot be empty", git.ErrInvalidGitResolverConfig)),
+			Entry("git branch not found",
+				fmt.Errorf("git resolution failed: %w: branch 'nonexistent' not found in repository", git.ErrBranchNotFound)),
 		)
 
 		DescribeTable("should return true for transient / retriable errors",
@@ -1056,10 +1061,46 @@ var _ = Describe("Loader helpers", func() {
 			Entry("service unavailable", errors.NewServiceUnavailable("service unavailable")),
 			Entry("too many requests", errors.NewTooManyRequests("throttled", 1)),
 			Entry("internal server error", errors.NewInternalError(fmt.Errorf("internal"))),
+			Entry("git remote access failed (transient network issue)",
+				fmt.Errorf("remote repository access failed: connection timeout")),
 		)
 
 		It("should return true for an unknown non-API error", func() {
 			Expect(IsRetryableCreationError(fmt.Errorf("some unexpected error"))).To(BeTrue())
 		})
+	})
+
+	Describe("isInvalidGitConfigError", func() {
+		It("should return false for nil error", func() {
+			Expect(isInvalidGitConfigError(nil)).To(BeFalse())
+		})
+
+		DescribeTable("should return true for permanent git configuration errors",
+			func(err error) {
+				Expect(isInvalidGitConfigError(err)).To(BeTrue())
+			},
+			Entry("ErrInvalidGitResolverConfig directly",
+				git.ErrInvalidGitResolverConfig),
+			Entry("ErrBranchNotFound directly",
+				git.ErrBranchNotFound),
+			Entry("wrapped ErrInvalidGitResolverConfig",
+				fmt.Errorf("git resolution failed: %w: repository URL and revision cannot be empty", git.ErrInvalidGitResolverConfig)),
+			Entry("wrapped ErrBranchNotFound",
+				fmt.Errorf("git resolution failed: %w: branch 'main' not found", git.ErrBranchNotFound)),
+			Entry("deeply wrapped ErrInvalidGitResolverConfig",
+				fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", git.ErrInvalidGitResolverConfig))),
+		)
+
+		DescribeTable("should return false for transient or unrelated errors",
+			func(err error) {
+				Expect(isInvalidGitConfigError(err)).To(BeFalse())
+			},
+			Entry("remote access failed (transient)",
+				fmt.Errorf("remote repository access failed: connection timeout")),
+			Entry("unrelated error",
+				fmt.Errorf("some random error")),
+			Entry("similar message but not sentinel error",
+				fmt.Errorf("invalid git configuration: something")),
+		)
 	})
 })

--- a/tekton/utils/pipeline_run_builder.go
+++ b/tekton/utils/pipeline_run_builder.go
@@ -218,7 +218,7 @@ func (b *PipelineRunBuilder) WithPipelineRef(pipelineRef *tektonv1.PipelineRef) 
 	b.pipelineRun.Spec.PipelineRef = pipelineRef
 
 	if pipelineRef != nil && pipelineRef.ResolverRef.Resolver == "git" {
-		var gitURL, revision string
+		var gitURL, revision, pathInRepo string
 
 		for _, param := range pipelineRef.ResolverRef.Params {
 			switch param.Name {
@@ -226,7 +226,14 @@ func (b *PipelineRunBuilder) WithPipelineRef(pipelineRef *tektonv1.PipelineRef) 
 				gitURL = param.Value.StringVal
 			case "revision":
 				revision = param.Value.StringVal
+			case "pathInRepo":
+				pathInRepo = param.Value.StringVal
 			}
+		}
+
+		if err := git.ValidateGitResolverConfig(gitURL, revision, pathInRepo); err != nil {
+			b.err = multierror.Append(b.err, fmt.Errorf("git resolution failed: %w", err))
+			return b
 		}
 
 		resolvedSHA, err := git.ResolveBranchToSHA(gitURL, revision)

--- a/tekton/utils/pipeline_run_builder_test.go
+++ b/tekton/utils/pipeline_run_builder_test.go
@@ -377,6 +377,10 @@ var _ = Describe("PipelineRun builder", func() {
 						Name:  "revision",
 						Value: "master",
 					},
+					{
+						Name:  "pathInRepo",
+						Value: "pipelines/release.yaml",
+					},
 				},
 			}
 
@@ -402,6 +406,10 @@ var _ = Describe("PipelineRun builder", func() {
 					{
 						Name:  "revision",
 						Value: originalSHA,
+					},
+					{
+						Name:  "pathInRepo",
+						Value: "pipelines/release.yaml",
 					},
 				},
 			}
@@ -433,6 +441,10 @@ var _ = Describe("PipelineRun builder", func() {
 					{
 						Name:  "revision",
 						Value: originalSHA,
+					},
+					{
+						Name:  "pathInRepo",
+						Value: "pipelines/release.yaml",
 					},
 				},
 			}
@@ -467,6 +479,10 @@ var _ = Describe("PipelineRun builder", func() {
 						Name:  "revision",
 						Value: nonExistentBranch,
 					},
+					{
+						Name:  "pathInRepo",
+						Value: "pipelines/release.yaml",
+					},
 				},
 			}
 
@@ -475,7 +491,7 @@ var _ = Describe("PipelineRun builder", func() {
 			_, err := builder.Build()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("git resolution failed"))
-			Expect(err.Error()).To(ContainSubstring("branch lookup failed"))
+			Expect(err.Error()).To(ContainSubstring("branch not found"))
 		})
 
 		It("fails fast when repository URL is invalid", func() {


### PR DESCRIPTION
## Describe your changes
Releases with invalid tenantPipeline git configuration (empty URL/revision or non-existent branch) were stuck "In Progress" indefinitely because git resolution errors weren't recognized as permanent failures.

This fix extends IsRetryableCreationError to classify git configuration errors as non-retriable, leveraging the existing handlePipelineCreationError machinery from [#1398](https://github.com/konflux-ci/release-service/pull/1398)  ([KONFLUX-12127](https://redhat.atlassian.net/browse/KONFLUX-12127)). Now these releases fail immediately with a clear error message instead of retrying forever.

## Relevant Jira
[RELEASE-2389](https://redhat.atlassian.net/browse/RELEASE-2389)

[KONFLUX-12127]: https://redhat.atlassian.net/browse/KONFLUX-12127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RELEASE-2389]: https://redhat.atlassian.net/browse/RELEASE-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ