### PR TITLE
fix: add fullsend-code to gitlint author ignore list

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -14,5 +14,5 @@ line-length=88
 [contrib-title-conventional-commits]
 
 [ignore-by-author-name]
-regex=((.*)\[bot\](.*)|fullsend-ai-review)
+regex=^(?:.*\[bot\].*|fullsend-code)$
 ignore=T1,B1,CC1


### PR DESCRIPTION
The ignore-by-author-name rule matches on the git author name field, not the email. The fullsend bot commits with author name "fullsend-code" (no [bot] suffix in the name), so it was not matched by the existing regex and the CC1 Signed-off-by check was still enforced against it.
Add fullsend-code as an explicit alternative in the regex and remove the unused fullsend-ai-review entry.

Assisted-by: Cursor AI

## Summary
<!-- Describe the changes in this PR -->

## Related Issues
Fixes #

## Testing
- [ ] Tests added/updated
- [ ] All tests pass (`make test`)
- [ ] Changes verified locally

## Checklist
- [ ] Code follows Kubernetes coding conventions
- [ ] Commit messages follow conventional format: `type(RELEASE-NNNN): description`
- [ ] Documentation updated if needed
- [ ] Generated manifests updated (`make manifests generate`)
