### PR TITLE
fix: exclude fullsend bot signed-off-by check

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -14,5 +14,5 @@ line-length=88
 [contrib-title-conventional-commits]
 
 [ignore-by-author-name]
-regex=(.*)\[bot\](.*)
-ignore=T1,B1
+regex=((.*)\[bot\](.*)|fullsend-ai-review)
+ignore=T1,B1,CC1


### PR DESCRIPTION
Exclude the fullsend-ai-review bot author from gitlint's Signed-off-by requirement (CC1), alongside the existing [bot] exclusion.

## Summary
<!-- Describe the changes in this PR -->

## Related Issues
Fixes #

## Testing
- [ ] Tests added/updated
- [ ] All tests pass (`make test`)
- [ ] Changes verified locally

## Checklist
- [ ] Code follows Kubernetes coding conventions
- [ ] Commit messages follow conventional format: `type(RELEASE-NNNN): description`
- [ ] Documentation updated if needed
- [ ] Generated manifests updated (`make manifests generate`)
