### PR TITLE
chore(RELEASE-2568): add linter configs and CI quality gates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,21 +7,27 @@ assignees: ''
 ---
 
 ## Describe the bug
+
 A clear description of what the bug is.
 
 ## To Reproduce
+
 Steps to reproduce the behavior:
+
 1. Apply CRD '...'
 2. Create Release '...'
 3. Observe error '...'
 
 ## Expected behavior
+
 What you expected to happen.
 
 ## Environment
+
 - Kubernetes version:
 - Release Service version:
 - Operator deployment method:
 
 ## Additional context
+
 Add any other context about the problem (logs, screenshots, etc.)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,13 +7,17 @@ assignees: ''
 ---
 
 ## Is your feature request related to a problem?
+
 A clear description of what the problem is. Ex. I'm always frustrated when [...]
 
 ## Describe the solution you'd like
+
 A clear description of what you want to happen.
 
 ## Describe alternatives you've considered
+
 Other solutions or features you've considered.
 
 ## Additional context
+
 Add any other context, screenshots, or examples about the feature request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,19 @@
 ## Summary
+
 <!-- Describe the changes in this PR -->
 
 ## Related Issues
+
 Fixes #
 
 ## Testing
+
 - [ ] Tests added/updated
 - [ ] All tests pass (`make test`)
 - [ ] Changes verified locally
 
 ## Checklist
+
 - [ ] Code follows Kubernetes coding conventions
 - [ ] Commit messages follow conventional format: `type(RELEASE-NNNN): description`
 - [ ] Documentation updated if needed

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -154,3 +154,23 @@ jobs:
       - uses: konflux-ci/renovate-config-validator-action@715fae6ea7b656ccefead2dec09ee41d395bee6d # main
         with:
           config_file: .github/renovate.json
+  golangci-lint:
+    name: Run golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+  markdownlint:
+    name: Run markdownlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe # v24.1.0
+        with:
+          globs: '**/*.md'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,43 @@
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - misspell
+    - unconvert
+    - unparam
+  settings:
+    staticcheck:
+      checks:
+        - "all"
+        - "-QF*"
+        - "-ST1000"
+        - "-ST1003"
+  exclusions:
+    rules:
+      - path: "_test\\.go"
+        linters:
+          - errcheck
+          - unparam
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/konflux-ci/release-service
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,11 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD014": false,
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD033": false,
+  "MD041": false,
+  "MD060": false
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Release Service is a Kubernetes operator that orchestrates software release pipe
 
 ## Technology Stack
 
-- **Language**: Go 
+- **Language**: Go
 - **Framework:** controller-runtime
 - **CRDs**: Release, ReleasePlan, ReleasePlanAdmission, ReleaseServiceConfig
 - **Pipeline engine**: Tekton PipelineRuns
@@ -13,7 +13,7 @@ Release Service is a Kubernetes operator that orchestrates software release pipe
 
 ## Repository Structure
 
-```
+```text
 api/v1alpha1/          # CRD types and webhooks
 controllers/           # Reconcilers: release/, releaseplan/, releaseplanadmission/
 loader/                # ObjectLoader interface — abstracts K8s resource fetching
@@ -27,10 +27,13 @@ main.go                # Entry point — registers controllers and webhooks
 ```
 
 ## Architecture
+
 ### Adapter Pattern
+
 Each controller delegates to an **adapter** (`adapter.go`) that holds the K8s client, resource under reconciliation, an `ObjectLoader`, and a `Syncer`. All domain logic lives in adapter methods, not in the controller.
 
 ### Reconciliation Pipeline
+
 The Release controller runs ~20 sequential **operations** via `controller.ReconcileHandler()` from operator-toolkit. Each returns `(OperationResult, error)` — failure requeues, success continues. The pipeline stages are:
 
 1. Finalizer management and config loading
@@ -41,6 +44,7 @@ The Release controller runs ~20 sequential **operations** via `controller.Reconc
 PipelineRuns are watched via `EnqueueRequestForAnnotation` — when a PipelineRun updates, the owning Release is re-reconciled.
 
 ### Resource Loading
+
 `loader.ObjectLoader` centralizes all K8s Gets with error classification (retriable vs permanent) and KubeArchive fallback for deleted resources. A mock implementation exists for tests.
 
 ## Development Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,10 @@ Once it’s filed:
 
 Enhancement suggestions are tracked as [GitHub issues](/issues).
 
-- Use a **clear and descriptive title** for the issue to identify the suggestion.
-- Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
-- Describe the current behavior, the expected one, and why you expect this behavior. At this point you can also list which alternatives do not work for you.
-- **Explain why this enhancement would be useful** to other users. You may also want to point out the other projects that solved it better and could serve as inspiration.
+* Use a **clear and descriptive title** for the issue to identify the suggestion.
+* Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
+* Describe the current behavior, the expected one, and why you expect this behavior. At this point you can also list which alternatives do not work for you.
+* **Explain why this enhancement would be useful** to other users. You may also want to point out the other projects that solved it better and could serve as inspiration.
 
 ## Submitting changes
 
