### PR TITLE
feat(RELEASE-2633): add one-command build/setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,14 @@ help: ## Display this help.
 
 ##@ Development
 
+.PHONY: deps
+deps: ## Download Go module dependencies
+	go mod download
+
+.PHONY: setup
+setup: deps manifests generate fmt vet ## Set up development environment from fresh clone
+	@echo "Development environment ready. Run 'make test' to verify."
+
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ Release service is a Kubernetes operator to control the life cycle of Konflux-ma
 
 ## Development
 
-All development tasks use the [Makefile](Makefile):
+All development tasks use the [Makefile](Makefile).
+
+**Setup from fresh clone**:
+```shell
+$ make setup  # One command to set up development environment
+$ make test   # Run tests to verify setup
+```
 
 **Run locally** (e.g., CRC cluster):
 ```shell


### PR DESCRIPTION
Single command to set up development environment from fresh clone.
Depends on https://github.com/konflux-ci/release-service/pull/1745.

Signed-off-by: David Moreno García <damoreno@redhat.com>
Generated-by: Claude