### PR TITLE
fix(RELEASE-2677): keep RSC mitigations when RPA overrides maxRetries

### DIFF
--- a/controllers/utils/retry/matcher.go
+++ b/controllers/utils/retry/matcher.go
@@ -48,18 +48,11 @@ func DetermineRetryInfo(rpa *v1alpha1.ReleasePlanAdmission, matchedRPs *v1alpha1
 		}
 	}
 
-	// Check if retries are explicitly overridden by RPA pipeline
-	if rpa.Spec.Pipeline.MaxRetries != nil {
-		if *rpa.Spec.Pipeline.MaxRetries == 0 {
-			return &v1alpha1.RetryInfo{
-				Enabled: false,
-				Reason:  "retries disabled by RPA pipeline override",
-			}
-		}
+	// Check if retries are explicitly disabled by RPA pipeline
+	if rpa.Spec.Pipeline.MaxRetries != nil && *rpa.Spec.Pipeline.MaxRetries == 0 {
 		return &v1alpha1.RetryInfo{
-			Enabled:    true,
-			MaxRetries: rpa.Spec.Pipeline.MaxRetries,
-			Reason:     "retries enabled by RPA pipeline override",
+			Enabled: false,
+			Reason:  "retries disabled by RPA pipeline override",
 		}
 	}
 
@@ -99,7 +92,17 @@ func DetermineRetryInfo(rpa *v1alpha1.ReleasePlanAdmission, matchedRPs *v1alpha1
 		}
 	}
 
-	// Retries enabled by RSC policy
+	// RPA can override the retry count but mitigations always come from the RSC
+	if rpa.Spec.Pipeline.MaxRetries != nil {
+		maxRetries := *rpa.Spec.Pipeline.MaxRetries
+		return &v1alpha1.RetryInfo{
+			Enabled:     true,
+			MaxRetries:  &maxRetries,
+			Mitigations: matchedRetryable.RetryPolicy.Mitigations,
+			Reason:      "retries enabled by RPA pipeline override",
+		}
+	}
+
 	maxRetries := matchedRetryable.RetryPolicy.MaxRetries
 	return &v1alpha1.RetryInfo{
 		Enabled:     true,

--- a/controllers/utils/retry/matcher_test.go
+++ b/controllers/utils/retry/matcher_test.go
@@ -506,7 +506,7 @@ var _ = Describe("Retry Matcher", func() {
 			Expect(retryInfo.Reason).To(Equal("retries disabled by RPA pipeline override"))
 		})
 
-		It("should return enabled when RPA pipeline MaxRetries is non-zero", func() {
+		It("should use RPA maxRetries but keep mitigations from RSC", func() {
 			maxRetries := 5
 			rpa := createTestRPA(
 				"https://github.com/org/repo",
@@ -525,6 +525,9 @@ var _ = Describe("Retry Matcher", func() {
 							PathInRepo: "pipelines/release.yaml",
 							RetryPolicy: v1alpha1.RetryPolicy{
 								MaxRetries: 3,
+								Mitigations: &v1alpha1.Mitigations{
+									OOMKill: &v1alpha1.MemoryMitigation{Multiplier: "2"},
+								},
 							},
 						},
 					},
@@ -533,12 +536,13 @@ var _ = Describe("Retry Matcher", func() {
 
 			retryInfo := retry.DetermineRetryInfo(rpa, &v1alpha1.ReleasePlanList{}, rsc, &logger)
 			Expect(retryInfo.Enabled).To(BeTrue())
-			Expect(retryInfo.MaxRetries).ToNot(BeNil())
 			Expect(*retryInfo.MaxRetries).To(Equal(5))
+			Expect(retryInfo.Mitigations).NotTo(BeNil())
+			Expect(retryInfo.Mitigations.OOMKill.Multiplier).To(Equal("2"))
 			Expect(retryInfo.Reason).To(Equal("retries enabled by RPA pipeline override"))
 		})
 
-		It("should enable retries with RPA override even when pipeline doesn't match RSC", func() {
+		It("should not enable retries with RPA override when pipeline doesn't match RSC", func() {
 			maxRetries := 2
 			rpa := createTestRPA(
 				"https://github.com/org/repo",
@@ -563,11 +567,10 @@ var _ = Describe("Retry Matcher", func() {
 				},
 			}
 
+			// pipeline must match the RSC to get mitigations, RPA only overrides the count
 			retryInfo := retry.DetermineRetryInfo(rpa, &v1alpha1.ReleasePlanList{}, rsc, &logger)
-			Expect(retryInfo.Enabled).To(BeTrue())
-			Expect(retryInfo.MaxRetries).ToNot(BeNil())
-			Expect(*retryInfo.MaxRetries).To(Equal(2))
-			Expect(retryInfo.Reason).To(Equal("retries enabled by RPA pipeline override"))
+			Expect(retryInfo.Enabled).To(BeFalse())
+			Expect(retryInfo.Reason).To(Equal("pipeline not configured for retries"))
 		})
 	})
 })


### PR DESCRIPTION
When the RPA sets spec.pipeline.maxRetries. DetermineRetryInfo was returning without matching against the RSC. This meant retries happened but with no mitigations added.

Now the RPA override only changes the retry count. The pipeline must still match an RSC retryable to get mitigations else it will be "pipeline not configured for retries"

Jira: https://redhat.atlassian.net/browse/RELEASE-2677

Assisted-by: Claude