@@ -54,7 +54,7 @@ The commit message should contain an overall explanation about the change and th
 
 A well formatted commit would look something like this:
 
-```
+```text
 feat(issue-id): what this commit does
 
 Overall explanation of what this commit is achieving and the motivation behind it.
@@ -81,7 +81,7 @@ Before a pull request can be merged:
 
 Tests are written using the *[Ginkgo](https://onsi.github.io/ginkgo/)* framework. Here are some general advices when writing tests:
 
-* When the global `Describe` doesn't add enough context to the tests, use a nested `Describe` or a `Context` to specify what this test alludes to. Contexts should always start with _When_ (ie. "_When calling the function Foo_")
+* When the global `Describe` doesn't add enough context to the tests, use a nested `Describe` or a `Context` to specify what this test alludes to. Contexts should always start with *When* (ie. "*When calling the function Foo*")
 * Start the descriptions of `It` blocks in lowercase and try to be as descriptive as possible
 * Avoid ignoring errors. In other words, make sure all of them are caught and tested
 * Files ending with `_suite_test.go` are meant to store the code that is common for tests in the same directory and that will be executed before them. Use these files only if your test setup is big enough to justify it (ie. the suite file has more than the test suite name and the teardown)
@@ -89,7 +89,7 @@ Tests are written using the *[Ginkgo](https://onsi.github.io/ginkgo/)* framework
 * After `Create()` or `Update()` objects, use `Get()` before making assurances as the object might be outdated. It is useful after `Delete()` to check if the client returns `errors.IsNotFound`
 * Some assurances are likely to require usage of `Eventually` blocks instead of or in addition to `Expect` blocks
 
-### Useful links:
+### Useful links
 
 Links that may be used as a starting point:
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,21 @@ Release service is a Kubernetes operator to control the life cycle of Konflux-ma
 All development tasks use the [Makefile](Makefile).
 
 **Setup from fresh clone**:
+
 ```shell
 $ make setup  # One command to set up development environment
 $ make test   # Run tests to verify setup
 ```
 
 **Run locally** (e.g., CRC cluster):
+
 ```shell
 $ make manifests generate  # After code changes
 $ make run install
 ```
 
 **Build and push image**:
+
 ```shell
 $ make docker-build docker-push
 $ TAG_NAME=my-tag make docker-build docker-push  # Custom tag
@@ -26,11 +29,13 @@ $ IMG=quay.io/user/release:my-tag make docker-build docker-push  # Custom repo
 ```
 
 **Run tests**:
+
 ```shell
 $ make test  # Includes coverage report
 ```
 
 **Disable webhooks** (local development):
+
 ```shell
 $ ENABLE_WEBHOOKS=false make run install
 ```

--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -21,9 +21,10 @@ import (
 
 	"github.com/konflux-ci/operator-toolkit/conditions"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/konflux-ci/release-service/metadata"
 	"github.com/konflux-ci/release-service/metrics"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/api/v1alpha1/releaseplan_types.go
+++ b/api/v1alpha1/releaseplan_types.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 
 	"github.com/konflux-ci/operator-toolkit/conditions"
-	"github.com/konflux-ci/release-service/metadata"
-	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/konflux-ci/release-service/metadata"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 )
 
 // ReleasePlanSpec defines the desired state of ReleasePlan.

--- a/api/v1alpha1/releaseplan_types_test.go
+++ b/api/v1alpha1/releaseplan_types_test.go
@@ -19,9 +19,10 @@ package v1alpha1
 import (
 	"time"
 
-	"github.com/konflux-ci/release-service/metadata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/release-service/metadata"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/api/v1alpha1/releaseplanadmission_types.go
+++ b/api/v1alpha1/releaseplanadmission_types.go
@@ -22,11 +22,12 @@ import (
 	"sort"
 
 	"github.com/konflux-ci/operator-toolkit/conditions"
-	"github.com/konflux-ci/release-service/metadata"
-	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/konflux-ci/release-service/metadata"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 )
 
 // ReleasePlanAdmissionSpec defines the desired state of ReleasePlanAdmission.

--- a/api/v1alpha1/releaseplanadmission_types_test.go
+++ b/api/v1alpha1/releaseplanadmission_types_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/konflux-ci/release-service/metadata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/release-service/metadata"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/api/v1alpha1/releaseserviceconfig_types.go
+++ b/api/v1alpha1/releaseserviceconfig_types.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"regexp"
+
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"regexp"
 )
 
 const ReleaseServiceConfigResourceName string = "release-service-config"

--- a/api/v1alpha1/suite_test.go
+++ b/api/v1alpha1/suite_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package v1alpha1
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"path/filepath"
 	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"

--- a/api/v1alpha1/webhooks/author/suite_test.go
+++ b/api/v1alpha1/webhooks/author/suite_test.go
@@ -25,9 +25,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/konflux-ci/release-service/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	crwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/api/v1alpha1/webhooks/author/webhook.go
+++ b/api/v1alpha1/webhooks/author/webhook.go
@@ -24,16 +24,18 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/konflux-ci/release-service/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlWebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+
 	"github.com/go-logr/logr"
-	"github.com/konflux-ci/release-service/metadata"
 	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admission/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/konflux-ci/release-service/metadata"
 )
 
 // Webhook describes the data structure for the author webhook
@@ -151,7 +153,7 @@ func (w *Webhook) sanitizeLabelValue(username string) string {
 	author = strings.Replace(author, "@", ".", 1)     // At sign is disallowed. Support usernames that uses email address.
 
 	if len(author) > metadata.MaxLabelLength {
-		author = string(author)[0:metadata.MaxLabelLength]
+		author = author[0:metadata.MaxLabelLength]
 	}
 
 	// Ensure author ends with an alphanumeric character

--- a/api/v1alpha1/webhooks/author/webhook_test.go
+++ b/api/v1alpha1/webhooks/author/webhook_test.go
@@ -21,10 +21,11 @@ import (
 
 	"github.com/konflux-ci/release-service/api/v1alpha1"
 
-	"github.com/konflux-ci/release-service/metadata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/konflux-ci/release-service/metadata"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/api/v1alpha1/webhooks/release/suite_test.go
+++ b/api/v1alpha1/webhooks/release/suite_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	toolkit "github.com/konflux-ci/operator-toolkit/webhook"
+
 	"github.com/konflux-ci/release-service/api/v1alpha1"
 	"github.com/konflux-ci/release-service/api/v1alpha1/webhooks/author"
 

--- a/api/v1alpha1/webhooks/release/webhook.go
+++ b/api/v1alpha1/webhooks/release/webhook.go
@@ -25,11 +25,12 @@ import (
 	"github.com/konflux-ci/release-service/metadata"
 
 	"github.com/go-logr/logr"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
 )
 
 // Webhook describes the data structure for the release webhook

--- a/api/v1alpha1/webhooks/release/webhook_test.go
+++ b/api/v1alpha1/webhooks/release/webhook_test.go
@@ -19,11 +19,12 @@ import (
 	"context"
 
 	toolkit "github.com/konflux-ci/operator-toolkit/loader"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/konflux-ci/release-service/api/v1alpha1"
 	"github.com/konflux-ci/release-service/loader"
 	"github.com/konflux-ci/release-service/metadata"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/api/v1alpha1/webhooks/releaseplan/suite_test.go
+++ b/api/v1alpha1/webhooks/releaseplan/suite_test.go
@@ -26,10 +26,11 @@ import (
 	"time"
 
 	toolkit "github.com/konflux-ci/operator-toolkit/webhook"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/api/v1alpha1/webhooks/author"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	crwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/api/v1alpha1/webhooks/author"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/api/v1alpha1/webhooks/releaseplan/webhook.go
+++ b/api/v1alpha1/webhooks/releaseplan/webhook.go
@@ -20,11 +20,12 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/metadata"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/metadata"
 )
 
 // Webhook describes the data structure for the bar webhook

--- a/api/v1alpha1/webhooks/releaseplan/webhook_test.go
+++ b/api/v1alpha1/webhooks/releaseplan/webhook_test.go
@@ -16,9 +16,10 @@
 package releaseplan
 
 import (
-	"github.com/konflux-ci/release-service/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/api/v1alpha1/webhooks/releaseplanadmission/suite_test.go
+++ b/api/v1alpha1/webhooks/releaseplanadmission/suite_test.go
@@ -26,10 +26,11 @@ import (
 	"time"
 
 	toolkit "github.com/konflux-ci/operator-toolkit/webhook"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/api/v1alpha1/webhooks/author"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	crwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/api/v1alpha1/webhooks/author"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/api/v1alpha1/webhooks/releaseplanadmission/webhook.go
+++ b/api/v1alpha1/webhooks/releaseplanadmission/webhook.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/metadata"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/metadata"
 )
 
 // Webhook describes the data structure for the bar webhook

--- a/api/v1alpha1/webhooks/releaseplanadmission/webhook_test.go
+++ b/api/v1alpha1/webhooks/releaseplanadmission/webhook_test.go
@@ -16,12 +16,13 @@
 package releaseplanadmission
 
 import (
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 
 	"github.com/konflux-ci/release-service/metadata"
 

--- a/api/v1alpha1/webhooks/webhooks.go
+++ b/api/v1alpha1/webhooks/webhooks.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"github.com/konflux-ci/operator-toolkit/webhook"
+
 	"github.com/konflux-ci/release-service/api/v1alpha1/webhooks/author"
 	"github.com/konflux-ci/release-service/api/v1alpha1/webhooks/release"
 	"github.com/konflux-ci/release-service/api/v1alpha1/webhooks/releaseplan"

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -20,9 +20,10 @@ import (
 	"context"
 
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
 )
 
 // SetupComponentCache adds a new index field to be able to search Components by application.

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"github.com/konflux-ci/operator-toolkit/controller"
+
 	"github.com/konflux-ci/release-service/controllers/release"
 	"github.com/konflux-ci/release-service/controllers/releaseplan"
 	"github.com/konflux-ci/release-service/controllers/releaseplanadmission"

--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -31,14 +31,6 @@ import (
 	integrationgitops "github.com/konflux-ci/integration-service/gitops"
 	"github.com/konflux-ci/operator-toolkit/controller"
 	toolkitmetadata "github.com/konflux-ci/operator-toolkit/metadata"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/loader"
-	"github.com/konflux-ci/release-service/metadata"
-	"github.com/konflux-ci/release-service/retry"
-	"github.com/konflux-ci/release-service/syncer"
-	"github.com/konflux-ci/release-service/tekton"
-	"github.com/konflux-ci/release-service/tekton/utils"
-	"github.com/konflux-ci/release-service/tracing"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -51,6 +43,15 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/loader"
+	"github.com/konflux-ci/release-service/metadata"
+	"github.com/konflux-ci/release-service/retry"
+	"github.com/konflux-ci/release-service/syncer"
+	"github.com/konflux-ci/release-service/tekton"
+	"github.com/konflux-ci/release-service/tekton/utils"
+	"github.com/konflux-ci/release-service/tracing"
 )
 
 // adapter holds the objects needed to reconcile a Release.
@@ -2443,7 +2444,7 @@ func (a *adapter) getTaskRunLogs(taskRun *tektonv1.TaskRun) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to stream pod logs: %w", err)
 	}
-	defer stream.Close()
+	defer func() { _ = stream.Close() }()
 
 	logs, err := io.ReadAll(stream)
 	if err != nil {

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -31,9 +31,6 @@ import (
 
 	"github.com/konflux-ci/operator-toolkit/controller"
 	toolkit "github.com/konflux-ci/operator-toolkit/loader"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/loader"
-	"github.com/konflux-ci/release-service/metadata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/operator-lib/handler"
@@ -44,6 +41,10 @@ import (
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/loader"
+	"github.com/konflux-ci/release-service/metadata"
 
 	ecapiv1alpha1 "github.com/conforma/crds/api/v1alpha1"
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
@@ -4852,8 +4853,8 @@ var _ = Describe("Release adapter", Ordered, func() {
 
 			bundle := enterpriseContractConfigMap.Data["verify_ec_task_bundle"]
 			revision := enterpriseContractConfigMap.Data["verify_ec_task_git_revision"]
-			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", Equal(string(bundle)))))
-			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", Equal(string(revision)))))
+			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", Equal(bundle))))
+			Expect(pipelineRun.Spec.Params).Should(ContainElement(HaveField("Value.StringVal", Equal(revision))))
 		})
 
 		It("passes ociStorage param from ReleasePlanAdmission to PipelineRun", func() {

--- a/controllers/release/controller.go
+++ b/controllers/release/controller.go
@@ -25,10 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/go-logr/logr"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/cache"
-	"github.com/konflux-ci/release-service/loader"
-	"github.com/konflux-ci/release-service/tekton"
 	libhandler "github.com/operator-framework/operator-lib/handler"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,6 +33,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	sigsctrl "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/cache"
+	"github.com/konflux-ci/release-service/loader"
+	"github.com/konflux-ci/release-service/tekton"
 )
 
 // Controller reconciles a Release object

--- a/controllers/release/suite_test.go
+++ b/controllers/release/suite_test.go
@@ -22,8 +22,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 
 	"github.com/konflux-ci/operator-toolkit/test"
 

--- a/controllers/release/utils.go
+++ b/controllers/release/utils.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	"github.com/konflux-ci/operator-toolkit/controller"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/konflux-ci/release-service/api/v1alpha1"
 	"github.com/konflux-ci/release-service/loader"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // maxConditionMessageLength is the maximum length for a Kubernetes condition message.

--- a/controllers/releaseplan/adapter.go
+++ b/controllers/releaseplan/adapter.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/konflux-ci/operator-toolkit/controller"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/konflux-ci/release-service/api/v1alpha1"
 	"github.com/konflux-ci/release-service/loader"
 	"github.com/konflux-ci/release-service/syncer"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // adapter holds the objects needed to reconcile a ReleasePlan.

--- a/controllers/releaseplan/adapter_test.go
+++ b/controllers/releaseplan/adapter_test.go
@@ -20,13 +20,15 @@ import (
 	"reflect"
 
 	toolkit "github.com/konflux-ci/operator-toolkit/loader"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/loader"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
 
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/loader"
+
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+
 	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/releaseplan/controller.go
+++ b/controllers/releaseplan/controller.go
@@ -23,16 +23,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/go-logr/logr"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/controllers/utils/handlers"
-	"github.com/konflux-ci/release-service/controllers/utils/predicates"
-	"github.com/konflux-ci/release-service/loader"
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	sigsctrl "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/controllers/utils/handlers"
+	"github.com/konflux-ci/release-service/controllers/utils/predicates"
+	"github.com/konflux-ci/release-service/loader"
 )
 
 // Controller reconciles a ReleasePlan object

--- a/controllers/releaseplan/suite_test.go
+++ b/controllers/releaseplan/suite_test.go
@@ -33,11 +33,12 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 )
 
 var (

--- a/controllers/releaseplanadmission/adapter.go
+++ b/controllers/releaseplanadmission/adapter.go
@@ -24,12 +24,13 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/konflux-ci/operator-toolkit/controller"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/loader"
-	"github.com/konflux-ci/release-service/retry"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/loader"
+	"github.com/konflux-ci/release-service/retry"
 )
 
 // adapter holds the objects needed to reconcile a ReleasePlanAdmission.

--- a/controllers/releaseplanadmission/adapter_test.go
+++ b/controllers/releaseplanadmission/adapter_test.go
@@ -24,12 +24,13 @@ import (
 	"time"
 
 	toolkit "github.com/konflux-ci/operator-toolkit/loader"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/konflux-ci/release-service/api/v1alpha1"
 	"github.com/konflux-ci/release-service/loader"
 	"github.com/konflux-ci/release-service/metadata"
 	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/controllers/releaseplanadmission/controller.go
+++ b/controllers/releaseplanadmission/controller.go
@@ -23,11 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/go-logr/logr"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/cache"
-	"github.com/konflux-ci/release-service/controllers/utils/handlers"
-	"github.com/konflux-ci/release-service/controllers/utils/predicates"
-	"github.com/konflux-ci/release-service/loader"
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -36,6 +31,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/cache"
+	"github.com/konflux-ci/release-service/controllers/utils/handlers"
+	"github.com/konflux-ci/release-service/controllers/utils/predicates"
+	"github.com/konflux-ci/release-service/loader"
 )
 
 // Controller reconciles a ReleasePlanAdmission object

--- a/controllers/releaseplanadmission/controller_test.go
+++ b/controllers/releaseplanadmission/controller_test.go
@@ -21,9 +21,10 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/konflux-ci/release-service/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/controllers/releaseplanadmission/suite_test.go
+++ b/controllers/releaseplanadmission/suite_test.go
@@ -29,11 +29,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 )
 
 var (

--- a/controllers/utils/handlers/enqueue_matched.go
+++ b/controllers/utils/handlers/enqueue_matched.go
@@ -18,15 +18,17 @@ package handlers
 
 import (
 	"context"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 
-	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	crtHandler "sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
 )
 
 var _ crtHandler.EventHandler = &EnqueueRequestForMatchedResource[client.Object]{}

--- a/controllers/utils/handlers/enqueue_matched_test.go
+++ b/controllers/utils/handlers/enqueue_matched_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/konflux-ci/release-service/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
 
 	"k8s.io/client-go/util/workqueue"
 )

--- a/controllers/utils/handlers/suite_test.go
+++ b/controllers/utils/handlers/suite_test.go
@@ -25,8 +25,9 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+
+	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	//+kubebuilder:scaffold:imports

--- a/controllers/utils/predicates/predicates.go
+++ b/controllers/utils/predicates/predicates.go
@@ -19,13 +19,14 @@ package predicates
 import (
 	"reflect"
 
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/metadata"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/metadata"
 )
 
 // MatchPredicate returns a predicate which returns true when a ReleasePlan or ReleasePlanAdmission

--- a/controllers/utils/predicates/predicates_test.go
+++ b/controllers/utils/predicates/predicates_test.go
@@ -22,14 +22,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/metadata"
-	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/metadata"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 )
 
 var _ = Describe("Predicates", Ordered, func() {

--- a/controllers/utils/predicates/suite_test.go
+++ b/controllers/utils/predicates/suite_test.go
@@ -25,8 +25,9 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+
+	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	//+kubebuilder:scaffold:imports

--- a/docs/adr/0001-use-architecture-decision-records.md
+++ b/docs/adr/0001-use-architecture-decision-records.md
@@ -3,15 +3,19 @@
 Date: 2026-06-30
 
 ## Status
+
 Accepted
 
 ## Context
+
 We need to record architectural decisions made in this project to help future contributors understand the rationale behind technical choices.
 
 ## Decision
+
 We will use Architecture Decision Records (ADRs) as described by Michael Nygard to document significant architectural decisions.
 
 ## Consequences
+
 - Decisions are documented with context and rationale
 - Future contributors understand why certain approaches were chosen
 - ADRs are lightweight, version-controlled, and stored alongside code

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -31,6 +31,7 @@ make test-e2e
 | `RELEASE_CATALOG_TA_QUAY_TOKEN` | `dockerconfigjson` | Quay auth for trusted artifacts |
 
 **Token Format Example:**
+
 ```json
 {
   "auths": {
@@ -63,6 +64,7 @@ make test-e2e-list                     # List all tests
 ```
 
 **Combine options:**
+
 ```bash
 make test-e2e LABEL=happy-path E2E_TIMEOUT=90m
 make test-e2e LABEL="release-service && !release-neg"

--- a/e2e-tests/cmd/e2e_test.go
+++ b/e2e-tests/cmd/e2e_test.go
@@ -18,13 +18,14 @@ import (
 
 	ecpApi "github.com/conforma/crds/api/v1alpha1"
 	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
-	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
 )
 
 func init() {

--- a/e2e-tests/pkg/framework/client.go
+++ b/e2e-tests/pkg/framework/client.go
@@ -15,8 +15,9 @@ import (
 
 	ecpApi "github.com/conforma/crds/api/v1alpha1"
 	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
-	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
 )
 
 // KubeClient wraps a controller-runtime client with helper methods.

--- a/e2e-tests/pkg/framework/framework.go
+++ b/e2e-tests/pkg/framework/framework.go
@@ -7,8 +7,9 @@ import (
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 
-	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
 )
 
 // ControllerHub aggregates all controller clients.

--- a/e2e-tests/pkg/framework/integration.go
+++ b/e2e-tests/pkg/framework/integration.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 
 	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
 	"github.com/konflux-ci/release-service/metadata"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // IntegrationController handles Snapshot operations (integration-service domain).

--- a/e2e-tests/pkg/framework/release.go
+++ b/e2e-tests/pkg/framework/release.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"strconv"
 
-	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/loader"
-	releaseMetadata "github.com/konflux-ci/release-service/metadata"
-	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/loader"
+	releaseMetadata "github.com/konflux-ci/release-service/metadata"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 )
 
 // ReleaseController handles Release, ReleasePlan, and ReleasePlanAdmission CRD operations.

--- a/e2e-tests/pkg/framework/tekton.go
+++ b/e2e-tests/pkg/framework/tekton.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 
 	ecp "github.com/conforma/crds/api/v1alpha1"
-	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
-	"github.com/konflux-ci/release-service/metadata"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -15,6 +12,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/metadata"
 )
 
 // TektonController handles Tekton-related operations: PipelineRun, TaskRun, EC Policy, PVC, and signing secrets.

--- a/e2e-tests/tests/release/service/block_releases_release_plan_admission.go
+++ b/e2e-tests/tests/release/service/block_releases_release_plan_admission.go
@@ -5,16 +5,18 @@ import (
 	"strings"
 
 	"github.com/konflux-ci/application-api/api/v1alpha1"
+
 	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
 	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
-	ginkgo "github.com/onsi/ginkgo/v2"
-	gomega "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = ginkgo.Describe("Release CR fails when block-releases true in ReleasePlanAdmission", releasecommon.LabelNegBlockReleases, ginkgo.Ordered, func() {

--- a/e2e-tests/tests/release/service/final_pipeline_finalizer_removed.go
+++ b/e2e-tests/tests/release/service/final_pipeline_finalizer_removed.go
@@ -8,15 +8,11 @@ import (
 
 	ecp "github.com/conforma/crds/api/v1alpha1"
 	"github.com/devfile/library/v2/pkg/util"
-	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.yaml.in/yaml/v2"
 
-	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
-	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
-	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
-	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+
 	ginkgo "github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -24,6 +20,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
 )
 
 const (

--- a/e2e-tests/tests/release/service/happy_path.go
+++ b/e2e-tests/tests/release/service/happy_path.go
@@ -5,18 +5,20 @@ import (
 	"fmt"
 
 	ecp "github.com/conforma/crds/api/v1alpha1"
-	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+
 	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+
 	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
 	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
-	ginkgo "github.com/onsi/ginkgo/v2"
-	gomega "github.com/onsi/gomega"
 )
 
 var _ = ginkgo.Describe("Release service happy path", releasecommon.LabelHappyPath, ginkgo.Ordered, func() {

--- a/e2e-tests/tests/release/service/invalid_git_config_surfaced.go
+++ b/e2e-tests/tests/release/service/invalid_git_config_surfaced.go
@@ -3,15 +3,16 @@ package service
 import (
 	"strings"
 
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	meta "k8s.io/apimachinery/pkg/api/meta"
+
 	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
 	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
 	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
-	ginkgo "github.com/onsi/ginkgo/v2"
-	gomega "github.com/onsi/gomega"
-	meta "k8s.io/apimachinery/pkg/api/meta"
 )
 
 const tenantPipelineRunCreationFailedMsg = "Release processing failed on tenant pipelineRun creation"

--- a/e2e-tests/tests/release/service/missing_release_plan_and_admission.go
+++ b/e2e-tests/tests/release/service/missing_release_plan_and_admission.go
@@ -5,16 +5,18 @@ import (
 	"strings"
 
 	"github.com/konflux-ci/application-api/api/v1alpha1"
+
 	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
 	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
-	ginkgo "github.com/onsi/ginkgo/v2"
-	gomega "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = ginkgo.Describe("Release CR fails when missing ReleasePlan and ReleasePlanAdmission", releasecommon.LabelNegative, ginkgo.Ordered, func() {

--- a/e2e-tests/tests/release/service/pipeline_creation_error_surfaced.go
+++ b/e2e-tests/tests/release/service/pipeline_creation_error_surfaced.go
@@ -7,12 +7,6 @@ import (
 	"strings"
 
 	ecp "github.com/conforma/crds/api/v1alpha1"
-	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
-	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
-	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
-	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
-	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -20,6 +14,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 )
 
 const managedPipelineRunCreationFailedMsg = "Release processing failed on managed pipelineRun creation"

--- a/e2e-tests/tests/release/service/release_plan_and_admission_matched.go
+++ b/e2e-tests/tests/release/service/release_plan_and_admission_matched.go
@@ -3,17 +3,19 @@ package service
 import (
 	"fmt"
 
-	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 	"k8s.io/apimachinery/pkg/api/meta"
+
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
 	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
-	ginkgo "github.com/onsi/ginkgo/v2"
-	gomega "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = ginkgo.Describe("ReleasePlan and ReleasePlanAdmission match", releasecommon.LabelReleasePlanAdm, ginkgo.Ordered, func() {

--- a/e2e-tests/tests/release/service/tenant_pipelines.go
+++ b/e2e-tests/tests/release/service/tenant_pipelines.go
@@ -5,20 +5,22 @@ import (
 	"fmt"
 	"time"
 
-	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
-	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
-	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
-	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+
 	ginkgo "github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
 )
 
 var _ = ginkgo.Describe("Release service tenant pipeline", releasecommon.LabelTenant, ginkgo.Ordered, func() {

--- a/e2e-tests/tests/release/testdata.go
+++ b/e2e-tests/tests/release/testdata.go
@@ -2,10 +2,11 @@
 package common
 
 import (
-	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
-	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
 )
 
 // Test suite labels for release-service e2e tests.

--- a/kubearchive/client.go
+++ b/kubearchive/client.go
@@ -106,7 +106,7 @@ func doGet(ctx context.Context, httpClient *http.Client, url string) ([]byte, in
 	if err != nil {
 		return nil, 0, fmt.Errorf("kubearchive request to %s failed: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -7,12 +7,13 @@ import (
 
 	ecapiv1alpha1 "github.com/conforma/crds/api/v1alpha1"
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/metadata"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/metadata"
 )
 
 const (

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -5,12 +5,13 @@ import (
 
 	v1alpha12 "github.com/conforma/crds/api/v1alpha1"
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/metadata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	rbac "k8s.io/api/rbac/v1"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/metadata"
 )
 
 var _ = Describe("Release Adapter", Ordered, func() {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -12,9 +12,6 @@ import (
 
 	ecapiv1alpha1 "github.com/conforma/crds/api/v1alpha1"
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/git"
-	"github.com/konflux-ci/release-service/metadata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -26,6 +23,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/git"
+	"github.com/konflux-ci/release-service/metadata"
 )
 
 var _ = Describe("Release Adapter", Ordered, func() {

--- a/loader/suite_test.go
+++ b/loader/suite_test.go
@@ -27,10 +27,11 @@ import (
 	ecapiv1alpha1 "github.com/conforma/crds/api/v1alpha1"
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/operator-toolkit/test"
-	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/cache"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/cache"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/konflux-ci/operator-toolkit/controller"
 	"github.com/konflux-ci/operator-toolkit/webhook"
+
 	"github.com/konflux-ci/release-service/api/v1alpha1/webhooks"
 	"github.com/konflux-ci/release-service/metadata"
 	"github.com/konflux-ci/release-service/tracing"

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -17,8 +17,9 @@ limitations under the License.
 package metadata
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // AddAnnotations copies the map into the resource's Annotations map.

--- a/metrics/suite_test.go
+++ b/metrics/suite_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package metrics
 
 import (
+	"testing"
+
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/retry/matcher.go
+++ b/retry/matcher.go
@@ -22,9 +22,10 @@ import (
 	"regexp"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/konflux-ci/release-service/api/v1alpha1"
 	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // DetermineRetryInfo determines the retry information for a given ReleasePlanAdmission.

--- a/retry/matcher_test.go
+++ b/retry/matcher_test.go
@@ -20,12 +20,13 @@ import (
 	"encoding/json"
 
 	"github.com/go-logr/logr"
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/retry"
-	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/retry"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 )
 
 var _ = Describe("Retry Matcher", func() {

--- a/retry/mitigations.go
+++ b/retry/mitigations.go
@@ -21,11 +21,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/konflux-ci/release-service/api/v1alpha1"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
 )
 
 // ApplyMemoryMitigation multiplies memory limits and requests by the configured multiplier,

--- a/retry/mitigations_test.go
+++ b/retry/mitigations_test.go
@@ -19,14 +19,15 @@ package retry_test
 import (
 	"time"
 
-	"github.com/konflux-ci/release-service/api/v1alpha1"
-	"github.com/konflux-ci/release-service/retry"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/retry"
 )
 
 var _ = Describe("Mitigations", func() {

--- a/syncer/suite_test.go
+++ b/syncer/suite_test.go
@@ -33,8 +33,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+
+	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	//+kubebuilder:scaffold:imports

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -18,6 +18,7 @@ package syncer
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -18,6 +18,8 @@ package syncer
 
 import (
 	"context"
+	"reflect"
+
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -25,7 +27,6 @@ import (
 	v12 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 

--- a/tekton/predicates.go
+++ b/tekton/predicates.go
@@ -17,10 +17,11 @@ limitations under the License.
 package tekton
 
 import (
-	"github.com/konflux-ci/release-service/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/konflux-ci/release-service/metadata"
 )
 
 // ReleasePipelineRunLifecyclePredicate is a predicate to select Release PipelineRuns during

--- a/tekton/predicates_test.go
+++ b/tekton/predicates_test.go
@@ -17,12 +17,13 @@ limitations under the License.
 package tekton
 
 import (
-	"github.com/konflux-ci/release-service/metadata"
-	"github.com/konflux-ci/release-service/tekton/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/konflux-ci/release-service/metadata"
+	"github.com/konflux-ci/release-service/tekton/utils"
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )

--- a/tekton/suite_test.go
+++ b/tekton/suite_test.go
@@ -33,9 +33,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+
+	appstudiov1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	//+kubebuilder:scaffold:imports

--- a/tekton/utils.go
+++ b/tekton/utils.go
@@ -19,12 +19,13 @@ package tekton
 import (
 	"reflect"
 
-	"github.com/konflux-ci/release-service/metadata"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/konflux-ci/release-service/metadata"
 )
 
 // isReleasePipelineRun returns a boolean indicating whether the object passed is a Final, Managed or a Tenant Release PipelineRun.

--- a/tekton/utils/pipeline_run_builder.go
+++ b/tekton/utils/pipeline_run_builder.go
@@ -24,7 +24,6 @@ import (
 	"unicode"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/konflux-ci/release-service/git"
 	libhandler "github.com/operator-framework/operator-lib/handler"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +31,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/konflux-ci/release-service/git"
 )
 
 type PipelineRunBuilder struct {

--- a/tekton/utils_test.go
+++ b/tekton/utils_test.go
@@ -19,8 +19,6 @@ package tekton
 import (
 	"time"
 
-	"github.com/konflux-ci/release-service/metadata"
-	"github.com/konflux-ci/release-service/tekton/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -29,6 +27,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/konflux-ci/release-service/metadata"
+	"github.com/konflux-ci/release-service/tekton/utils"
 )
 
 var _ = Describe("Utils", Ordered, func() {


### PR DESCRIPTION
Add golangci-lint and markdownlint configurations and integrate them into the PR workflow to enforce code quality standards.

- Add .golangci.yml with Go linting rules
- Add .markdownlint.json for Markdown consistency
- Add golangci-lint job to PR workflow
- Add markdownlint job to PR workflow

Fixes RELEASE-2617

Generated-by: Claude